### PR TITLE
Run yarn install in case of cache miss (before yarn build)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,11 @@ jobs:
       - uses: borales/actions-yarn@v2.0.0
         if: steps.cache-build.outputs.cache-hit != 'true'
         with:
+          cmd: install
+
+      - uses: borales/actions-yarn@v2.0.0
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        with:
           cmd: build
 
       - name: install saucectl
@@ -103,6 +108,11 @@ jobs:
           path: |
             build
           key: ${{ runner.os }}-${{ github.sha }}
+
+      - uses: borales/actions-yarn@v2.0.0
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        with:
+          cmd: install
 
       - uses: borales/actions-yarn@v2.0.0
         if: steps.cache-build.outputs.cache-hit != 'true'


### PR DESCRIPTION
When there is a miss in the `test` or `deploy` step, only `yarn build` is triggered.
As the miss is nearly impossible, when experiencing caches issues with github-actions, the `yarn build` cannot succeed because of the lack or `yarn install`.

This PR fixes this issue.
