### PR TITLE
dev mode that requires no API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ __Table of Contents__
 
 	This command builds the site and serves it on your machine's host (http://localhost:3000).
 
+* Serve the website locally:
+
+   ```
+   yarn run dev
+   ```
+
+	This command builds the site and serves it on your machine's host (http://localhost:3000) and requires no API key.
+
+
 
 ## Contributing
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+const docusaurusConfig = {
   title: 'Sauce Labs Documentation',
   tagline: 'Find everything you need to know about manual and automated cross-browser and mobile app testing in the Sauce Labs Continuous Testing Cloud.',
   url: 'https://docs.saucelabs.com',
@@ -15,11 +15,6 @@ module.exports = {
     hideableSidebar: true,
     prism: {
       additionalLanguages: ['java', 'ruby', 'csharp', 'bash', 'powershell', 'python'],
-    },
-    algolia: {
-      appId: process.env.ALGOLIA_APP_ID,
-      apiKey: process.env.ALGOLIA_KEY,
-      indexName: 'saucelabs',
     },
     /* Dark and Light Mode Config */
     colorMode: {
@@ -364,4 +359,14 @@ module.exports = {
       },
     ],
   ],
-};
+}
+
+if (!process.env.SAUCE_DOCS_DEV) {
+  docusaurusConfig.themeConfig.algolia = {
+    appId: process.env.ALGOLIA_APP_ID,
+    apiKey: process.env.ALGOLIA_KEY,
+    indexName: 'saucelabs',
+  }
+}
+
+module.exports = docusaurusConfig;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "dev": "cross-env SAUCE_DOCS_DEV=true docusaurus start",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
@@ -17,8 +18,8 @@
     "@docusaurus/preset-classic": "2.0.0-alpha.70",
     "@mdx-js/react": "1.6.21",
     "@saucelabs/theme-github-codeblock": "0.0.4",
-    "docusaurus2-dotenv": "^1.4.0",
     "clsx": "1.1.1",
+    "docusaurus2-dotenv": "^1.4.0",
     "react": "16.8.4",
     "react-dom": "16.8.4"
   },
@@ -35,6 +36,7 @@
     ]
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "cypress": "^4.12.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3532,6 +3532,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
@@ -3552,7 +3559,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Added a script "dev" that sets an environment variable `SAUCE_DOCS_DEV` that tells docusaurus.config.js to bypass the algolia API keys. This is so you can run the site locally without needing to set algolia api keys.