### PR TITLE
[TCD-1919] delete broken Jenkins doc link

### DIFF
--- a/docs/ci/jenkins.md
+++ b/docs/ci/jenkins.md
@@ -26,7 +26,7 @@ The OnDemand plugin allows you to easily manage your Sauce Labs testing from [Je
     - IP range `162.222.72.0/21`
     - `saucelabs.com`
     - `ondemand.saucelabs.com`
-* [Jenkins documentation for setting up a Proxy](https://wiki.jenkins-ci.org/display/JENKINS/JenkinsBehindProxy)
+
 
 ## Installing the OnDemand Plugin
 


### PR DESCRIPTION
### Description
Deleted a link to the Jenkins doc for proxy configuration that does not exist anymore and was producing a 404.

### Motivation and Context
Jenkins has updated their doc off of Confluence and there does not appear to be a replacement page for this doc.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
