### PR TITLE
Removing --doctor from the documentation

### DIFF
--- a/docs/secure-connections/sauce-connect/troubleshooting.md
+++ b/docs/secure-connections/sauce-connect/troubleshooting.md
@@ -30,7 +30,8 @@ If any of these commands fail, you should work with your internal network team t
   values={[
     {label: 'ping', value: 'ping'},
     {label: 'telnet', value: 'telnet'},
-    {label: 'cURL', value: 'curl'},  ]}>
+    {label: 'cURL', value: 'curl'},
+    {label: 'Sauce Connect Proxy', value: 'sc'},  ]}>
 
 <TabItem value="ping">
 
@@ -53,11 +54,20 @@ This command should return an IP address of 162.222.73.2.
 <TabItem value="curl">
 
 ```curl
-curl -v https://</span>saucelabs.com/
+curl -v https://saucelabs.com/
 ```
 
 This command should return the status message connected to `saucelabs.com`.
 
+</TabItem>
+
+<TabItem value="sc">
+
+```bash
+sc -c /path/to/your/config.yaml
+```
+
+This command should return the error message "Failed to reach https://saucelabs.com/rest/v1/USERNAME/tunnels/info/updates" if SauceConnect Proxy fails to connect to `saucelabs.com`.
 </TabItem>
 </Tabs>
 
@@ -73,65 +83,10 @@ Cross-Origin Resource Sharing (CORS) errors could be caused by a variety of reas
 * Start a Sauce Connect Proxy instance using the `-B` all and `-N` flags. For more information about what these flags do for your tunnel, see the [Sauce Connect Proxy CLI Reference](/dev/cli/sauce-connect-proxy).
 
 ## Additional Support
-If you're still experiencing Sauce Connect Proxy test failures, try the diagnostic steps under Sauce Connect Proxy Debugging and Diagnostics with `--doctor` flag.
-
-## Debugging and Diagnostics with `--doctor` Flag
-When running Sauce Labs tests with Sauce Connect Proxy, there may be situations in which Sauce Connect Proxy doesn't perform as expected. To make sure everything is in working order, you can run Sauce Connect diagnostic tests by appending the `--doctor` flag to your command line.
-
-:::note
-While the `--doctor` flag can facilitate debugging, you'll find most valuable troubleshooting information in your verbose logs (which you'd need to enable).
-:::
-
-## Running Tests Using the `--doctor` Flag
-To use the `--doctor` flag, you would run the same command for starting the Sauce Connect Proxy, including any additional flags related to your specific tunnel (e.g., `--tunnelidentifier` or `-x` to specify a data center).
-
-:::note
-When adding the `--doctor` flag to your code, placement matters. Here's the correct order of flags:
-
-```bash
-`c -u [Your Sauce Username] -k [Your Sauce Access Key] --doctors`
-```
-:::
-
-### Diagnostics Performed
-`--doctor` will run a series of diagnostic operations to verify the following:
-
-* Which DNS servers and SSL certificates can be found in your network when Sauce Connect Proxy boots up
-* Sauce Connect Proxy outbound connections to:
-  * saucelabs.com on port 443 for the REST API and the primary tunnel connection to the Sauce Labs cloud
-  * gv.symcd.com and g.symd.com on port 443 using the SSL certificates found in your network
-  * https://google.com
-* Connectivity to these Sauce Labs REST API calls:
-  * https://saucelabs.com/version.json
-  * https://saucelabs.com/rest/v1/[Your Sauce Username]/tunnels
-
-:::note
-Sauce Connect Proxy will exit after these checks are performed. A tunnel will not be started.
-:::
-
-## Identifying and Resolving Common Errors with the `--doctor` Flag
-In the table below, you'll find descriptions of the errors that `--doctor` will detect and how to resolve them.
-
-| Error                                                                                                                    | Resolution                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| failed to fetch PAC file `<file>`                                                                                 | Indicates the specified PAC file couldn't be downloaded. This may be caused by an incorrect URL, or a network mis-configuration. To troubleshoot this type of issue, try to download the PAC file manually from the machine running Sauce Connect Proxy with cURL or another HTTP client. To debug the PAC file you can create one locally and pass it to Sauce Connect Proxy using the  `--pac` option like this:  ``` sc --pac file:///</span>path/to/pacfile.js ```  In Windows, remember to add the drive to the path like this:  ``` sc --pac file://C:/</span>path/to/pacfile.js ``` |
-| failed to fetch or empty PAC file                                                                                        | Connection to the remote server was successful, but the PAC file was empty or missing.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| both `--proxy` and `--pac` are used                                                                                      | Using both may work, but this is unsupported by Sauce Labs and should only be used if directed by the Sauce Labs support.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| invalid REST URL                                                                                                         | URL specified in the `-x` option is invalid.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| failed to find proxy via PAC for `<host>`                                                                         | PAC file was downloaded successfully, but no proxy was found for this host. This may be the result of an incorrect PAC file: make sure a proxy is specified for all the hosts.                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| can't resolve `saucelabs.com`/... tunnel hostname(s) via any DNS server                                                  | Please check your firewall and DNS settings. To troubleshoot this issue, use `dig` or `host` to resolve the domain and verify it is correct:  ``` dig saucelabs.com ```                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| your hosts file contains an entry for `<host>`                                                                     | If this error occurred, it is likely that your DNS server couldn't resolve saucelabs.com correctly.   As a result, Sauce Labs Support might have directed someone at your organization to add the host to `/etc/hosts`. This is most likely because the DNS system has a special configuration for some hosts.  Please remove this entry from the host file: it's usually `/etc/hosts` on Unix-like systems. With Linux/Mac OS X systems, you can check the hosts file with this command:  ``` grep 'saucelabs.com' /etc/hosts ```                                                                     |
-| connecting via `<proxy>` to `http://<url>:<error>`   or   connecting to `http://<url>:<error>` | URL isn't accessible. If you see this error after other errors in the logs, try to fix the previous errors first.  Please refer to [libcurl error codes](https://curl.se/libcurl/c/libcurl-errors.html) to troubleshoot this issue.                                                                                                                                                                                                                                                                                                                                                                    |
-| SSL connect failed, socket: `<code_number>` code: `%d`                                                                | Secure connection couldn't be established. Please refer to the [OpenSSL manual](https://www.openssl.org/docs/manpages.html) to get more information about the error.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| failed to retrieve certificate chain                                                                                     | Some X509 certificates couldn't be imported into the SSL library. This may indicate an issue with DNS, or public CAs being unreachable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| failed to reach `https?://google.com`                                                                                     | Sauce Connect Proxy client can't reach google.com. This indicates that the client doesn't have full Internet connectivity. It may not be an issue; Sauce Connect Proxy only needs access to saucelabs.com and its tunnels.                                                                                                                                                                                                                                                                                                                                                                             |
-
-## Additional Support
 If you need more help, please get in touch with our support team at help@saucelabs.com.
 
 To better assist you, when creating your support ticket, please include the following information with your request:
 
-* `--doctor` flag
 * Link to your Sauce Labs test from the Test Results page in Sauce Labs, showing reproduction of the problem
 * Your Sauce Connect Proxy verbose log, which you can get by adding the `-v` and `-l sc.log` options to your Sauce Connect Proxy command line:
 


### PR DESCRIPTION
### Description

`--doctor` option was not very useful for some time now. SC-4.7.0 disabled it and incorporated a lot of its functionality into SC logs. It became unnecessary to have `--doctor` option documentation (even for older versions).

### Motivation and Context
This documentation change improves user troubleshooting by eliminating pointless suggestion to run `sc --doctor`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
