### PR TITLE
Cleanup support frameworks and browsers

### DIFF
--- a/docs/testrunner-toolkit.md
+++ b/docs/testrunner-toolkit.md
@@ -51,29 +51,23 @@ Each docker image tag is the 'latest' image that supports the specific framework
   
 <TabItem value="cypress">
 
-| Cypress Version | Supported Browsers                     | Docker Image Tag            |        Sauce Cloud Support [[?](testrunner-toolkit/running-tests.md#test-on-sauce-labs)]         |
-|---------|----------------------------------------|-------------------------------------|------------------------------|
-| 5.6.0   | <ul><li>Chrome 81.0.4044.138</li><li>Firefox 74.0</li></ul> | [saucelabs/stt-cypress-mocha:v5.6.0](https://hub.docker.com/layers/saucelabs/stt-cypress-mocha-node/v5.6.0/images/sha256-70bc83fce7bf4fb3443f2f68b18f295f5eef71ec57f64ce1a9b5307797756221?context=explore)  |     Windows 10   |
-| 5.5.0   | <ul><li>Chrome 81.0.4044.138</li><li>Firefox 74.0</li></ul>  | [saucelabs/stt-cypress-mocha:v0.2.3](https://hub.docker.com/layers/saucelabs/stt-cypress-mocha-node/v0.2.3/images/sha256-95b25c5a85624779c2ed9aaa82a6ca76e770a77e487936e6814f9f9c95dc1e52?context=explore)  |           |
-| 5.4.0   | <ul><li>Chrome 81.0.4044.138</li><li>Firefox 74.0</li></ul>  | [saucelabs/stt-cypress-mocha:v0.1.18](https://hub.docker.com/layers/saucelabs/stt-cypress-mocha-node/v0.1.18/images/sha256-1709f9e55223267b0a63b33fa9f00a84920dd1c175dcd33ee0fababf5abfed50?context=explore) |          |
-| 4.9.0   | <ul><li>Chrome 81.0.4044.138</li><li>Firefox 74.0</li></ul>  | [saucelabs/stt-cypress-mocha:v0.1.12](https://hub.docker.com/layers/saucelabs/stt-cypress-mocha-node/v0.1.12/images/sha256-7c8d0ce5bc1b0260375345bfba71e9d76dfff97fd223da0aa570e8f4715ba075?context=explore) |          |
+| Cypress Version    | Supported Browsers        | Release Notes                                                                                                 | Sauce Cloud Support [[?](testrunner-toolkit/running-tests.md#test-on-sauce-labs)] |
+|--------------------|---------------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| 5.6.0              | Please see release notes. | [saucelabs/sauce-cypress-runner](https://github.com/saucelabs/sauce-cypress-runner/releases/tag/v5.7.2)       | Windows 10                                                                        |
 
 </TabItem>
 <TabItem value="playwright">
 
-| Playwright Version | Supported Browsers                                      | Docker Image Tag                       | Sauce Cloud Support          |
-|---------|---------------------------------------------------------|---------------------------------------------------|------------------------------|
-| 1.7.1   | <ul><li>Playwright</li></ul> | [saucelabs/stt-playwright-node:v1.7.1](https://hub.docker.com/layers/saucelabs/stt-playwright-node/v1.7.1/images/sha256-a7b9117dc33a889eac27db968217de04446c27acf2358ff45252ea54898486ad?context=explore)         |     |
-| 1.4.0   | <ul><li>Chromium 86.0.4217.0</li> <li>Mozilla Firefox 78.0b5</li> <li>WebKit 14.0</li></ul> | [saucelabs/stt-playwright-jest-node:v0.2.1](https://hub.docker.com/layers/saucelabs/stt-playwright-jest-node/v0.2.1/images/sha256-4084258641418233491812a61f47ef3da7baf2dd8ae0d54e1a3125fb1fd5cf42?context=explore)         |     |
-| 1.3.0   | <ul><li>Chromium 86.0.4217.0</li> <li>Mozilla Firefox 78.0b5</li> <li>WebKit 14.0</li></ul> | [saucelabs/stt-playwright-jest-node:v0.2.0](https://hub.docker.com/layers/saucelabs/stt-playwright-jest-node/v0.2.0/images/sha256-3f98d1d68ecb82ecf16ca72ba3d3ff75ab5c4f9e85edfe7b631069ecd2a18067?context=explore)         |     |
-| 1.0.0   | <ul><li>Chromium 84.0.4135.0</li> <li>Mozilla Firefox 76.0b5</li></ul>             | [saucelabs/stt-playwright-jest-node:v0.1.6-alpha.1](https://hub.docker.com/layers/saucelabs/stt-playwright-jest-node/v0.1.6-alpha.1/images/sha256-301dbb659245c403b144972e06bc26a859f969e8bda2c3abbdd1756ecd692e2a?context=explore) |      |
+| Playwright Version | Supported Browsers        | Release Notes                                                                                                 | Sauce Cloud Support [[?](testrunner-toolkit/running-tests.md#test-on-sauce-labs)] |
+|--------------------|---------------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| 1.7.1              | Please see release notes. | [saucelabs/sauce-playwright-runner](https://github.com/saucelabs/sauce-playwright-runner/releases/tag/v1.7.3) |                                                                                   |
 
 </TabItem>
 <TabItem value="testcafe">
 
-| TestCafe Version | Supported Browsers                | Docker Image Tag           | Sauce Cloud Support          |
-|---------|-----------------------------------|-------------------------------------|------------------------------|
-| 1.8.5   | <ul><li>Chrome 81.0.4044.138</li><li>Firefox 74.0</li></ul> | [saucelabs/stt-testcafe-node:v0.1.13](https://hub.docker.com/layers/saucelabs/stt-testcafe-node/v0.1.13/images/sha256-698c954f254b3a68ba57b8ed0f6f87becf0dc7686998e02e197f306e0002fa10?context=explore) |    |
+| TestCafe Version   | Supported Browsers        | Release Notes                                                                                                 | Sauce Cloud Support [[?](testrunner-toolkit/running-tests.md#test-on-sauce-labs)] |
+|--------------------|---------------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| 1.8.5              | Please see release notes. | [saucelabs/sauce-testcafe-runner](https://github.com/saucelabs/sauce-testcafe-runner/releases/tag/v0.1.16)    |                                                                                   |
 
 </TabItem>
 </Tabs> 


### PR DESCRIPTION
### Description
1. Removes list of supported browsers --> The release notes ought to be the source of truth in this context. We don't need to manage both.
2. Replace docker image links with links to the github release page. --> This is more informative to the customer than looking at the image layer information on the docker registry.
3. Format the tables nicely so that it's easier to read and maintain the list as "code".
4. Remove very old releases, so that (new) users are not encouraged to use them. --> There is no ongoing support for the old images.

PS: This is how the markup looks like now with a nice format:
![Screen Shot 2021-02-16 at 1 41 37 PM](https://user-images.githubusercontent.com/1869292/108125096-d521db00-705c-11eb-9cca-cc1688432e0c.png)
