### PR TITLE
Add missing puppeteer references

### DIFF
--- a/docs/testrunner-toolkit.md
+++ b/docs/testrunner-toolkit.md
@@ -96,6 +96,7 @@ Each docker image tag is the 'latest' image that supports the specific framework
   values={[
     {label: 'Cypress', value: 'cypress'},
     {label: 'Playwright', value: 'playwright'},
+    {label: 'Puppeteer', value: 'puppeteer'},
     {label: 'TestCafe', value: 'testcafe'},
   ]}>
   

--- a/docs/testrunner-toolkit/configuration.md
+++ b/docs/testrunner-toolkit/configuration.md
@@ -97,6 +97,7 @@ Below are framework-specific configuration examples that exist in the [Testrunne
   values={[
     {label: 'Cypress', value: 'cypress'},
     {label: 'Playwright', value: 'playwright'},
+    {label: 'Puppeteer', value: 'puppeteer'},
     {label: 'TestCafe', value: 'testcafe'},
   ]}>
 
@@ -111,6 +112,13 @@ https://github.com/saucelabs/testrunner-toolkit/blob/master/.sauce/cypress.yml
 
 ```yaml reference
 https://github.com/saucelabs/testrunner-toolkit/blob/master/.sauce/playwright.yml
+```
+
+</TabItem>
+<TabItem value="puppeteer">
+
+```yaml reference
+https://github.com/saucelabs/saucectl-puppeteer-example/blob/master/.sauce/config.yml
 ```
 
 </TabItem>

--- a/docs/testrunner-toolkit/configuration/common-syntax.md
+++ b/docs/testrunner-toolkit/configuration/common-syntax.md
@@ -27,7 +27,7 @@ __Type__: *string*
 
 __Example__:
 ```yaml
-kind: < cypress | playwright | testcafe >
+kind: < cypress | playwright | testcafe | puppeteer >
 ```
 
 ## `sauce`

--- a/sidebars.js
+++ b/sidebars.js
@@ -514,6 +514,7 @@ module.exports = {
                   'testrunner-toolkit/configuration/common-syntax',
                   'testrunner-toolkit/configuration/cypress',
                   'testrunner-toolkit/configuration/playwright',
+                  'testrunner-toolkit/configuration/puppeteer',
                   'testrunner-toolkit/configuration/testcafe',
               ],
           },


### PR DESCRIPTION
### Description
Add missing puppeteer references, which includes the sidebar as well as config/docker examples.