### PR TITLE
Fix/broken images in team management section

### DIFF
--- a/docs/basics/acct-team-mgmt/adding-deactivating-users.md
+++ b/docs/basics/acct-team-mgmt/adding-deactivating-users.md
@@ -3,6 +3,8 @@ id: adding-deactivating-users
 title: Adding and Deactivating Users
 sidebar_label: Adding and Deactivating Users
 ---
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 <p><button class="badge-blue">ENTERPRISE PLANS ONLY</button></p>
 
 ## Adding Users
@@ -13,15 +15,15 @@ When you add a user manually, you assign the user a user name and password. To a
 ### Adding a User Manually
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 
-<img src="/static/img/team-mgmt/team-mgmt-nav.jpg" alt="Team management navigation" width="400"/>
+   <img src={useBaseUrl('img/team-mgmt/team-mgmt-nav.jpg')} alt="Team management navigation" width="400"/>
 
 2. On the **Users** tab, click the blue plus sign.
-
-<img src="/static/img/team-mgmt/add-new-user-nav.jpg" alt="Add new user - Blue plus sign" width="700"/>
+    
+   <img src={useBaseUrl('img/team-mgmt/add-new-user-nav.jpg')} alt="Add new user - Blue plus sign" width="700"/>
 
 3. On the **Manual Entry** tab, enter an email address, user name, password, and optional first and last name for the new user.
 
-<img src="/static/img/team-mgmt/add-new-user-manual.jpg" alt="Add new user - manually" width="500"/>
+   <img src={useBaseUrl('img/team-mgmt/add-new-user-manual.jpg')} alt="Add new user - manually" width="500"/>
 
 4. In the **Add to Team** dropdown, select the team for the user. If you don't select a team, the user will be added to the default team.  
 5. In the **Org Role** dropdown, select an organizational role for the user. The options are Org. Admin, Team Member, and Member. For more information about the permissions associated with each role, see [User Roles](/basics/acct-team-mgmt/managing-user-info).
@@ -32,7 +34,7 @@ When you add a user manually, you assign the user a user name and password. To a
 2. On the **Users** tab, click the blue plus sign.
 3. On the **Invite Via Email** tab, enter the user's email address, and then select a role from the **User Role** dropdown.
 
-<img src="/static/img/team-mgmt/add-new-user-email.jpg" alt="Add new user - email" width="500"/>
+   <img src={useBaseUrl('img/team-mgmt/add-new-user-email.jpg')} alt="Add new user - email" width="500"/>
 
 4. To invite multiple users to the same team, click **Add Another Row** and add the additional users' information.
 5. In the **Add to Team** dropdown, select the team to which to add the user(s).
@@ -59,7 +61,7 @@ You can deactivate users in your account on the **Organization Management** page
 2. On the **Users** tab, select the check box of the user you want to deactivate.
 3. Above the list of users, in the **Action** dropdown, click **Deactivate User**.
 
-<img src="/static/img/team-mgmt/deactivate-user-org-mgmt.jpg" alt="Deactivate a user in team management"/>
+   <img src={useBaseUrl('img/team-mgmt/deactivate-user-org-mgmt.jpg')} alt="Deactivate a user in team management"/>
 
 4. In the **Confirm deactivate** box, click **Yes, Deactivate**.
 
@@ -67,10 +69,10 @@ You can deactivate users in your account on the **Organization Management** page
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 2. On the **Users** tab, click the user name of the user you want to deactivate.
 
-<img src="/static/img/team-mgmt/users-list-username.jpg" alt="Deactivate a user in User Details"/>
+   <img src={useBaseUrl('img/team-mgmt/users-list-username.jpg')} alt="Deactivate a user in User Details"/>
 
 3. On the **User Details** page, in the **User Name** box, click **Deactivate User**.
 
-<img src="/static/img/team-mgmt/deactivate-user-user-details.jpg" alt="Deactivate a user in User Details"/>
+   <img src={useBaseUrl('img/team-mgmt/deactivate-user-user-details.jpg')} alt="Deactivate a user in User Details"/>
 
 4. In the **Confirm deactivate** box, click **Yes, Deactivate**.

--- a/docs/basics/acct-team-mgmt/adding-deleting-teams.md
+++ b/docs/basics/acct-team-mgmt/adding-deleting-teams.md
@@ -3,6 +3,9 @@ id: adding-deleting-teams
 title: Adding and Deleting Teams
 sidebar_label: Adding and Deleting Teams
 ---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 <p><button class="badge-blue">ENTERPRISE PLANS ONLY</button></p>
 If you are an organization admin, you can create and delete teams and assign concurrency limits to each team.
 
@@ -10,16 +13,16 @@ If you are an organization admin, you can create and delete teams and assign con
 
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 
-<img src="/static/img/team-mgmt/team-mgmt-nav.jpg" alt="Team management navigation" width="400"/>
+   <img src={useBaseUrl('img/team-mgmt/team-mgmt-nav.jpg')} alt="Team management navigation" width="400"/>
 
 2. On the **Teams** tab, click the blue plus sign.
 
-<img src="/static/img/team-mgmt/add-new-team-nav.jpg" alt="Add new team"/>
+   <img src={useBaseUrl('img/team-mgmt/add-new-team-nav.jpg')} alt="Add new team"/>
 
 
 3. In the **Create new team** box, enter a team name and description.
 
-<img src="/static/img/team-mgmt/create-new-team.jpg" alt="Create new team" width="400"/>
+<img src={useBaseUrl('img/team-mgmt/create-new-team.jpg')} alt="Create new team" width="400"/>
 
 4. In the **To Line of Business** dropdown, select the line of business the team will be associated with.
 5. Under **Team VM Concurrency Limits**, use the up and down arrows to set the number of concurrent virtual machines that the team can access. For more information about concurrency, see [Concurrency Limits and Team Accounts](/basics/acct-team-mgmt/concurrency-limits).
@@ -31,7 +34,7 @@ If you are an organization admin, you can create and delete teams and assign con
 2. On the **Teams** tab, select the checkbox of the team or teams you want to delete.
 3. Next to **Teams Selected**, in the **Action** dropdown, click **Delete team**.
 
-<img src="/static/img/team-mgmt/delete-team.jpg" alt="Delete team"/>
+<img src={useBaseUrl('img/team-mgmt/delete-team.jpg')} alt="Delete team"/>
 
 4. In the **Confirm Delete** box, select the team that you want to transfer the members of the deleted team to. If you don't select a a new team, the team members will be moved to the default team.   
 5. Click **Yes, Remove**.

--- a/docs/basics/acct-team-mgmt/assigning-removing-users-teams.md
+++ b/docs/basics/acct-team-mgmt/assigning-removing-users-teams.md
@@ -3,19 +3,21 @@ id: assigning-removing-users-teams
 title: Assigning and Removing Users from Teams
 sidebar_label: Assigning and Removing Users from Teams
 ---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 <p><button class="badge-blue">ENTERPRISE PLANS ONLY</button></p>
 If you are an organization admin, you can assign users to and remove users from a team.
 
 ## Assigning a User to a Team
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 
-<img src="/static/img/team-mgmt/team-mgmt-nav.jpg" alt="Team management navigation" width="400"/>
-
+   <img src={useBaseUrl('img/team-mgmt/team-mgmt-nav.jpg')} alt="Team management navigation" width="400"/>
 
 2. On the **Users** tab, select the checkbox of the user(s) you want to assign or remove.
 3. Next to **Users Selected**, in the **Action** dropdown, click **Team Assignment**.
 
-<img src="/static/img/team-mgmt/assign-users-to-team.jpg" alt="Assign users to a team"/>
+   <img src={useBaseUrl('img/team-mgmt/assign-users-to-team.jpg')} alt="Assign users to a team"/>
 
 4. In the **Team Assignment** box, in the **Select team** dropdown, select the team to assign the user to.
 
@@ -27,6 +29,6 @@ A user can only be assigned to one team; changing a user's team assignment will 
 3. On the **Members** tab, select the checkbox of the user you want to remove.
 4. Next to **User Selected**, in the **Action** dropdown, click **Remove User from team**.
 
-<img src="/static/img/team-mgmt/remove-user-from-team.jpg" alt="Remove a user from a team"/>
+   <img src={useBaseUrl('img/team-mgmt/remove-user-from-team.jpg')} alt="Remove a user from a team"/>
 
 If a user is removed from a team and/or not assigned to a team, their name will only be visible in the **Users** tab.

--- a/docs/basics/acct-team-mgmt/concurrency-limits.md
+++ b/docs/basics/acct-team-mgmt/concurrency-limits.md
@@ -4,6 +4,8 @@ title: Concurrency Limits and Team Accounts
 sidebar_label: Concurrency Limits and Team Accounts
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 If your organization has multiple teams sharing a Sauce Labs account, it's important to monitor your concurrency limits--the number of virtual machines that you can run tests on simultaneously. You'll need to ensure that your organization's concurrency is distributed among your accounts, rather than allocating all of it to a single user.
 
 ## How Concurrency Limits Work
@@ -11,7 +13,7 @@ Only organization admins can set the total concurrency of their organization's S
 
 In the diagram below, OrgX has a total concurrency of 100 VMs, and the org admin allocates 20 VMs to their Apps Team, which has five members. This means that each member can run 20 VMs at the same time and max out the organization's 100 VM limit. To avoid this scenario, set the concurrency limit for each Apps Team member to 4, so that if all members run tests at the same time, they'd be consuming 20 VMs.
 
-<img src="/static/img/team-mgmt/concurrency-allocation-diagram.jpg" alt="Concurrency allocation diagram" width="600"/>
+<img src={useBaseUrl('img/team-mgmt/concurrency-allocation-diagram.jpg')} alt="Concurrency allocation diagram" width="600"/>
 
 ## Queuing Tests
 Once you've used all of your concurrency slots, additional tests will not start until an existing test finishes. As tests complete, queued tests are allocated to concurrency slots in the order they were queued, however, we do not recommend queuing tests intentionally. Tests will time out with an error if they are queued for too long and/or if too many tests are already queued.

--- a/docs/basics/acct-team-mgmt/managing-subscription.md
+++ b/docs/basics/acct-team-mgmt/managing-subscription.md
@@ -4,6 +4,8 @@ title: Managing Your Subscription
 sidebar_label: Managing Your Subscription
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 ## Canceling Your Subscription
 
 You can cancel your subscription plan at any time from the **Team Management** page.
@@ -12,7 +14,7 @@ You can cancel your subscription plan at any time from the **Team Management** p
 
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 
-<img src="/static/img/team-mgmt/team-mgmt-nav.jpg" alt="Team management navigation" width="400"/>
+   <img src={useBaseUrl('img/team-mgmt/team-mgmt-nav.jpg')} alt="Team management navigation" width="400"/>
 
 2. Next to your plan description on the **Team Management** page, click **Manage**.
 3. Click the **Cancel Subscription** link at the bottom of the **Plan Details** page.

--- a/docs/basics/acct-team-mgmt/managing-user-info.md
+++ b/docs/basics/acct-team-mgmt/managing-user-info.md
@@ -3,6 +3,9 @@ id: managing-user-info
 title: Managing User Information
 sidebar_label: Managing User Information
 ---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 <p><button class="badge-blue">ENTERPRISE PLANS ONLY</button></p>
 
 ## Updating User Information
@@ -10,15 +13,15 @@ Organization admins can update the name, email address, user name, role, and tea
 
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 
-<img src="/static/img/team-mgmt/team-mgmt-nav.jpg" alt="Team management navigation" width="400"/>
+   <img src={useBaseUrl('img/team-mgmt/team-mgmt-nav.jpg')} alt="Team management navigation" width="400"/>
 
 2. On the **Users** tab, click the user name of the user whose information you want to edit.
 
-<img src="/static/img/team-mgmt/users-list-username.jpg" alt="User details"/>
+   <img src={useBaseUrl('img/team-mgmt/users-list-username.jpg')} alt="User details"/>
 
 3. On the **User Details** page, in the **User Information** section, make the necessary changes and then click **Update**.
 
-<img src="/static/img/team-mgmt/user-details-user-info.jpg" alt="User details"/>
+   <img src={useBaseUrl('img/team-mgmt/user-details-user-info.jpg')} alt="User details"/>
 
 ## Filtering Users
 
@@ -52,17 +55,17 @@ You can change a user’s role on the **Organization Management** page and also 
 2. On the **Users** tab, select the checkbox of the user you want to deactivate.
 3. Above the list of users, in the **Action** dropdown, click **Assign Role** and then click the new role.
 
-<img src="/static/img/team-mgmt/change-role-org-mgmt.jpg" alt="Change a user's role"/>
+   <img src={useBaseUrl('img/team-mgmt/change-role-org-mgmt.jpg')} alt="Change a user's role"/>
 
 ### Changing a User’s Role - User Details
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 2. On the **Users** tab, click the user name of the user whose role you want to change.
 
-<img src="/static/img/team-mgmt/users-list-username.jpg" alt="Users list"/>
+   <img src={useBaseUrl('img/team-mgmt/users-list-username.jpg')} alt="Users list"/>
 
 3. On the **User Details** page, in the **User Information** section, click the **Org. Role** dropdown and then click the new role.
 
-<img src="/static/img/team-mgmt/change-role-user-details.jpg" alt="Change a user's role"/>
+   <img src={useBaseUrl('img/team-mgmt/change-role-user-details.jpg')} alt="Change a user's role"/>
 
 4. Click **Update**.
 
@@ -73,12 +76,11 @@ You can regenerate a user's access key on the **Organization Management** page.
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 2. On the **Users** tab, click the user name of the user whose access key you want to regenerate.
 
-<img src="/static/img/team-mgmt/users-list-username.jpg" alt="Users list"/>
-
+   <img src={useBaseUrl('img/team-mgmt/users-list-username.jpg')} alt="Users list"/>
 
 3. On the **User Details** page, in the **Access Key** section, click **Regenerate Access Key**.
 
-<img src="/static/img/team-mgmt/user-details-access-key.jpg" alt="User Details - Access Key"/>
+   <img src={useBaseUrl('img/team-mgmt/user-details-access-key.jpg')} alt="User Details - Access Key"/>
 
 **NOTE:** Regenerating your access key will update the access key throughout your configuration. Commands containing your old access key will fail.
 

--- a/docs/basics/acct-team-mgmt/org-settings.md
+++ b/docs/basics/acct-team-mgmt/org-settings.md
@@ -3,6 +3,9 @@ id: org-settings
 title: Organization Settings
 sidebar_label: Organization Settings
 ---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 ## General Settings
 General settings determine the options available to your users when they create their Sauce Labs accounts.
 
@@ -10,11 +13,11 @@ To access General settings:
 
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 
-<img src="/static/img/team-mgmt/team-mgmt-nav.jpg" alt="Team management navigation" width="400" />
+<img src={useBaseUrl('img/team-mgmt/team-mgmt-nav.jpg')} alt="Team management navigation" width="400" />
 
 2. On the **Organization Management** page, in the **Organization Settings** section, click **View Settings**.
 
-<img src="/static/img/team-mgmt/team-mgmt-view-settings-nav.jpg" alt="View settings" width="600" />
+<img src={useBaseUrl('img/team-mgmt/team-mgmt-view-settings-nav.jpg')} alt="View settings" width="600" />
 
 3. On the **General** tab, you have the following option:
 
@@ -30,7 +33,7 @@ To access Security settings:
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 2. On the **Organization Management** page, in the **Organization Settings** section, click **View Settings**.
 
-<img src="/static/img/team-mgmt/team-mgmt-view-settings-nav.jpg" alt="View settings" width="600" />
+<img src={useBaseUrl('img/team-mgmt/team-mgmt-view-settings-nav.jpg')} alt="View settings" width="600" />
 
 3. On the **Security** tab, you have the following options:
 
@@ -52,11 +55,11 @@ When you set up SSO with Sauce Labs, you are establishing a connection between t
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 2. On the **Organization Management** page, in the **Organization Settings** section, click **View Settings**.
 
-<img src="/static/img/team-mgmt/team-mgmt-view-settings-nav.jpg" alt="View settings" width="600" />
+<img src={useBaseUrl('img/team-mgmt/team-mgmt-view-settings-nav.jpg')} alt="View settings" width="600" />
 
 3. On the **Organization Settings** page, click the **Single Sign-On** tab.
 
-<img src="/static/img/team-mgmt/sso-settings-tab.jpg" alt="SSO Settings tab" width="600" />
+<img src={useBaseUrl('img/team-mgmt/sso-settings-tab.jpg')} alt="SSO Settings tab" width="600" />
 
 4. Enter a **unique identifier string**. The string will be applied to user names to make sure that your users will have unique names associated with your account.
 5. Upload the SAML metadata file provided by your IdP that contains the list of your SSO users. Sauce Labs SSO supports most SAML 2.0 metadata files. For more information about specific IdPs, see [Configuring Active Directory Federation Services (AD FS)](/basics/sso/config-adfs) and [Configuring Okta](/basics/sso/config-okta).

--- a/docs/basics/acct-team-mgmt/plan-details.md
+++ b/docs/basics/acct-team-mgmt/plan-details.md
@@ -3,11 +3,14 @@ id: plan-details
 title: Viewing Plan Details
 sidebar_label: Viewing Plan Details
 ---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 You can view the number of concurrent VMs, concurrent devices, and minutes allowed under your plan.
 
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 
-<img src="/static/img/team-mgmt/team-mgmt-nav.jpg" alt="Team management navigation" width="400"/>
+<img src={useBaseUrl('img/team-mgmt/team-mgmt-nav.jpg')} alt="Team management navigation" width="400"/>
 
 2. Your plan type (for example, Enterprise or Subscription) is displayed at the top of the **Team Management** page.
 3. Click **View Details** to see specific information about VMs, devices, and minutes allowed under your plan.

--- a/docs/basics/acct-team-mgmt/updating-billing.md
+++ b/docs/basics/acct-team-mgmt/updating-billing.md
@@ -4,6 +4,8 @@ title: Updating Your Billing Information
 sidebar_label: Updating Your Billing Information
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 You can update your plan billing information at any time for our online plans.
 
 **NOTE:** If you want to update the billing information for an Enterprise plan, contact your Sauce Labs account executive.
@@ -13,7 +15,7 @@ You can update your plan billing information at any time for our online plans.
 ## Virtual Device Cloud Billing
 In Sauce Labs, click **Account**, and then click **Billing**.
 
-<img src="/static/img/team-mgmt/billing-nav.jpg" alt="Billing navigation" width="400"/>
+<img src={useBaseUrl('img/team-mgmt/billing-nav.jpg')} alt="Billing navigation" width="400"/>
 
 ### Payment Tab
 If the **Payment** tab is visible:
@@ -38,14 +40,14 @@ If the **Billing Information** tab is visible:
 ## Real Device Cloud Billing
 1. In Sauce Labs, in the left panel, click **Sauce Apps** and then click **Legacy RDC**.
 
-<img src="/static/img/team-mgmt/legacy-rdc-nav.jpg" alt="Legacy RDC navigation" width="400"/>
+   <img src={useBaseUrl('img/team-mgmt/legacy-rdc-nav.jpg')} alt="Legacy RDC navigation" width="400"/>
 
 2. Click the person icon, and then click **Account Settings**.
 
-<img src="/static/img/team-mgmt/legacy-rdc-acct-settings.jpg" alt="Legacy RDC account settings" width="400"/>
+   <img src={useBaseUrl('img/team-mgmt/legacy-rdc-acct-settings.jpg')} alt="Legacy RDC account settings" width="400"/>
 
 3. On the **Billing** tab, click **Payment Data**.
 
-<img src="/static/img/team-mgmt/rdc-billing-payment-data.jpg" alt="Legacy RDC billing payment data" width="500"/>
+   <img src={useBaseUrl('img/team-mgmt/rdc-billing-payment-data.jpg')} alt="Legacy RDC billing payment data" width="500"/>
 
 4. In the **Update Payment Data** window, update the billing information and/or credit card on file, and then click **Save**.

--- a/docs/basics/acct-team-mgmt/viewing-exporting-usage-data.md
+++ b/docs/basics/acct-team-mgmt/viewing-exporting-usage-data.md
@@ -3,6 +3,9 @@ id: viewing-exporting-usage-data
 title: Viewing and Exporting Usage Data
 sidebar_label: Viewing and Exporting Usage Data
 ---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 <p><button class="badge-blue">ENTERPRISE PLANS ONLY</button></p>
 
 If you're the owner of the overall Sauce Labs account, you can view usage information for all accounts on the **Organization Management** page. If you're an individual user, you can view your usage information on the **My Account** page.
@@ -24,7 +27,7 @@ The **Users** tab on the **Organization Management** page provides the following
   </tr>
 </table>
 
-<img src="/static/img/team-mgmt/usage-data-users-tab.jpg" alt="Usage data - Users tab"/>
+<img src={useBaseUrl('img/team-mgmt/usage-data-users-tab.jpg')} alt="Usage data - Users tab"/>
 
 Click a user name in the list to view the following information on the **User Details** page:
 <table>
@@ -40,7 +43,7 @@ Click a user name in the list to view the following information on the **User De
   </tr>
 </table>
 
-<img src="/static/img/team-mgmt/usage-data-user-details.jpg" alt="Usage data - User Details tab"/>
+<img src={useBaseUrl('img/team-mgmt/usage-data-user-details.jpg')} alt="Usage data - User Details tab"/>
 
 ## Usage Data - Teams
 The **Teams** tab on the **Organization Management** page provides the following information for each team:
@@ -63,7 +66,7 @@ The **Teams** tab on the **Organization Management** page provides the following
   </tr>
 </table>
 
-<img src="/static/img/team-mgmt/usage-data-teams-tab.jpg" alt="Usage data - Teams tab"/>
+<img src={useBaseUrl('img/team-mgmt/usage-data-teams-tab.jpg')} alt="Usage data - Teams tab"/>
 
 Click a team name in the list to view the following information on the **Team Details** page:
 <table>
@@ -79,7 +82,7 @@ Click a team name in the list to view the following information on the **Team De
   </tr>
 </table>
 
-<img src="/static/img/team-mgmt/usage-data-team-details.jpg" alt="Usage data - Team Details"/>
+<img src={useBaseUrl('img/team-mgmt/usage-data-team-details.jpg')} alt="Usage data - Team Details"/>
 
 ## Minutes Used vs. Concurrency
 One way to tell if you're getting the most efficient use out of your Sauce Labs plan is to compare the minutes used with the number of concurrent tests run during the same period. If the ratio of minutes to concurrency is low, for example, 2:1 (100 minutes:50 concurrent tests), then you are using a lot of minutes to run very few tests. You should redesign your tests to take greater advantage of concurrency. See [Using Frameworks to Run Tests in Parallel](https://wiki.saucelabs.com/display/DOCS/Using+Frameworks+to+Run+Tests+in+Parallel) for more information.
@@ -90,9 +93,9 @@ You can export a .csv file that contains the usage information for selected acco
 
 1. In Sauce Labs, click **Account** and then click **Team Management**.
 
-<img src="/static/img/team-mgmt/team-mgmt-nav.jpg" alt="Team management navigation" width="500"/>
+   <img src={useBaseUrl('img/team-mgmt/team-mgmt-nav.jpg')} alt="Team management navigation" width="500"/>
 
 2. On the **User** tab, select the checkboxes of the users whose usage information you want to export.
 3. Next to **Users Selected**, click the download button.
 
-<img src="/static/img/team-mgmt/usage-download-button.jpg" alt="Usage download button"/>
+   <img src={useBaseUrl('img/team-mgmt/usage-download-button.jpg')} alt="Usage download button"/>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fixed broken image tags in the team management section.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- Images rendering incorrectly due to missing import (`import useBaseUrl from '@docusaurus/useBaseUrl';`) 
- `img src` reference tags should be wrapped with `{useBaseUrl('')}` like so: 
`<img src={useBaseUrl('img/team-mgmt/team-mgmt-nav.jpg')} alt="Team management navigation" width="400"/>`
- Fixed image indentations

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/master/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->