### PR TITLE
[TCD-1928] Doc Concurrency API

### DIFF
--- a/docs/basics/acct-team-mgmt/concurrency-limits.md
+++ b/docs/basics/acct-team-mgmt/concurrency-limits.md
@@ -20,7 +20,7 @@ Once you've used all of your concurrency slots, additional tests will not start 
 
 ## Checking Concurrency
 
-You can use the [Get User Concurrency](/dev/api/accounts/#get-a-users-concurrency) API endpoint to retrieve a specific user's concurrency usage compared with their organization and team concurrency allowances.
+You can use the [Get User Concurrency](/dev/api/accounts/#get-user-concurrency) API endpoint to retrieve a specific user's concurrency usage compared with their organization and team concurrency allowances.
 
 ```jsx title="Sample Concurrency Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \

--- a/docs/basics/acct-team-mgmt/concurrency-limits.md
+++ b/docs/basics/acct-team-mgmt/concurrency-limits.md
@@ -17,3 +17,13 @@ In the diagram below, OrgX has a total concurrency of 100 VMs, and the org admin
 
 ## Queuing Tests
 Once you've used all of your concurrency slots, additional tests will not start until an existing test finishes. As tests complete, queued tests are allocated to concurrency slots in the order they were queued, however, we do not recommend queuing tests intentionally. Tests will time out with an error if they are queued for too long and/or if too many tests are already queued.
+
+## Checking Concurrency
+
+You can use the [Get User Concurrency](/dev/api/accounts/#get-a-users-concurrency) API endpoint to retrieve a specific user's concurrency usage compared with their organization and team concurrency allowances.
+
+```jsx title="Sample Concurrency Request"
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
+--request GET 'https://api.us-west-1.saucelabs.com/rest/v1.2/users/<username>/concurrency' \
+--header 'Content-Type: application/json' \ | json_pp
+```

--- a/docs/dev/api.md
+++ b/docs/dev/api.md
@@ -62,8 +62,8 @@ $ export SAUCE_ACCESS_KEY=<your access key>
 
 The API is versioned by URL, each of which may be in a different stage of release. The currently published version of each endpoint is reflected in the URL itself, as demonstrated in the following two endpoints:
 
-* `https://api.us-west-1.saucelabs.com/rest/v1.2/users/<USERNAME>/concurrency`
-* `https://api.us-west-1.saucelabs.com/rest/v1/users/<USERNAME>/activity`
+* `https://api.us-west-1.saucelabs.com/rest/v1/<USERNAME>/jobs`
+* `https://api.us-west-1.saucelabs.com/v2/performance/metrics/`
 
 ### Methods
 
@@ -132,11 +132,9 @@ Requests received after the rate limit is reached return a [429 response code](h
 
 | REST API Endpoint | Rate Limit | Authenticated |
 | :-------------------------- | :---:| ---:|
-| `/rest/v1/*/activity` | 3 requests per second, or 3,500 requests per hour | :heavy_check_mark: |
-| All other authenticated request endpoints | 10 requests per second, or 3,500 requests per hour | :heavy_check_mark: |
+| All authenticated request endpoints | 10 requests per second, or 3,500 requests per hour | :heavy_check_mark: |
 | All unauthenticated request endpoints | 2 requests per minute ||
 
-For more information about rate limiting check out this blog post: [Announcing New Rest API Usage Limits](https://saucelabs.com/blog/announcing-new-rest-api-rate-limits).
 
 ## JQ Response Formatting
 

--- a/docs/dev/api/accounts.md
+++ b/docs/dev/api/accounts.md
@@ -1506,7 +1506,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ---
 
-### Get a User's Concurrency
+### Get User Concurrency
 
 <details><summary><span className="get">GET</span> <code>/rest/v1.2/users/&#123;username&#125;/concurrency</code></summary>
 <p/>

--- a/docs/dev/api/accounts.md
+++ b/docs/dev/api/accounts.md
@@ -1484,7 +1484,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 </tbody>
 </table>
 
-```jsx title="Sample Failed Response"
+```jsx title="Sample Response"
 {
     "id": "e5be7513ba224f6f9463c209cb4c5d83",
     "username": "jsmith",
@@ -1505,6 +1505,120 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 </details>
 
 ---
+
+### Get a User's Concurrency
+
+<details><summary><span className="get">GET</span> <code>/rest/v1.2/users/&#123;username&#125;/concurrency</code></summary>
+<p/>
+
+Allows you to update individual user values without replacing the entire profile.
+
+#### Parameters
+
+<table id="table-api">
+  <tbody>
+    <tr>
+     <td><code>username</code></td>
+     <td><p><small>| PATH | REQUIRED | STRING |</small></p><p>The username of the user whose concurrency you are looking up. You can look up a user's name using a variety of filtering paramters with the <a href="#lookup-users">Lookup Users</a> endpoint.</p></td>
+    </tr>
+  </tbody>
+</table>
+
+<Tabs
+groupId="dc-url"
+defaultValue="us"
+values={[
+{label: 'United States', value: 'us'},
+{label: 'Europe', value: 'eu'},
+]}>
+
+<TabItem value="us">
+
+```jsx title="Sample Request"
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
+--request GET 'https://api.us-west-1.saucelabs.com/rest/v1.2/users/<username>/concurrency' \
+--header 'Content-Type: application/json' \ | json_pp
+```
+
+</TabItem>
+<TabItem value="eu">
+
+```jsx title="Sample Request"
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
+--request GET 'https://api.eu-central-1.saucelabs.com/rest/v1.2/users/<username>/concurrency' \
+--header 'Content-Type: application/json' \ | json_pp
+```
+
+</TabItem>
+</Tabs>
+
+#### Responses
+
+<table id="table-api">
+<tbody>
+  <tr>
+    <td><code>200</code></td>
+    <td colSpan='2'>Success. User updated.</td>
+  </tr>
+</tbody>
+<tbody>
+  <tr>
+    <td><code>401</code></td>
+    <td colSpan='2'>Unauthorized.</td>
+  </tr>
+</tbody>
+<tbody>
+  <tr>
+    <td><code>400</code></td>
+    <td colSpan='2'>Bad request.</td>
+  </tr>
+</tbody>
+<tbody>
+  <tr>
+    <td><code>404</code></td>
+    <td colSpan='2'>Not found.</td>
+  </tr>
+</tbody>
+</table>
+
+```jsx title="Sample Response"
+{
+   "concurrency" : {
+      "organization" : {
+         "allowed" : {
+            "mac_vms" : 1000,
+            "rds" : 20,
+            "vms" : 1000
+         },
+         "current" : {
+            "mac_vms" : 0,
+            "rds" : 0,
+            "vms" : 0
+         },
+         "id" : "7fb25570b4064716b9b6daae1a846790"
+      },
+      "team" : {
+         "allowed" : {
+            "mac_vms" : 1000,
+            "rds" : 20,
+            "vms" : 100
+         },
+         "current" : {
+            "mac_vms" : 0,
+            "rds" : 0,
+            "vms" : 0
+         },
+         "id" : "98b9f34e596047d99abba56f517846a9"
+      }
+   },
+   "timestamp" : 1631125800.61984
+}
+
+```
+</details>
+
+---
+
 
 ### Get a User's Team
 


### PR DESCRIPTION
### Description
- [X] Added doc for the classic API endpoint for retrieving a user's concurrency, since it does not have a replacement in the new team-management API.
- [X] Updated the API Overview page to not reference out-dated/private endpoints in the verseioning and rate limit sections.
- [X] Added a link to the concurrency API endpoint doc from the Concurrency doc page.

### Motivation and Context
Customers were looking for the concurrency API doc, which had been removed along with the other classic account API endpoints that were superseded by the team-management APIs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
