### PR TITLE
Revert "Enable testcafe for windows platform"

### DIFF
--- a/docs/testrunner-toolkit.md
+++ b/docs/testrunner-toolkit.md
@@ -82,7 +82,6 @@ Each docker image tag is the 'latest' image that supports the specific framework
 |TestCafe Version|Supported Platforms|Supported Browsers|
 |-----|-----|-----|
 |1.11.0|macOS 11.00|Safari, Chrome, Firefox, MicrosoftEdge|
-|1.11.0|Windows 10|Chrome, Firefox, MicrosoftEdge|
 |1.10.1|Windows 10|Chrome, Firefox, MicrosoftEdge|
 
 </TabItem>


### PR DESCRIPTION
Reverts saucelabs/sauce-docs#280

testcafe on windows10 is still not ready