### PR TITLE
TCD-1668: Expand Deque page to include other frameworks

### DIFF
--- a/docs/basics/integrations/deque.md
+++ b/docs/basics/integrations/deque.md
@@ -24,13 +24,21 @@ See the [following link](https://www.deque.com/web-accessibility-beginners-guide
 * [A Sauce Labs Account](https://saucelabs.com/sign-up)
 * [A Deque Account (Optional)](https://axe.deque.com/plans)
 * [Install Git](https://git-scm.com/downloads)
-* [Install Node/NPM](https://nodejs.org/en/download/)
-
-:::note
-For the purpose of this guide, we will focus entirely on [WebdriverIO](https://webdriver.io/)
-:::
+* Language Binaries ([Node/NPM](https://nodejs.org/en/download/), [Ruby](https://www.ruby-lang.org/en/downloads/), [Python](https://www.python.org/downloads/), etc.)
 
 ## Set Up Dependencies
+
+<Tabs
+groupId="langs"
+defaultValue="node"
+values={[
+    {label: 'node.js / wdio', value: 'node'},
+    {label: 'java', value: 'java'},
+    {label: 'python', value: 'python'},
+    {label: 'ruby', value: 'ruby'},
+]}>
+
+<TabItem value="node">
 
 Add the following dependencies to your `package.json` file:
 
@@ -42,11 +50,36 @@ Add the following dependencies to your `package.json` file:
 "@wdio/sauce-service"
 ```
 
-## Create the Configuration
+:::note WebdriverIO Configuration
+If you haven't already, create a `wdio.conf.js` in your root project directory, see the [WebdriverIO documentation](https://webdriver.io/docs/gettingstarted#set-up) for further details. 
+:::
 
-Next, create a `wdio.conf.js` in your root project directory, see the [WebdriverIO documentation](https://webdriver.io/docs/gettingstarted#set-up) for further details. 
+</TabItem>
+<TabItem value="java">
 
-### WebdriverIO Instance
+</TabItem>
+<TabItem value="python">
+
+</TabItem>
+<TabItem value="ruby">
+
+</TabItem>
+</Tabs>
+
+
+## Create an Axe Instance
+
+<Tabs
+groupId="langs"
+defaultValue="node"
+values={[
+    {label: 'node.js/wdio', value: 'node'},
+    {label: 'java', value: 'java'},
+    {label: 'python', value: 'python'},
+    {label: 'ruby', value: 'ruby'},
+]}>
+
+<TabItem value="node">
 
 In the `wdio.conf.js` file, create an object called `axeWdio`. This object creates a new `AxeWebdriverIO` instance which accepts the current browser object from WDIO as an argument.
 
@@ -84,206 +117,47 @@ browser.addCommand('getAxeResults', function (name) {
 })
 ```
 
-### Set Local Driver Capabilities
-Before you test on Sauce Labs, ensure your axe™ accessibility tests return the desired `a11y` results. The best course of action is to test against local drivers such as chrome, firefox, safari, etc.
-
-Here are some examples of how to instantiate a local driver through the `capabilities` object:
-
-<Tabs
-defaultValue="chrome"
-values={[
-{label: 'Chrome', value: 'chrome'},
-{label: 'Firefox', value: 'firefox'},
-]}>
-
-<TabItem value="chrome">
-
-```js
-    capabilities: [{
-        browserName: 'chrome', 
-        'goog:chromeOptions': {
-            args: [
-                '--no-sandbox', 
-                '--disable-infobars',
-            ],
-        },
-    },
-];
-```
+</TabItem>
+<TabItem value="java">
 
 </TabItem>
-<TabItem value="firefox">
+<TabItem value="python">
 
-```js
-    capabilities: [{
-        browserName: 'firefox',
-        specs: [
-            'test/ffOnly/*'
-        ],
-        'mox:firefoxOptions': {
-            args: [
-                '--headless'
-            ],
-        },
-    },
-];
-```
+</TabItem>
+<TabItem value="ruby">
 </TabItem>
 </Tabs>
 
+## Run the Test
 
-For further information please read the following:
+Now in your actual tests, all you need to do is call the following to retrieve the `axe-core` test results:
 
-* [WebdriverIO Documentation for setting up Driver Binaries](https://webdriver.io/docs/driverbinaries/#geckodriver)
-* [WebdriverIO Documentation for the config file](https://webdriver.io/docs/configurationfile)
+<Tabs
+groupId="langs"
+defaultValue="node"
+values={[
+    {label: 'node.js/wdio', value: 'node'},
+    {label: 'java', value: 'java'},
+    {label: 'python', value: 'python'},
+    {label: 'ruby', value: 'ruby'},
+]}>
 
-### Running the Test
-Now in your actual tests, all you need to do is call the following to get the `axe-core` test results:
+<TabItem value="node">
 
 ```js
 browser.getAxeResults()
 ```
 
-## Sauce Labs Setup
-
-It's recommended that you create a separate `.conf.js` file in order to manage the Sauce Labs configuration details.
-
-For example:
-
-```js
-const {config} = require('./wdio.conf');
-
-config.user = "yourUserName";
-config.key = "yourAccessKey";
-config.region = "yourRegion -> us / eu";
-
-config.capabilities = [
-    
-];
-
-config.services = config.services.concat('sauce');
-
-exports.config = config;
-```
-
-### Sauce Labs Credentials
-
-Specify the Sauce Labs `user` access `key` and data center `region` in which you want to run your tests.
-
-```js
-config.user = "yourUserName";
-config.key = "yourAccessKey";
-config.region = "yourRegion -> us / eu";
-```
-
-You can retrieve your Sauce Labs account credentials with [this link](https://app.saucelabs.com/user-settings). The `region` property is used for both Virtual Machine Cloud and Real Device Cloud tests, and the acceptable values are:
-
-* `us` - *default*
-* `eu`
-
-:::warning Don't Hard-Code Credentials
-Hard-coding your `user`, `key`, and `region` property values is not a recommended best practice due to security reasons.
-
-Instead, export your [Sauce Labs Account Credentials as Environment Variables](https://wiki.saucelabs.com/display/DOCS/Best+Practice%3A+Use+Environment+Variables+for+Authentication+Credentials) and add them in your script like the following example:
-
-```js
-config.user = process.env.SAUCE_USERNAME;
-config.key = process.env.SAUCE_ACCESS_KEY;
-config.region = process.env.REGION || 'us';
-```
-
-Visit the [WebDriverIO documentation](https://webdriver.io/docs/sauce-service.html) for further details.
-:::
-
-### Set Sauce Labs Capabilities
-
-In order to test on Sauce Labs with multiple different browsers and platforms, add the following configuration options in the `capabilities` object.
-
-Here are some examples:
-
-<Tabs
-defaultValue="chrome"
-values={[
-{label: 'Chrome', value: 'chrome'},
-{label: 'Firefox', value: 'firefox'},
-{label: 'Safari', value: 'safari'},
-{label: 'Edge', value: 'edge'},
-]}>
-
-<TabItem value="chrome">
-
-```js
-    {
-        browserName: 'googlechrome',
-        platformName: 'Windows 10',
-        browserVersion: 'latest',
-    },
-```
+</TabItem>
+<TabItem value="java">
 
 </TabItem>
-<TabItem value="firefox">
-
-```js
-    {
-        browserName: 'firefox', 
-        platformName: 'Windows 10',
-        browserVersion: 'latest',
-    },
-```
+<TabItem value="python">
 
 </TabItem>
-<TabItem value="safari">
-
-```js
-    {
-        browserName: 'safari', 
-        platformName: 'macOS 10.15',
-        browserVersion: 'latest',
-    },
-```
-
-</TabItem>
-<TabItem value="edge">
-
-```js
-    {
-        browserName: 'MicrosoftEdge',
-        platformName: 'Windows 10',
-        browserVersion: 'latest',
-    },
-```
-
+<TabItem value="ruby">
 </TabItem>
 </Tabs>
-
-:::tip Browers and OS support on Sauce Labs
-For a full list of supported browsers/platforms visit [this page](https://saucelabs.com/platform/supported-browsers-devices).
-:::
-
-It's also a best practice to set test options that are specific to Sauce Labs features. For example, declare this at the top of your configuration:
-
-```js
-const defaultBrowserSauceOptions = {
-    build: `Best Practices: Sauce Labs Desktop Web build-${new Date().getTime()}`,
-    screenResolution: '1600x1200',
-};
-```
-
-and call it in the `sauce:options` test option, as a part of the `capabilities` object, like in this example below:
-
-```js {6-7}
-config.capabilities = [
-    {
-        browserName: 'googlechrome',
-        platformName: 'Windows 10',
-        browserVersion: 'latest',
-        'sauce:options': {
-            ...defaultBrowserSauceOptions,
-        },
-    },
-...
-];
-```
 
 ## Additional Resources
 * [`sa11y` (Selenium Accessibility) Example Code](https://github.com/saucelabs/sa11y)
@@ -291,3 +165,4 @@ config.capabilities = [
 * [Deque `axe-core` Example WebDriverIO Project](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/webdriverio)
 * [Documentation about the chainable `axe` API for WebdriverIO](https://www.npmjs.com/package/@axe-core/webdriverio)
 * [Sauce Labs / Deque Marketing Blog Post](https://saucelabs.com/news/sauce-labs-and-deque-systems-join-forces-to-help-enterprises-ensure-digital-accessibility)
+* [Sauce Labs Automated Testing Basics](/web-apps)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Refactored page to include other languages and frameworks.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- WDIO local and sauce setup points are either duplicate/redundant or unnecessary given the purpose of the doc is to illustrate how to configure accessibility testing.
- Hand-hold steps should be relegated to training
- Move config-specific setup instructions to ‘Additional Resources’

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/master/CONTRIBUTING.MD) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->

CC @titusfortner and @wswebcreation 

Resolves: [TCD-1668](https://saucedev.atlassian.net/browse/TCD-1668)