### PR TITLE
[TCD-1759] changing json formatter from JQ to json_pp

### DIFF
--- a/docs/dev/api.md
+++ b/docs/dev/api.md
@@ -136,15 +136,8 @@ Requests received after the rate limit is reached return a [429 response code](h
 | All unauthenticated request endpoints | 2 requests per minute ||
 
 
-## JQ Response Formatting
+## JSON Response Formatting
 
-The request samples throughout the API documentation are appended with `| jq` in order to return the response in a more readable format. You can install JQ using NPM or Brew:
+The request samples throughout the API documentation are appended with `| json_pp` as a convenience to return the response in a more readable format that does not require the installation of any additional tools.
 
-```
-npm install jq
-```
-```
-brew install jq
-```
-
-Alternatively, you can remove the `|jq` reference from your requests and the response will be returned as raw JSON.
+You can remove the `|json_pp` reference from your requests to have responses returned as raw JSON, or you can specify a different syntax formatter of your choosing, such as [JQ](https://stedolan.github.io/jq/).

--- a/docs/dev/api/accounts.md
+++ b/docs/dev/api/accounts.md
@@ -47,7 +47,7 @@ values={[
 ```jsx title="cURL with jq Example"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/team-management/v1/teams?name=sauce' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -57,7 +57,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="cURL with jq Example"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/team-management/v1/teams?name=sauce' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -137,7 +137,7 @@ values={[
 ```jsx title="cURL with jq Example"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/team-management/v1/teams/<team-id>' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -147,7 +147,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="cURL with jq Example"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/team-management/v1/teams/<team-id>' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -262,7 +262,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
     },
     "organization": "<org-id>",
     "description": "Docs QA Team"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -279,7 +279,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
     },
     "organization": "<org-id>",
     "description": "Docs QA Team"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -357,7 +357,7 @@ values={[
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request DELETE 'https://api.us-west-1.saucelabs.com/team-management/v1/teams/<team-id>/' \
 --header 'Content-Type: application/json' \
---data-raw '' | jq
+--data-raw '' | json_pp
 ```
 
 </TabItem>
@@ -367,7 +367,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request DELETE 'https://api.eu-central-1.saucelabs.com/team-management/v1/teams/<team-id>/' \
 --header 'Content-Type: application/json' \
---data-raw '' | jq
+--data-raw '' | json_pp
 ```
 
 </TabItem>
@@ -457,7 +457,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
         "virtual_machines": "10"
     },
     "description": "Docs Team"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -473,7 +473,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
         "virtual_machines": "10"
     },
     "description": "Docs Team"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -585,7 +585,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
     "settings": {
         "virtual_machines": "25"
     }
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -600,7 +600,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
     "settings": {
         "virtual_machines": "25"
     }
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -684,7 +684,7 @@ values={[
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/team-management/v1/teams/<team-id>/members' \
 --header 'Content-Type: application/json' \
---data-raw '' | jq
+--data-raw '' | json_pp
 ```
 
 </TabItem>
@@ -694,7 +694,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/team-management/v1/teams/<team-id>/members' \
 --header 'Content-Type: application/json' \
---data-raw '' | jq
+--data-raw '' | json_pp
 ```
 
 </TabItem>
@@ -764,7 +764,7 @@ values={[
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.us-west-1.saucelabs.com/team-management/v1/teams/<team-id>/reset-access-key' \
 --header 'Content-Type: application/json' \
---data-raw '' | jq
+--data-raw '' | json_pp
 ```
 
 </TabItem>
@@ -774,7 +774,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.eu-central-1.saucelabs.com/team-management/v1/teams/<team-id>/reset-access-key' \
 --header 'Content-Type: application/json' \
---data-raw '' | jq
+--data-raw '' | json_pp
 ```
 
 </TabItem>
@@ -892,7 +892,7 @@ values={[
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/team-management/v1/users?roles=3&limit=30' \
 --header 'Content-Type: application/json' \
---data-raw '' | jq
+--data-raw '' | json_pp
 ```
 
 </TabItem>
@@ -902,7 +902,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/team-management/v1/users?roles=3&limit=30' \
 --header 'Content-Type: application/json' \
---data-raw '' | jq
+--data-raw '' | json_pp
 ```
 
 </TabItem>
@@ -977,7 +977,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/team-management/v1/users/<user-id>' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -986,7 +986,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/team-management/v1/users/<user-id>' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -1130,7 +1130,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
     "password": "$m1th*RULES",
     "role": 4,
     "team": "<team-id>"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -1148,7 +1148,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
     "password": "$m1th*RULES",
     "role": 4,
     "team": "<team-id>"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -1302,7 +1302,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
     "email": "jsmith@icloud.com",
     "password": "$m1th*RULEStheworld",
     "verify_password": "$m1th*RULEStheworld"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -1318,7 +1318,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
     "email": "jsmith@icloud.com",
     "password": "$m1th*RULEStheworld",
     "verify_password": "$m1th*RULEStheworld"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -1437,7 +1437,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "first_name": "Jimmy"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -1449,7 +1449,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "first_name": "Jimmy"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -1655,7 +1655,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/team-management/v1/users/<user-id>/teams/' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -1664,7 +1664,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/team-management/v1/users/<user-id>/teams/' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -1752,7 +1752,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --data-raw '{
     "user": "<user-id>",
     "team": "<team-id>"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -1765,7 +1765,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --data-raw '{
     "user": "<user-id>",
     "team": "<team-id>"
-}' | jq
+}' | json_pp
 ```
 
 </TabItem>
@@ -1877,7 +1877,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.us-west-1.saucelabs.com/team-management/v1/users/<user-id>/set-admin/' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -1886,7 +1886,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.eu-central-1.saucelabs.com/team-management/v1/users/<user-id>/set-admin/' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -1971,7 +1971,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.us-west-1.saucelabs.com/team-management/v1/users/<user-id>/set-team-admin/' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -1980,7 +1980,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.eu-central-1.saucelabs.com/team-management/v1/users/<user-id>/set-team-admin/' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -2066,7 +2066,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.us-west-1.saucelabs.com/team-management/v1/users/<user-id>/set-team-admin/' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -2075,7 +2075,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.eu-central-1.saucelabs.com/team-management/v1/users/<user-id>/set-team-admin/' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -2161,7 +2161,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/team-management/v1/users/<user-id>/access-key' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -2170,7 +2170,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/team-management/v1/users/<user-id>/access-key' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -2240,7 +2240,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.us-west-1.saucelabs.com/team-management/v1/users/<user-id>/reset-access-key' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -2249,7 +2249,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.eu-central-1.saucelabs.com/team-management/v1/users/<user-id>/reset-access-key' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -2314,7 +2314,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.us-west-1.saucelabs.com/team-management/v1/users/<user-id>/deactivate' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -2323,7 +2323,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.eu-central-1.saucelabs.com/team-management/v1/users/<user-id>/deactivate' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -2410,7 +2410,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.us-west-1.saucelabs.com/team-management/v1/users/<user-id>/activate' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -2419,7 +2419,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.eu-central-1.saucelabs.com/team-management/v1/users/<user-id>/activate' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>

--- a/docs/dev/api/connect.md
+++ b/docs/dev/api/connect.md
@@ -50,7 +50,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/rest/v1/jim.smith/tunnels' \
---header 'Content-Type: application/json' \
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -59,7 +59,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/jim.smith/tunnels' \
---header 'Content-Type: application/json' \
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -128,7 +128,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8' \
---header 'Content-Type: application/json' \
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -137,7 +137,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8' \
---header 'Content-Type: application/json' \
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -229,7 +229,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://apip.us-west-1.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8/num_jobs' \
---header 'Content-Type: application/json' \
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -238,7 +238,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://apip.eu-central-1.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8/num_jobs' \
---header 'Content-Type: application/json' \
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -309,7 +309,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request DELETE 'https://api.us-west-1.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8' \
---header 'Content-Type: application/json' \
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -318,7 +318,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request DELETE 'https://api.eu-central-1.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8' \
---header 'Content-Type: application/json' \
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>

--- a/docs/dev/api/insights.md
+++ b/docs/dev/api/insights.md
@@ -130,7 +130,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET "https://api.us-west-1.saucelabs.com/v1/analytics/tests?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&size=10&from=10&build=build-123"
+--request GET "https://api.us-west-1.saucelabs.com/v1/analytics/tests?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&size=10&from=10&build=build-123" | json_pp
 ```
 
 </TabItem>
@@ -138,7 +138,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET "https://api.eu-central-1.saucelabs.com/v1/analytics/tests?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&size=10&from=10&build=build-123"
+--request GET "https://api.eu-central-1.saucelabs.com/v1/analytics/tests?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&size=10&from=10&build=build-123" | json_pp
 ```
 
 </TabItem>
@@ -290,7 +290,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET "https://api.us-west-1.saucelabs.com/v1/analytics/insights/test-metrics?start=1515687172&end=1516291972&query=AnalyticsSeleniumTest%20on%20OS%20X%2010.10"
+--request GET "https://api.us-west-1.saucelabs.com/v1/analytics/insights/test-metrics?start=1515687172&end=1516291972&query=AnalyticsSeleniumTest%20on%20OS%20X%2010.10" | json_pp
 ```
 
 </TabItem>
@@ -298,7 +298,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET "https://api.eu-central-1.saucelabs.com/v1/analytics/insights/test-metrics?start=1515687172&end=1516291972&query=AnalyticsSeleniumTest%20on%20OS%20X%2010.10"
+--request GET "https://api.eu-central-1.saucelabs.com/v1/analytics/insights/test-metrics?start=1515687172&end=1516291972&query=AnalyticsSeleniumTest%20on%20OS%20X%2010.10" | json_pp
 ```
 
 </TabItem>
@@ -477,7 +477,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET "https://api.us-west-1.saucelabs.com/v1/analytics/trends/tests?interval=1h&start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&os=Linux"
+--request GET "https://api.us-west-1.saucelabs.com/v1/analytics/trends/tests?interval=1h&start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&os=Linux" | json_pp
 ```
 
 </TabItem>
@@ -485,7 +485,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET "https://api.eu-central-1.saucelabs.com/v1/analytics/trends/tests?interval=1h&start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&os=Linux"
+--request GET "https://api.eu-central-1.saucelabs.com/v1/analytics/trends/tests?interval=1h&start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&os=Linux" | json_pp
 ```
 
 </TabItem>
@@ -675,7 +675,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET "https://api.us-west-1.saucelabs.com/v1/analytics/trends/builds_tests?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z"
+--request GET "https://api.us-west-1.saucelabs.com/v1/analytics/trends/builds_tests?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z" |json_pp
 ```
 
 </TabItem>
@@ -683,7 +683,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET "https://api.eu-central-1.saucelabs.com/v1/analytics/trends/builds_tests?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z"
+--request GET "https://api.eu-central-1.saucelabs.com/v1/analytics/trends/builds_tests?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z" | json_pp
 ```
 
 </TabItem>
@@ -860,7 +860,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET "https://api.us-west-1.saucelabs.com/v1/analytics/trends/errors?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&scope=organization"
+--request GET "https://api.us-west-1.saucelabs.com/v1/analytics/trends/errors?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&scope=organization" | json_pp
 ```
 
 </TabItem>
@@ -868,7 +868,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET "https://api.eu-central-1.saucelabs.com/v1/analytics/trends/errors?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&scope=organization"
+--request GET "https://api.eu-central-1.saucelabs.com/v1/analytics/trends/errors?start=2021-05-01T12:00:00Z&end=2021-05-02T12:00:00Z&scope=organization" | json_pp
 ```
 
 </TabItem>

--- a/docs/dev/api/jobs.md
+++ b/docs/dev/api/jobs.md
@@ -87,7 +87,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/rest/v1/jsmith/jobs?from=1616262316&to=1618940716' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/rest/v1/jsmith/jobs?from=1616262316&to=1618940716' | json_pp
 ```
 
 </TabItem>
@@ -96,7 +96,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/jsmith/jobs?from=1616262316&to=1618940716' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/jsmith/jobs?from=1616262316&to=1618940716' | json_pp
 ```
 
 </TabItem>
@@ -192,7 +192,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/rest/v1/jsmith/jobs/eed5eb4999d840f89f67f8b6d60a2da3' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/rest/v1/jsmith/jobs/eed5eb4999d840f89f67f8b6d60a2da3' | json_pp
 ```
 
 </TabItem>
@@ -201,7 +201,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/jsmith/jobs/eed5eb4999d840f89f67f8b6d60a2da3' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/jsmith/jobs/eed5eb4999d840f89f67f8b6d60a2da3' | json_pp
 ```
 
 </TabItem>
@@ -494,7 +494,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request PUT 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/ec92ec2e200d40b8a75a4f6c06e2226f/stop' | jq
+--request PUT 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/ec92ec2e200d40b8a75a4f6c06e2226f/stop' | json_pp
 ```
 
 </TabItem>
@@ -503,7 +503,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request PUT 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/ec92ec2e200d40b8a75a4f6c06e2226f/stop' | jq
+--request PUT 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/ec92ec2e200d40b8a75a4f6c06e2226f/stop' | json_pp
 ```
 
 </TabItem>
@@ -591,7 +591,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.us-west-1.saucelabs.com/rest/v1.1/jobs/a521fd8a78c4426fb10ab765ab1f6831' | jq
+--request DELETE 'https://api.us-west-1.saucelabs.com/rest/v1.1/jobs/a521fd8a78c4426fb10ab765ab1f6831' | json_pp
 ```
 
 </TabItem>
@@ -600,7 +600,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.eu-central-1.saucelabs.com/rest/v1.1/jobs/a521fd8a78c4426fb10ab765ab1f6831' | jq
+--request DELETE 'https://api.eu-central-1.saucelabs.com/rest/v1.1/jobs/a521fd8a78c4426fb10ab765ab1f6831' | json_pp
 ```
 
 </TabItem>
@@ -659,7 +659,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.us-west-1.saucelabs.com/rest/v1.1/nancy.sweeney/jobs' | jq
+--request DELETE 'https://api.us-west-1.saucelabs.com/rest/v1.1/nancy.sweeney/jobs' | json_pp
 ```
 
 </TabItem>
@@ -668,7 +668,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.us-west-1.saucelabs.com/rest/v1.1/nancy.sweeney/jobs' | jq
+--request DELETE 'https://api.us-west-1.saucelabs.com/rest/v1.1/nancy.sweeney/jobs' | json_pp
 ```
 
 </TabItem>
@@ -733,7 +733,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets' | json_pp
 ```
 
 </TabItem>
@@ -742,7 +742,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets' | json_pp
 ```
 
 </TabItem>
@@ -827,7 +827,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets/performance.json' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets/performance.json' | json_pp
 ```
 
 </TabItem>
@@ -836,7 +836,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets/performance.json' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets/performance.json' | json_pp
 ```
 
 </TabItem>
@@ -1055,7 +1055,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets' | jq
+--request DELETE 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets' | json_pp
 ```
 
 </TabItem>
@@ -1064,7 +1064,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.eu-central-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets' | jq
+--request DELETE 'https://api.eu-central-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets' | json_pp
 ```
 
 </TabItem>
@@ -1178,7 +1178,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/rest/v1/jsmith/builds' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/rest/v1/jsmith/builds' | json_pp
 ```
 
 </TabItem>
@@ -1187,7 +1187,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/jsmith/builds' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/jsmith/builds' | json_pp
 ```
 
 </TabItem>

--- a/docs/dev/api/performance.md
+++ b/docs/dev/api/performance.md
@@ -60,14 +60,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/?metric_names=speedIndex' | jq
+curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/?metric_names=speedIndex' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/?metric_names=speedIndex' | jq
+curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/?metric_names=speedIndex' | json_pp
 ```
 
 </TabItem>
@@ -167,14 +167,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/f62eaf7d63c9449eb0424cf7678bf6a9/' | jq
+curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/f62eaf7d63c9449eb0424cf7678bf6a9/' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/f62eaf7d63c9449eb0424cf7678bf6a9/' | jq
+curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/f62eaf7d63c9449eb0424cf7678bf6a9/' | json_pp
 ```
 
 </TabItem>
@@ -312,14 +312,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/assert/?metric_names=speedIndex&order_index=1' | jq
+curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/assert/?metric_names=speedIndex&order_index=1' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/assert/?metric_names=speedIndex&order_index=1' | jq
+curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/assert/?metric_names=speedIndex&order_index=1' | json_pp
 ```
 
 </TabItem>
@@ -422,14 +422,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/?metric_names=speedIndex&order_index=0' | jq
+curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/?metric_names=speedIndex&order_index=0' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/?metric_names=speedIndex&order_index=0' | jq
+curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/?metric_names=speedIndex&order_index=0' | json_pp
 ```
 
 </TabItem>
@@ -517,14 +517,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/reset/' | jq
+curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/reset/' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/reset' | jq
+curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/reset' | json_pp
 ```
 
 </TabItem>
@@ -585,14 +585,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request POST 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/reset/' | jq
+curl --location --request POST 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/reset/' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request POST 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/reset' | jq
+curl --location --request POST 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/baseline/reset' | json_pp
 ```
 
 </TabItem>
@@ -658,14 +658,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/discarded/?order_index=0' | jq
+curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/discarded/?order_index=0' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/discarded/?order_index=0' | jq
+curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/discarded/?order_index=0' | json_pp
 ```
 
 </TabItem>
@@ -738,14 +738,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request POST 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/discarded/?order_index=0' | jq
+curl --location --request POST 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/discarded/?order_index=0' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request POST 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/discarded/?order_index=0' | jq
+curl --location --request POST 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/discarded/?order_index=0' | json_pp
 ```
 
 </TabItem>
@@ -823,14 +823,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request POST 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/history/?order_index=0' | jq
+curl --location --request POST 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/history/?order_index=0' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request POST 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/discarded/?order_index=0' | jq
+curl --location --request POST 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/0308500535c24468a977b250da266b18/discarded/?order_index=0' | json_pp
 ```
 
 </TabItem>
@@ -992,14 +992,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/b6bee25245724ddca6b852a7ec49f155/regimes/?order_index=0&metric_names=speedIndex,domContentLoaded,lastVisualChange' | jq
+curl --location --request GET 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/b6bee25245724ddca6b852a7ec49f155/regimes/?order_index=0&metric_names=speedIndex,domContentLoaded,lastVisualChange' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/b6bee25245724ddca6b852a7ec49f155/regimes/?order_index=0&metric_names=speedIndex,domContentLoaded,lastVisualChange' | jq
+curl --location --request GET 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/b6bee25245724ddca6b852a7ec49f155/regimes/?order_index=0&metric_names=speedIndex,domContentLoaded,lastVisualChange' | json_pp
 ```
 
 </TabItem>
@@ -1095,14 +1095,14 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl --location --request POST 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/b6bee25245724ddca6b852a7ec49f155/regimes/acknowledge/?order_index=0' | jq
+curl --location --request POST 'https://api.us-west-1.saucelabs.com/v2/performance/metrics/b6bee25245724ddca6b852a7ec49f155/regimes/acknowledge/?order_index=0' | json_pp
 ```
 
 </TabItem>
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl --location --request POST 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/b6bee25245724ddca6b852a7ec49f155/regimes/acknowledge/?order_index=0' | jq
+curl --location --request POST 'https://api.eu-central-1.saucelabs.com/v2/performance/metrics/b6bee25245724ddca6b852a7ec49f155/regimes/acknowledge/?order_index=0' | json_pp
 ```
 
 </TabItem>

--- a/docs/dev/api/platform.md
+++ b/docs/dev/api/platform.md
@@ -37,7 +37,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/rest/v1/info/status' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -46,7 +46,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/info/status' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -116,7 +116,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/rest/v1/info/platforms/all' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 --data-raw ''
 ```
 
@@ -126,7 +126,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/info/platforms/all' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 --data-raw ''
 ```
 
@@ -235,7 +235,7 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.us-west-1.saucelabs.com/rest/v1/info/platforms/appium/eol' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>
@@ -244,7 +244,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/info/platforms/appium/eol' \
---header 'Content-Type: application/json' | jq
+--header 'Content-Type: application/json' | json_pp
 ```
 
 </TabItem>

--- a/docs/dev/api/rdc.md
+++ b/docs/dev/api/rdc.md
@@ -35,7 +35,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/v1/rdc/devices' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/v1/rdc/devices' | json_pp
 ```
 
 </TabItem>
@@ -44,7 +44,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/v1/rdc/devices' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/v1/rdc/devices' | json_pp
 ```
 
 </TabItem>
@@ -147,7 +147,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/v1/rdc/devices/iPad_Pro_11_14_2018_real' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/v1/rdc/devices/iPad_Pro_11_14_2018_real' | json_pp
 ```
 
 </TabItem>
@@ -156,7 +156,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/v1/rdc/devices/iPad_Pro_11_14_2018_real' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/v1/rdc/devices/iPad_Pro_11_14_2018_real' | json_pp
 ```
 
 </TabItem>
@@ -249,7 +249,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/v1/rdc/devices/available' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/v1/rdc/devices/available' | json_pp
 ```
 
 </TabItem>
@@ -258,7 +258,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/v1/rdc/devicesavailable' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/v1/rdc/devicesavailable' | json_pp
 ```
 
 </TabItem>
@@ -354,7 +354,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/v1/rdc/jobs?limit=5' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/v1/rdc/jobs?limit=5' | json_pp
 ```
 
 </TabItem>
@@ -363,7 +363,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/v1/rdc/jobs?limit=5' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/v1/rdc/jobs?limit=5' | json_pp
 ```
 
 </TabItem>
@@ -451,7 +451,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/v1/rdc/jobs/293d84fb2f634ff29a750c3f8eaee592' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/v1/rdc/jobs/293d84fb2f634ff29a750c3f8eaee592' | json_pp
 ```
 
 </TabItem>
@@ -460,7 +460,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/v1/rdc/jobs/48c6d12f9ef944439453b5abc6715b54' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/v1/rdc/jobs/48c6d12f9ef944439453b5abc6715b54' | json_pp
 ```
 
 </TabItem>

--- a/docs/dev/api/storage.md
+++ b/docs/dev/api/storage.md
@@ -79,7 +79,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/v1/storage/files' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/v1/storage/files' | json_pp
 ```
 
 </TabItem>
@@ -87,7 +87,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/v1/storage/files' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/v1/storage/files' | json_pp
 ```
 
 </TabItem>
@@ -210,7 +210,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-west-1.saucelabs.com/v1/storage/groups' | jq
+--request GET 'https://api.us-west-1.saucelabs.com/v1/storage/groups' | json_pp
 ```
 
 </TabItem>
@@ -218,7 +218,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.eu-central-1.saucelabs.com/v1/storage/groups' | jq
+--request GET 'https://api.eu-central-1.saucelabs.com/v1/storage/groups' | json_pp
 ```
 
 </TabItem>
@@ -645,7 +645,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.us-west-1.saucelabs.com/v1/storage/files/43732d5b-5275-4a79-a936-197e4b9cd2d4' | jq
+--request DELETE 'https://api.us-west-1.saucelabs.com/v1/storage/files/43732d5b-5275-4a79-a936-197e4b9cd2d4' | json_pp
 ```
 
 </TabItem>
@@ -653,7 +653,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.eu-central-1.saucelabs.com/v1/storage/files/43732d5b-5275-4a79-a936-197e4b9cd2d4' | jq
+--request DELETE 'https://api.eu-central-1.saucelabs.com/v1/storage/files/43732d5b-5275-4a79-a936-197e4b9cd2d4' | json_pp
 ```
 
 </TabItem>
@@ -743,7 +743,7 @@ values={[
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.us-west-1.saucelabs.com/v1/storage/groups/64612' | jq
+--request DELETE 'https://api.us-west-1.saucelabs.com/v1/storage/groups/64612' | json_pp
 ```
 
 </TabItem>
@@ -751,7 +751,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.eu-central-1.saucelabs.com/v1/storage/groups/64612' | jq
+--request DELETE 'https://api.eu-central-1.saucelabs.com/v1/storage/groups/64612' | json_pp
 ```
 
 </TabItem>


### PR DESCRIPTION
### Description
Updated all API sample requests to use `json_pp` instead of `jq` and updated the related section in the API Overview page.

### Motivation and Context
Some customers have complained that all the API samples include the JQ parser, which causes a copy/paste example to fail if the user does not have JQ installed. Aleks suggested the json_pp alternative, which does not require installation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
