### PR TITLE
TCD-1703: Updated Github Actions Cache Convention

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,12 +30,12 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/package.json') }}
 
       - name: Install Dependencies
         if: steps.cache-npm-packages.outputs.cache-hit != 'true'
         run: |
-          npm install
+          npm ci
 
       - uses: actions/cache@v2
         id: cache-build
@@ -69,7 +69,7 @@ jobs:
       - name: Install Dependencies
         if: steps.cache-npm-packages.outputs.cache-hit != 'true'
         run: |
-          npm install
+          npm ci
 
       - name: Run Build
         if: steps.cache-build.outputs.cache-hit != 'true'
@@ -118,7 +118,7 @@ jobs:
       - name: Install Dependencies
         if: steps.cache-npm-packages.outputs.cache-hit != 'true'
         run: |
-          npm install
+          npm ci
 
       - name: Run Build
         if: steps.cache-build.outputs.cache-hit != 'true'
@@ -158,7 +158,7 @@ jobs:
       - name: Install Dependencies
         if: steps.cache-npm-packages.outputs.cache-hit != 'true'
         run: |
-          npm install
+          npm ci
 
       - name: Run Build
         if: steps.cache-build.outputs.cache-hit != 'true'

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -139,12 +139,6 @@ const docusaurusConfig = {
           systemvars: true,
         },
       ],
-      [
-        '@docusaurus/plugin-client-redirects',
-        {
-          fromExtensions: ['html'],
-        },
-      ],
   ],
 }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Since upgrading Docusaurus to `"@docusaurus/core": "2.0.0-beta.0",` , there's been problems with our GH actions `cache` rule. I updated the `key` to use a GH secret in order to force a cache update in the future.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- Added convention for punching whole through GH action cache
- Forces a clean install during build via `npm ci`
- Hopefully resolve future `node_modules` problems in the GCP bucket whenever we need to upgrade.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/master/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->

# Resolves [TCD-1703](https://saucedev.atlassian.net/browse/TCD-1703)