### PR TITLE
add code examples to test status page

### DIFF
--- a/docs/test-results/test-status.md
+++ b/docs/test-results/test-status.md
@@ -13,20 +13,28 @@ import TabItem from '@theme/TabItem';
 * How to use the Sauce Labs REST API to update the status of your test after it has already completed
 
 ## Update Test Status in Session
-You can use the Selenium JavaScript Executor to annotate your test in the @after hook. This is the ideal means of writing your tests to interpret the results as a pass/fail and update the status accordingly.
+You can use the Selenium JavaScript Executor to annotate your test in the @after hook. This is the ideal means of 
+writing your tests to interpret the results as a pass/fail and update the status accordingly.
 
 :::caution JavaScript Executor
-The JavaScript Executer commands can only be run while the test is in session. Once the test is complete, the JavaScript Executor commands are no longer applicable and you must use the REST API to update the test.
+The JavaScript Executer commands can only be run while the test is in session. 
+Once the test is complete, the JavaScript Executor commands are no longer applicable and you must use the 
+REST API to update the test.
 :::
 
 ### Video: Setting Test Status to Pass Fail
-Watch this video for a demonstration of using the Selenium JavaScript Executor to annotate your test result with a Passed/Failed status.
+Watch this video for a demonstration of using the Selenium JavaScript Executor to annotate your test result with a 
+Passed/Failed status.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/iaKRGjO-L8Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/iaKRGjO-L8Y" title="YouTube video player" 
+frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+allowfullscreen></iframe>
 
 ### Code Examples
 
-The annotation for calling the JavaScript Executor in your test differs slightly for each framework and language, which are provided in the following code snippet examples. Refer to our Sauce Labs Demonstration Code Repositories on GitHub for further information, and more context, on annotating your tests to record the pass/fail status.
+The annotation for calling the JavaScript Executor in your test differs slightly for each framework and language, 
+which are provided in the following code snippet examples. Refer to our Sauce Labs Demonstration Code Repositories 
+on GitHub for further information, and more context, on annotating your tests to record the pass/fail status.
 
 <Tabs
 defaultValue="java"
@@ -39,30 +47,72 @@ values={[
 ]}>
 
 <TabItem value="java">
-Coming Soon!
-</TabItem>
 
+* JUnit 5
+```java reference title="Test Reporting with JUnit 5 Test Watcher"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.0/selenium-examples/src/test/java/com/saucedemo/selenium/demo/SeleniumTest.java#L56-L68
+```
+
+* TestNG
+```java reference title="Test Reporting with TestNG"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.0/selenium-testng-examples/src/test/java/com/saucedemo/selenium/testng/demo/SeleniumTest.java#L43-L47
+```
+
+</TabItem>
 <TabItem value="c#">
-Coming Soon!
-</TabItem>
 
+* MSTest
+```csharp reference title="Test Reporting with MSTest"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.0/SauceExamples/SeleniumMsTest/Onboarding/InstantSauceTest.cs#L83-L85
+```
+
+* NUnit
+```csharp reference title="Test Reporting with NUnit"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.0/DotnetCore/Sauce.Demo/Core.Selenium.Examples/AllTestsBase.cs#L61-L64
+```
+
+</TabItem>
 <TabItem value="python">
-Coming Soon!
-</TabItem>
 
+* PyTest
+```python reference title="Test Reporting with PyTest"
+https://github.com/saucelabs-training/demo-python/blob/docs-1.0/examples/w3c-examples/test_pytest_chrome.py#L33-L38
+```
+
+* Robot Framework
+```python reference title="Test Reporting with Robot Framework"
+https://github.com/saucelabs-training/demo-python/blob/docs-1.0/examples/robotframework/desktop_web/Tests/resource.robot#L58-L61
+```
+
+</TabItem>
 <TabItem value="node">
-Coming Soon!
+
+* WebdriverIO
+
+The [Sauce Service for WebdriverIO](https://v6.webdriver.io/docs/sauce-service.html) does the reporting for you automatically.
+
+* Nightwatch
+```javascript reference title="Test Reporting with Nightwatch"
+https://github.com/saucelabs-training/demo-js/blob/docs-1.0/nightwatch/appium-web/examples/update-sauce-real-devices/tests/custom-commands/customSauceLabsEnd.js#L30-L35
+```
+
 </TabItem>
 
 <TabItem value="ruby">
-Coming Soon!
+
+* RSpec
+```ruby reference title="Test Reporting with RSpec"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.0/intro/spec/spec_helper.rb#L20-L24
+```
+
 </TabItem>
 </Tabs>
 
 
 ## Updating Test Status After Completion
 
-If you did not use the JavaScript Executor to update the status of your test as an assertion in the test code, you can still use the Sauce Labs REST API to update the test status.
+If you did not use the JavaScript Executor to update the status of your test as an assertion in the test code, 
+you can still use the Sauce Labs REST API to update the test status.
 
 ### What You'll Need
 * Your Sauce Labs account credentials


### PR DESCRIPTION
I added examples for more than one test runner per language to provide a little extra context since they are all a little different.