### PR TITLE
Fixed syntax error within `timeout`

### DIFF
--- a/docs/testrunner-toolkit/configuration/testcafe.md
+++ b/docs/testrunner-toolkit/configuration/testcafe.md
@@ -83,6 +83,7 @@ Instructs how long (in `ms`, `s`, `m`, or `h`) `saucectl` should wait for each s
 
 ```yaml
   timeout: 15m
+```
 ---
 
 ## `sauce`


### PR DESCRIPTION
The end of the `timeout` code block was missing the closing tags.
