### PR TITLE
[DEVX-1241] Add notPackage documentation

### DIFF
--- a/docs/mobile-apps/automated-testing/espresso-xcuitest.md
+++ b/docs/mobile-apps/automated-testing/espresso-xcuitest.md
@@ -132,7 +132,7 @@ Real Device testing on Sauce Labs is data center contingent, so you will only ha
 | Specify an alternative path and file to use as the configuration file. | `config --path` | `--config` |
 | Set environment variable values on which other settings depend (such as proxy host/port values). | Not supported | `--env` |
 | Simulate a test without actually executing. | Not supported | `--dry-run` |
-| Return additional output for troubleshooting purposes. | ``--verbose` | `--verbose` |
+| Return additional output for troubleshooting purposes. | `--verbose` | `--verbose` |
 | Provide tags for use in filtering jobs in the Sauce Labs UI in ways that are meaningful for your org, such as release numbers or dev teams. | Not supported | `--tags <tag1,tag2...>` (Espresso RDC Only)|
 | Associate the job with a build ID for grouping jobs in the Sauce Labs UI. | Not supported | `--build` (Espresso RDC Only)|
 | Specify the circumstances under which to download test artifacts. | Not supported | Must use YAML |

--- a/docs/mobile-apps/automated-testing/espresso-xcuitest.md
+++ b/docs/mobile-apps/automated-testing/espresso-xcuitest.md
@@ -117,6 +117,7 @@ Real Device testing on Sauce Labs is data center contingent, so you will only ha
 | Exclude certain classes from the test. | `--e -e= class name.of.class1,name.of.class2`  | Must use YAML |
 | Run only tests matching the specified size. | `--e -i=size size` | Must use YAML |
 | Specify which package to run. | `--e package` | Must use YAML |
+| Exclude tests in the specified package. | `--e notPackage` | Must use YAML |
 | Run only tests matching the specified annotation.  | `--e -i=annotation com.my.annotation` | Must use YAML |
 | Exclude tests matching the specified annotation.  | `--e -i=notAnnotation com.my.annotation` | Must use YAML |
 | Further specify Espresso test options using supported key-value pairs. | `--e` | Not supported |
@@ -131,7 +132,7 @@ Real Device testing on Sauce Labs is data center contingent, so you will only ha
 | Specify an alternative path and file to use as the configuration file. | `config --path` | `--config` |
 | Set environment variable values on which other settings depend (such as proxy host/port values). | Not supported | `--env` |
 | Simulate a test without actually executing. | Not supported | `--dry-run` |
-| Return additional output for troubleshooting purposes. | --verbose | `--verbose` |
+| Return additional output for troubleshooting purposes. | ``--verbose` | `--verbose` |
 | Provide tags for use in filtering jobs in the Sauce Labs UI in ways that are meaningful for your org, such as release numbers or dev teams. | Not supported | `--tags <tag1,tag2...>` (Espresso RDC Only)|
 | Associate the job with a build ID for grouping jobs in the Sauce Labs UI. | Not supported | `--build` (Espresso RDC Only)|
 | Specify the circumstances under which to download test artifacts. | Not supported | Must use YAML |
@@ -151,21 +152,22 @@ Real Device testing on Sauce Labs is data center contingent, so you will only ha
 | Provide a name for the test. | `testname:` | `suites[].name:` |
 | Specify a virtual machine emulator. (Espresso Only) | `-d` (one value)<br/> `--devices[]` | `suites[].emulators[]:` |
 | Specify the emulator(s) to run the test on. (Espresso Only) | `deviceName=name` | `suites[].emulators[].name:` |
-| Specify the test orientation for the emulator. (Espresso Only) | `orientation=portrait|landscape` | `suites[].emulators[].orientation:` |
+| Specify the test orientation for the emulator. (Espresso Only) | `orientation=portrait\|landscape` | `suites[].emulators[].orientation:` |
 | Specify the emulator platform versions to apply. (Espresso Only) | `platformVersion=version#` | `suites[].emulators[].platformVersions[]:` |
 | Specify a real device to run the test on. | `device:` | `suites[].devices[].id:` |
 | Indicate real device selection to be dynamic. | `devices:` | `suites[].devices[]:` |
 | Choose a real device running a particular platform version. | `devices.platformVersion:` | `suites[].devices[].platformVersion:` |
 | Choose real devices from a private pool only. | `privateDevicesOnly:` | `suites[].devices[].options.private:` |
 | Choose a phone real device only. | `phoneOnly:` | `suites[].devices.options.deviceType: PHONE` |
-| Choose a tablet real device only. | tabletOnly: | `suites[].devices[].options.deviceType: TABLET` |
+| Choose a tablet real device only. | `tabletOnly:` | `suites[].devices[].options.deviceType: TABLET` |
 | Ensure the real device is connected to a cellular network. | Not supported | `suites[].devices[].options.carrierConnectivity` |
 | Choose any real device where the name matches the regex. | `devices.deviceNameQuery:` | `suites[].devices[].name:` |
 | Specify which test class to run. | `testsToRun.testClass:` | `suites[].testOptions.class:` |
 | Specify which methods to run. | `testsToRun.testMethod:` | `suites[].testOptions.class: class/Method` (XCUITest Only) |
 | Exclude certain classes from the test. | Must use CLI | `suites[].testOptions.notClass:` (Espresso Only) |
 | Run only tests matching the specified size. | Must use CLI | `suites[].testOptions.size:` (Espresso Only) |
-| Specify which package to run. | Not supported | `suites[].testOptions.package:`  (Espresso Only) |
+| Specify which package to run. | Must use CLI | `suites[].testOptions.package:`  (Espresso Only) |
+| Exclude tests in the specified package. | Must use CLI | `suites[].testOptions.notPackage:`  (Espresso Only) |
 | Run only tests matching the specified annotation.  | Must use CLI | `suites[].testOptions.annotation:`  (Espresso Only) |
 | Exclude tests matching the specified annotation.  | Must use CLI | `suites[].testOptions.notAnnotation:`  (Espresso Only) |
 | Break the test into separate shards. | Not supported | `suites[].testOptions.numShards:`  (Espresso Only) |

--- a/docs/testrunner-toolkit/configuration/espresso.md
+++ b/docs/testrunner-toolkit/configuration/espresso.md
@@ -575,7 +575,7 @@ Instructs `saucectl` to run only tests in the specified package.
 ---
 
 #### `notPackage`
-<p><small>| OPTIONAL | STRING |</small></p>
+<p><small>| OPTIONAL | STRING | REAL DEVICES ONLY |</small></p>
 
 Instructs `saucectl` to run run all tests *except* those in the specified package.
 

--- a/docs/testrunner-toolkit/configuration/espresso.md
+++ b/docs/testrunner-toolkit/configuration/espresso.md
@@ -523,7 +523,7 @@ suites:
       - com.example.android.testing.androidjunitrunnersample.CalculatorInstrumentationTest
     size: small
     package: com.example.android.testing.androidjunitrunnersample
-    notPakacge: com.example.android.testing.androidMyDemoTests
+    notPackage: com.example.android.testing.androidMyDemoTests
     annotation: com.android.buzz.MyAnnotation
     notAnnotation: com.android.buzz.NotMyAnnotation
     numShards: 4

--- a/docs/testrunner-toolkit/configuration/espresso.md
+++ b/docs/testrunner-toolkit/configuration/espresso.md
@@ -515,18 +515,20 @@ Request that the matching device is from your organization's private pool.
 A set of parameters allowing you to provide additional details about which test class should be run for the suite and how to apply them.
 
 ```yaml
-testOptions:
-  class:
-    - com.example.android.testing.androidjunitrunnersample.CalculatorAddParameterizedTest
-  notClass:
-    - com.example.android.testing.androidjunitrunnersample.CalculatorInstrumentationTest
-  size: small
-  package: com.example.android.testing.androidjunitrunnersample
-  annotation: com.android.buzz.MyAnnotation
-  notAnnotation: com.android.buzz.NotMyAnnotation
-  numShards: 4
-  clearPackageData: true
-  useTestOrchestrator: true
+suites:
+  testOptions:
+    class:
+      - com.example.android.testing.androidjunitrunnersample.CalculatorAddParameterizedTest
+    notClass:
+      - com.example.android.testing.androidjunitrunnersample.CalculatorInstrumentationTest
+    size: small
+    package: com.example.android.testing.androidjunitrunnersample
+    notPakacge: com.example.android.testing.androidMyDemoTests
+    annotation: com.android.buzz.MyAnnotation
+    notAnnotation: com.android.buzz.NotMyAnnotation
+    numShards: 4
+    clearPackageData: true
+    useTestOrchestrator: true
 ```
 ---
 
@@ -569,6 +571,16 @@ Instructs `saucectl` to run only tests in the specified package.
 
 ```yaml
   package: com.example.android.testing.androidjunitrunnersample
+```
+---
+
+#### `notPackage`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Instructs `saucectl` to run run all tests *except* those in the specified package.
+
+```yaml
+  notPackage: com.example.android.testing.androidMyDemoTests
 ```
 ---
 


### PR DESCRIPTION
### Description
Updated Espresso docs to include new support of `notPackage` test option.

### Motivation and Context
Document feature in DEVX-1241.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
