### PR TITLE
fixed image references

### DIFF
--- a/docs/guides/live-testing/mobile-apps.md
+++ b/docs/guides/live-testing/mobile-apps.md
@@ -8,13 +8,15 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 With Virtual Devices on Sauce Labs, you can test your mobile applications on a variety of Android emulators and iOS simulators. If you do not have an app, consider using the Sauce Labs [Swag Labs](https://github.com/saucelabs/sample-app-mobile) sample app for validating your account functionality as well as your tests. 
 
-## What You'll Need
+__What You'll Need__
+
 * A Sauce Labs Account
 * A Mobile Application to Test
 
 > If you do not have an app, consider using the Sauce Labs [Swag Labs](https://github.com/saucelabs/sample-app-mobile) sample app for validating your account functionality as well as your tests.
 
 ## Upload Your Application
+
 Before you begin a live test session, you must upload an application to [Sauce Application Storage](storage.md).
 
 For further information regarding:
@@ -45,7 +47,7 @@ After you've uploaded and selected the application, you're ready to launch a liv
 
 You must select a device prior to launching a session. By default, the public devices will display in a grid format like so:
     
-   <img src="/static/img/live-testing/device-grid.png" alt="Device Grid" />
+   <img src={useBaseUrl('img/live-testing/device-grid.png')} alt="Device Grid" />;
 
 There is a distinction between __Public Devices__ and __Private Devices__.
 
@@ -56,4 +58,4 @@ There is a distinction between __Public Devices__ and __Private Devices__.
 
 Hover over a device thumbnail and click on __Details__ to see the specs for that device. Once you find the desired device, select __Launch__.
 
-<img src="/static/img/live-testing/device-details.png" alt="Device Details" />
+<img src={useBaseUrl('img/live-testing/device-details.png')} alt="Device Details" />;

--- a/docs/guides/live-testing/web-apps.md
+++ b/docs/guides/live-testing/web-apps.md
@@ -6,7 +6,8 @@ sidebar_label: Web Apps
 
 You can run live tests of your websites/web-applications on a wide range of operating systems and web browser versions.
 
-## What You'll Need
+__What You'll Need__
+
 * A Sauce Labs Account
 * A Publicly Available Web Application to Test
 

--- a/docs/products/testrunner-toolkit/configuration.md
+++ b/docs/products/testrunner-toolkit/configuration.md
@@ -7,14 +7,19 @@ sidebar_label: Configuration
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The Testrunner Toolkit requires a configuration file to know which tests to run, along with which framework to use.
+The Testrunner Toolkit requires a configuration file to know which tests to run, along with which framework to use. Examples of some possible configuration fields you can set include:
+
+* custom `tags`
+* location of the test `files`
+* desired framework `image` and `version`
+* desired `sauce` data center
 
 ## Basic Configuration
 
-By default, `config.yml` is the file `saucectl` looks to for its configuration.
+By default `saucectl` searches for a file called `config.yml`, for example:
 
 ```yaml
-#Simple config.yml using puppeteer
+# Simple config.yml using puppeteer
 apiVersion: v1
 metadata:
   name: Feature XYZ

--- a/docs/products/testrunner-toolkit/integrations.md
+++ b/docs/products/testrunner-toolkit/integrations.md
@@ -162,7 +162,7 @@ The easiest way to add credentials to Jenkins is with the UI:
 * Go to __Manage Jenkins > Manage Credentials__
 * Next to (Global), select __Add credentials__
 
-    <img src="/static/img/stt/add_credentials.png" alt="Add Jenkins Credentials" width="500" />
+    <img src={useBaseUrl('img/stt/add_credentials.png')} alt="Add Jenkins Credentials" width="500" />;
     
 * For __Kind__, select __Secret Text__
 * Enter the following information:
@@ -172,7 +172,7 @@ The easiest way to add credentials to Jenkins is with the UI:
     * Description: Sauce Labs Username
 * Repeat the above steps for your Sauce Labs Access Key
 
-    <img src="/static/img/stt/secrets.png" alt="Jenkins Secrets" width="500"/>
+    <img src={useBaseUrl('img/stt/secrets.png')} alt="Jenkins Secrets" width="500" />;
 
     > For further information on how to store your Sauce Labs credentials in Jenkins, visit [the Jenkinsfile documentation](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#handling-credentials).
 
@@ -304,7 +304,7 @@ Now you can commit these files and Jenkins will detect the new pipeline and laun
 
 For example if you're using the [Blue Ocean plugin](https://plugins.jenkins.io/blueocean/), your output may look something like this:
 
-<img src="/static/img/stt/blue-ocean.png" alt="GitHub Settings" width="500" />
+<img src={useBaseUrl('img/stt/blue-ocean.png')} alt="GitHub Settings" />;
 
 ## GitHub Actions
 
@@ -324,7 +324,7 @@ The first order of business is to export your [Sauce Labs account credentials]()
 
 1. Navigate to your project repository and select the __settings__ icon
 
-    <img src="/static/img/stt/github-settings.png" alt="GitHub Settings" width="500" />
+    <img src={useBaseUrl('img/stt/github-settings.png')} alt="GitHub Settings" width="500" />;
 
 2. Select __Secrets__
 3. Click the __New secret__ button
@@ -493,8 +493,8 @@ To see the output:
 2. Navigate to your repository page
 3. Click on Actions
 
-    <img src="/static/img/stt/github-actions.png" alt="GitHub Actions" width="500" />
+    <img src={useBaseUrl('img/stt/github-actions.png')} alt="GitHub Actions" width="500" />;
     
 Your output may look something like this:
 
-<img src="/static/img/stt/github-workflow.png" alt="GitHub Workflow" width="800" />    
+<img src={useBaseUrl('img/stt/github-workflow.png')} alt="GitHub Workflow" width="800" />;    

--- a/docs/products/testrunner-toolkit/preparation.md
+++ b/docs/products/testrunner-toolkit/preparation.md
@@ -38,7 +38,7 @@ To learn more about how to configure `saucectl`, please visit the [Configuration
 
 ### Quick demo
 
-<img src="/static/img/stt/saucectl-demo.gif" alt="saucectl Demo" />
+<img src={useBaseUrl('img/stt/saucectl-demo.gif')} alt="saucectl Demo" />;
 
 ## Automation Framework Examples
 The examples here show how Pipeline testing can be used. Try them and find your own use cases. 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -14,27 +14,31 @@ When testing mobile applications, you now have the option to upload your applica
 * Share your uploaded apps between your Extended Team Management (xTM) team members.
 * Apps live in the new application storage for 60 days rather than 7 days in the old Sauce Storage.
 
-## What You'll Need
+__What You'll Need__
 
 * A Sauce Labs Account.
 * A mobile app/binary file you wish to test. If you don't have one, you can use the [Sauce Labs sample mobile app](https://github.com/saucelabs/sample-app-mobile).
 
 ## Upload an App with App-Upload
 
-1. Log in to Sauce Labs and select __LIVE__ from the options in the left-hand navigation.
-2. Select __Mobile-App__.
-3. You will see a list of previously uploaded apps.
-4. To the right of the page, select __App-Upload__ to upload a new application (Note: Live Testing on Real Devices only at the moment):
+:::info Important
+The App-Upload feature is currently only available with Live Testing on Real Devices.
+:::
+
+1. Log in to Sauce Labs and select __LIVE__ from the options in the left-hand navigation
+2. Select __Mobile-App__
+3. You will see a list of previously uploaded apps
+4. To the right of the page, select __App-Upload__ to upload a new application
     
-    <img src="/static/img/live-testing/live-test-mobile-app.png" alt="Live Testing Mobile Apps" width="500" />
+    <img src={useBaseUrl('img/live-testing/live-test-mobile-app.png')} alt="Live Testing Mobile Apps" />;
 
 5. You can either drag and drop and application, or browse for the file (*.APK or *.IPA format):   
    
-   <img src="/static/img/live-testing/app-upload.png" alt="App Upload" width="500" />
+   <img src={useBaseUrl('img/live-testing/app-upload.png')} alt="App Upload" />;
 
-6. To use an app you've previously uploaded, select "Check out the __old repository__" link at the bottom of the page. This will re-direct you to the legacy App Management UI with all your previously uploaded apps:
+6. To use an app you've previously uploaded, select "Check out the old repository" link at the bottom of the page. This will re-direct you to the legacy App Management UI with all your previously uploaded apps:
    
-   <img src="/static/img/live-testing/old-repository.png" alt="Old Repository Button" width="500" />
+   <img alt="Old Repository Button" src={useBaseUrl('img/live-testing/old-repository.png')} />;
 
 ### Delete Apps with the Delete Button
 
@@ -42,7 +46,7 @@ The __Delete__ button will delete a whole application (e.g. a group of builds be
 
 Files associated with app identifiers i.e. belong to the same platform and are accessible to the same team, are indicated by the __+__ symbol next to version number. Also, the version number shown is the most recently updated file, not necessarily the 'latest' version of the application.
    
-   <img src="/static/img/live-testing/latest-version.png" alt="Latest Versions" width="500" />
+   <img src={useBaseUrl('img/live-testing/latest-version.png')} alt="Latest Versions" />;
 
 ## Upload an App/File with the REST API
 
@@ -69,7 +73,7 @@ For specific instructions on how to set environment variables visit, the followi
 
 App Storage uses an XTM (Extended Team Management) sync feature which allows for user permissions schemes. In other words, a Sauce Labs admin (either an org admin or a team admin) can control access to individual application files or specific binary/script files. 
 
-By default, all uploaded files are shared with the same team where the user participates currently. You, as a user, can only access files that are shared with the team where you contribute/participate unless your role is an organization admin in which case you have access to all files in your particular organization.
+Teams share all files uploaded by any user in the current organization by default. However, you can only access files shared with your team (i.e. the team where you contribute/participate). The one exception is if your role is an organization admin, in which case you have access to all files in your organization.
 
 To manage access to your organization go to Account > Team Management.
 


### PR DESCRIPTION
Images had relative links, but `docusaurus build` requires you to set image links accordingly: https://v2.docusaurus.io/docs/static-assets/#jsx-example