### PR TITLE
Add mingw warning

### DIFF
--- a/docs/testrunner-toolkit/installation.md
+++ b/docs/testrunner-toolkit/installation.md
@@ -81,6 +81,11 @@ chmod 700 get_saucectl.sh && \
 ./get_saucectl.sh
 ```
 
+:::warning Windows and mingw
+Mingw is known to interfere with `saucectl`, especially with interactive commands like `saucectl configure` or `saucectl new`.
+We therefor advise Windows users to simply use `cmd` or `powershell` when interacting with `saucectl`.
+:::
+
 ## Connecting to Sauce Labs
 
 You need to retrieve your Sauce Labs `username` and `accessKey` in order post your test results to the Sauce Labs platform. To retrieve your Sauce Labs account credentials navigate to [Account > User Settings](https://app.saucelabs.com/user-settings).

--- a/docs/testrunner-toolkit/installation.md
+++ b/docs/testrunner-toolkit/installation.md
@@ -83,7 +83,7 @@ chmod 700 get_saucectl.sh && \
 
 :::warning Are you using mingw?
 Mingw on Windows is known to interfere with `saucectl`, especially with interactive commands like `saucectl configure` or `saucectl new`.
-We therefor advise Windows users to simply use `cmd` or `powershell` when interacting with `saucectl`.
+We therefore advise Windows users to simply use `cmd` or `powershell` when interacting with `saucectl`.
 :::
 
 ## Connecting to Sauce Labs

--- a/docs/testrunner-toolkit/installation.md
+++ b/docs/testrunner-toolkit/installation.md
@@ -81,8 +81,8 @@ chmod 700 get_saucectl.sh && \
 ./get_saucectl.sh
 ```
 
-:::warning Windows and mingw
-Mingw is known to interfere with `saucectl`, especially with interactive commands like `saucectl configure` or `saucectl new`.
+:::warning Are you using mingw?
+Mingw on Windows is known to interfere with `saucectl`, especially with interactive commands like `saucectl configure` or `saucectl new`.
 We therefor advise Windows users to simply use `cmd` or `powershell` when interacting with `saucectl`.
 :::
 


### PR DESCRIPTION
### Description
Add a `mingw` warning to the installation page.

### Motivation and Context
Mingw has been known to interfere with interactive golang CLIs.
