### PR TITLE
[TCD-1892] Added "stop_urls" for APIFM2 config

### DIFF
--- a/.docsearch/config.json
+++ b/.docsearch/config.json
@@ -6,7 +6,9 @@
   "sitemap_urls": [
     "https://docs.saucelabs.com/sitemap.xml"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://docs.saucelabs.com/api-testing/mark2/"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
@@ -38,7 +40,7 @@
       "url",
       "url_without_anchor",
       "type"
-    ]
+    ],
   },
   "nb_hits": 1062
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Edited DocSearch config.json to include `stop_urls` for legacy API fortress docs.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To exclude legacy documentation from appearing in search results.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
