### PR TITLE
Add reporting section to Jenkins

### DIFF
--- a/docs/ci/jenkins.md
+++ b/docs/ci/jenkins.md
@@ -293,14 +293,30 @@ Alternatively, you can configure your project so you can choose specific operati
 
 Jenkins populates the `SELENIUM_PLATFORM`, `SELENIUM_VERSION`, `SELENIUM_BROWSER`, and `SELENIUM_DRIVER` environment variables for each combination you specified and runs the tests in parallel.
 
-## Publishing Test Status to Sauce Labs
+## Reporting between Sauce Labs and Jenkins
+
+<p><span className="sauceDBlue">VIRTUAL CLOUD ONLY</span></p>
+
+The following sections describe how to share information about your Sauce Labs tests in both the Sauce Labs site and your Jenkins dashboard.
+
+### Capture Build Details
+
+Set the `SAUCE_BUILD_NAME` environment variable as the value of the `build` desired capability to set the Sauce build name at runtime. This enables you to access your test reports by build in the Sauce Labs dashboard and also view them on the Jenkins **Build Details** page.
+
+```java title="Jave Build Capabilities Example"
+DesiredCapabilities capabilities = new DesiredCapabilities();
+// ...
+capabilities.setCapability("build", System.getenv("SAUCE_BUILD_NAME");
+```
+
+### Publish Test Status to Sauce Labs
 
 The Sauce plugin for Jenkins will also mark the Sauce jobs as passed or failed, but you need to configure Jenkins to parse the test results.
 
 1. From the **Configure** page of your project, select the **Post-Build Actions** tab.
 1. Select **Run Sauce Labs Test Publisher**.
 
-## Outputting the Jenkins Session ID to stdout
+### Output the Jenkins Session ID to stdout
 
 As part of the post-build activities, the Sauce plugin will parse the test result files in an attempt to associate test results with Sauce jobs. It does this by identifying lines in the stdout or stderr that have this format:
 `SauceOnDemandSessionID=<session id> job-name=<some job name>`


### PR DESCRIPTION
### Description
- Added a reporting section to Jenkins
- Added the Virtual Cloud Only badge to the reporting section.

### Motivation and Context
Resolves customer request to clearly state that reporting integration between SL and Jenkins is not supported for RDC.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/master/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->