### PR TITLE
[DEVX-1243] Update tunnel properties to name and owner

### DIFF
--- a/docs/dev/cli/sauce-connect-proxy.md
+++ b/docs/dev/cli/sauce-connect-proxy.md
@@ -72,7 +72,7 @@ __Shorthand__: `-x`
 
 ---
 ### `--shared-tunnel`
-__Description__: Allows other users of the tunnel owner to use the tunnel. For more information, see [Sharing Sauce Connect Proxy Tunnels](/basics/acct-team-mgmt/sauce-connect-proxy-tunnels).<br/>
+__Description__: Allows users other than the tunnel owner to use the tunnel. For more information, see [Sharing Sauce Connect Proxy Tunnels](/basics/acct-team-mgmt/sauce-connect-proxy-tunnels).<br/>
 __Shorthand__: `-s`
 
 

--- a/docs/mobile-apps/automated-testing/espresso-xcuitest.md
+++ b/docs/mobile-apps/automated-testing/espresso-xcuitest.md
@@ -121,7 +121,8 @@ Real Device testing on Sauce Labs is data center contingent, so you will only ha
 | Run only tests matching the specified annotation.  | `--e -i=annotation com.my.annotation` | Must use YAML |
 | Exclude tests matching the specified annotation.  | `--e -i=notAnnotation com.my.annotation` | Must use YAML |
 | Further specify Espresso test options using supported key-value pairs. | `--e` | Not supported |
-| Identify a running Sauce Connect tunnel to use for secure connectivity to the cloud. | `--tunnelIdentifier` | `--tunnel-id` |
+| Identify a running Sauce Connect tunnel to use for secure connectivity to the cloud. | `--tunnelIdentifier` | `--tunnel-name` <br/><small>`--tunnel-id`  <span className="sauceGold">DEPRECATED</span></small> |
+| Identify the user who created the tunnel, if it differs from the user running the test. | Not supported | `--tunnel-owner` <br/><small>`--tunnel-parent` <span className="sauceGold">DEPRECATED</span></small> |
 | Specify how often (seconds) the runner should check for test results. | `--checkFrequency` | Not supported |
 | Specify the maximum length of time (minutes) the test can run. | `--timeout` | `--timeout` |
 | Specify a folder to direct the JUnit XML output. | `--xmlFolder` | Not supported |
@@ -171,7 +172,8 @@ Real Device testing on Sauce Labs is data center contingent, so you will only ha
 | Run only tests matching the specified annotation.  | Must use CLI | `suites[].testOptions.annotation:`  (Espresso Only) |
 | Exclude tests matching the specified annotation.  | Must use CLI | `suites[].testOptions.notAnnotation:`  (Espresso Only) |
 | Break the test into separate shards. | Not supported | `suites[].testOptions.numShards:`  (Espresso Only) |
-| Identify a running Sauce Connect tunnel to use for secure connectivity to the cloud. | `tunnelIdentifier:` | `sauce.tunnel.id:` |
+| Identify a running Sauce Connect tunnel to use for secure connectivity to the cloud. | `tunnelIdentifier:` | `sauce.tunnel.name:`<br/><small>`id`  <span className="sauceGold">DEPRECATED</span></small>  |
+| Identify the user who created the tunnel, if it differs from the user running the test. | Not supported | `sauce.tunnel.owner` <br/><small>`parent` <span className="sauceGold">DEPRECATED</span></small> |
 | Specify how often (seconds) the runner should check for test results. | `checkFrequency:` | Not supported |
 | Specify the maximum length of time (minutes) the test can run. | `timeout:` | Must use CLI |
 | Specify a folder to direct the JUnit XML output. | `xmlFolder:` | Not supported |

--- a/docs/testrunner-toolkit/configuration/common-syntax.md
+++ b/docs/testrunner-toolkit/configuration/common-syntax.md
@@ -140,24 +140,48 @@ saucectl run --ccy 5
 ---
 
 ### `tunnel`
-<p><small>| OPTIONAL | OBJECT |  <span class="highlight sauce-cloud">Sauce Cloud only</span> |</small></p>
+<p><small>| OPTIONAL | OBJECT |</small></p>
 
-`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection when running your tests on Sauce Labs. To do so, launch a tunnel; then provide the identifier in this property.
+`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection with Sauce Labs. To do so, launch a tunnel; then provide the name and owner (if applicable) in this property.
 
-:::note Choose the Correct Tunnel Identifier
-When you launch a tunnel, you can accept the tunnel identifier name that Sauce Labs generates for your account (e.g., `{SL-username}_tunnel_id`) or specify a name in the launch command:
-
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
-bin/sc -u {SL-username} -k {SL-access_key} -i {tunnel_identifier}
-```
+---
 
-This is the identifier `saucectl` expects as the `id` property, even though the Sauce Labs UI refers to this values as the `Tunnel Name`.
+#### `name`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies an active Sauce Connect tunnel to use for secure connectivity to the Sauce Labs cloud.
+
+:::note
+This property replaces the former `id` property, which is deprecated.
 :::
 
 ```yaml
- tunnel:
-    id: your_tunnel_id
-    parent: parent_owner_of_tunnel # if applicable, specify the owner of the tunnel
+sauce:
+  tunnel:
+    name: your_tunnel_name
+```
+---
+
+#### `owner`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies the Sauce Labs user who created the specified tunnel, which is required if the user running the tests did not create the tunnel.
+
+:::note
+This property replaces the former `parent` property, which is deprecated.
+:::
+
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
 ---
 

--- a/docs/testrunner-toolkit/configuration/cypress.md
+++ b/docs/testrunner-toolkit/configuration/cypress.md
@@ -169,24 +169,48 @@ saucectl run --retries 1
 ---
 
 ### `tunnel`
-<p><small>| OPTIONAL | OBJECT | <span class="highlight sauce-cloud">Sauce Cloud only</span> |</small></p>
+<p><small>| OPTIONAL | OBJECT |</small></p>
 
-`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection when running your tests on Sauce Labs. To do so, launch a tunnel; then provide the identifier in this property.
+`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection with Sauce Labs. To do so, launch a tunnel; then provide the name and owner (if applicable) in this property.
 
-:::note Choose the Correct Tunnel Identifier
-When you launch a tunnel, you can accept the tunnel identifier name that Sauce Labs generates for your account (e.g., `{SL-username}_tunnel_id`) or specify a name in the launch command:
-
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
-bin/sc -u {SL-username} -k {SL-access_key} -i {tunnel_identifier}
-```
+---
 
-This is the identifier `saucectl` expects as the `id` property, even though the Sauce Labs UI refers to this value as the `Tunnel Name`.
+#### `name`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies an active Sauce Connect tunnel to use for secure connectivity to the Sauce Labs cloud.
+
+:::note
+This property replaces the former `id` property, which is deprecated.
 :::
 
 ```yaml
- tunnel:
-    id: your_tunnel_id
-    parent: parent_owner_of_tunnel # if applicable, specify the owner of the tunnel
+sauce:
+  tunnel:
+    name: your_tunnel_name
+```
+---
+
+#### `owner`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies the Sauce Labs user who created the specified tunnel, which is required if the user running the tests did not create the tunnel.
+
+:::note
+This property replaces the former `parent` property, which is deprecated.
+:::
+
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
 ---
 

--- a/docs/testrunner-toolkit/configuration/espresso.md
+++ b/docs/testrunner-toolkit/configuration/espresso.md
@@ -156,22 +156,46 @@ saucectl run --retries 1
 ### `tunnel`
 <p><small>| OPTIONAL | OBJECT |</small></p>
 
-`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection with Sauce Labs. To do so, launch a tunnel; then provide the identifier in this property.
+`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection with Sauce Labs. To do so, launch a tunnel; then provide the name and owner (if applicable) in this property.
 
-:::note Choose the Correct Tunnel Identifier
-When you launch a tunnel, you can accept the tunnel identifier name that Sauce Labs generates for your account (e.g., `{SL-username}_tunnel_id`) or specify a name in the launch command:
-
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
-bin/sc -u {SL-username} -k {SL-access_key} -i {tunnel_identifier}
-```
+---
 
-This is the identifier `saucectl` expects as the `id` property, even though the Sauce Labs UI refers to this values as the `Tunnel Name`.
+#### `name`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies an active Sauce Connect tunnel to use for secure connectivity to the Sauce Labs cloud.
+
+:::note
+This property replaces the former `id` property, which is deprecated.
 :::
 
 ```yaml
- tunnel:
-    id: your_tunnel_id
-    parent: parent_owner_of_tunnel # if applicable, specify the owner of the tunnel
+sauce:
+  tunnel:
+    name: your_tunnel_name
+```
+---
+
+#### `owner`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies the Sauce Labs user who created the specified tunnel, which is required if the user running the tests did not create the tunnel.
+
+:::note
+This property replaces the former `parent` property, which is deprecated.
+:::
+
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
 ---
 

--- a/docs/testrunner-toolkit/configuration/playwright.md
+++ b/docs/testrunner-toolkit/configuration/playwright.md
@@ -168,24 +168,48 @@ saucectl run --retries 1
 ---
 
 ### `tunnel`
-<p><small>| OPTIONAL | OBJECT | <span class="highlight sauce-cloud">Sauce Cloud only</span> |</small></p>
+<p><small>| OPTIONAL | OBJECT |</small></p>
 
-`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection when running your tests on Sauce Labs. To do so, launch a tunnel; then provide the identifier in this property.
+`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection with Sauce Labs. To do so, launch a tunnel; then provide the name and owner (if applicable) in this property.
 
-:::note Choose the Correct Tunnel Identifier
-When you launch a tunnel, you can accept the tunnel identifier name that Sauce Labs generates for your account (e.g., `{SL-username}_tunnel_id`) or specify a name in the launch command:
-
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
-bin/sc -u {SL-username} -k {SL-access_key} -i {tunnel_identifier}
-```
+---
 
-This is the identifier `saucectl` expects as the `id` property, even though the Sauce Labs UI refers to this values as the `Tunnel Name`.
+#### `name`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies an active Sauce Connect tunnel to use for secure connectivity to the Sauce Labs cloud.
+
+:::note
+This property replaces the former `id` property, which is deprecated.
 :::
 
 ```yaml
- tunnel:
-    id: your_tunnel_id
-    parent: parent_owner_of_tunnel # if applicable, specify the owner of the tunnel
+sauce:
+  tunnel:
+    name: your_tunnel_name
+```
+---
+
+#### `owner`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies the Sauce Labs user who created the specified tunnel, which is required if the user running the tests did not create the tunnel.
+
+:::note
+This property replaces the former `parent` property, which is deprecated.
+:::
+
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
 ---
 

--- a/docs/testrunner-toolkit/configuration/testcafe.md
+++ b/docs/testrunner-toolkit/configuration/testcafe.md
@@ -169,24 +169,48 @@ saucectl run --retries 1
 ---
 
 ### `tunnel`
-<p><small>| OPTIONAL | OBJECT | <span class="highlight sauce-cloud">Sauce Cloud only</span> |</small></p>
+<p><small>| OPTIONAL | OBJECT |</small></p>
 
-`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection when running your tests on Sauce Labs. To do so, launch a tunnel; then provide the identifier in this property.
+`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection with Sauce Labs. To do so, launch a tunnel; then provide the name and owner (if applicable) in this property.
 
-:::note Choose the Correct Tunnel Identifier
-When you launch a tunnel, you can accept the tunnel identifier name that Sauce Labs generates for your account (e.g., `{SL-username}_tunnel_id`) or specify a name in the launch command:
-
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
-bin/sc -u {SL-username} -k {SL-access_key} -i {tunnel_identifier}
-```
+---
 
-This is the identifier `saucectl` expects as the `id` property, even though the Sauce Labs UI refers to this values as the `Tunnel Name`.
+#### `name`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies an active Sauce Connect tunnel to use for secure connectivity to the Sauce Labs cloud.
+
+:::note
+This property replaces the former `id` property, which is deprecated.
 :::
 
 ```yaml
- tunnel:
-    id: your_tunnel_id
-    parent: parent_owner_of_tunnel # if applicable, specify the owner of the tunnel
+sauce:
+  tunnel:
+    name: your_tunnel_name
+```
+---
+
+#### `owner`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies the Sauce Labs user who created the specified tunnel, which is required if the user running the tests did not create the tunnel.
+
+:::note
+This property replaces the former `parent` property, which is deprecated.
+:::
+
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
 ---
 

--- a/docs/testrunner-toolkit/configuration/xcuitest.md
+++ b/docs/testrunner-toolkit/configuration/xcuitest.md
@@ -161,21 +161,46 @@ saucectl run --retries 1
 ### `tunnel`
 <p><small>| OPTIONAL | OBJECT |</small></p>
 
-`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection with Sauce Labs. To do so, launch a tunnel; then provide the identifier in this property.
+`saucectl` supports using [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) to establish a secure connection with Sauce Labs. To do so, launch a tunnel; then provide the name and owner (if applicable) in this property.
 
-:::note Choose the Correct Tunnel Identifier
-When you launch a tunnel, you can accept the tunnel identifier name that Sauce Labs generates for your account (e.g., `{SL-username}_tunnel_id`) or specify a name in the launch command:
-
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
-bin/sc -u {SL-username} -k {SL-access_key} -i {tunnel_identifier}
-```
+---
 
-This is the identifier `saucectl` expects as the `id` property, even though the Sauce Labs UI refers to this values as the `Tunnel Name`.
+#### `name`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies an active Sauce Connect tunnel to use for secure connectivity to the Sauce Labs cloud.
+
+:::note
+This property replaces the former `id` property, which is deprecated.
 :::
 
 ```yaml
- tunnel:
-    id: your_tunnel_id
+sauce:
+  tunnel:
+    name: your_tunnel_name
+```
+---
+
+#### `owner`
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Identifies the Sauce Labs user who created the specified tunnel, which is required if the user running the tests did not create the tunnel.
+
+:::note
+This property replaces the former `parent` property, which is deprecated.
+:::
+
+```yaml
+sauce:
+  tunnel:
+    name: your_tunnel_name
+    owner: tunnel_owner_username
 ```
 ---
 

--- a/docs/testrunner-toolkit/saucectl.md
+++ b/docs/testrunner-toolkit/saucectl.md
@@ -377,28 +377,38 @@ saucectl run --timeout 30m
 ```
 ---
 
-### `--tunnel-id <string>`
-<p><small>| OPTIONAL | STRING | <span class="highlight sauce-cloud">Sauce Cloud only</span> |</small></p>
+### `--tunnel-name <string>`
+<p><small>| OPTIONAL | STRING | <span className="sauceDBlue">Sauce Cloud only</span> |</small></p>
 
 Specifies an active [Sauce Connect](/testrunner-toolkit/configuration#sauce-connect) tunnel to establish a secure connection to run this test on Sauce Labs.
 
-:::note Choose the Correct Tunnel Identifier
-When you launch a tunnel, you can accept the tunnel identifier name that Sauce Labs generates for your account (e.g., `{SL-username}_tunnel_id`) or specify a name in the launch command:
-
-```bash
-bin/sc -u {SL-username} -k {SL-access_key} -i {tunnel_identifier}
-```
-
-This is the value `saucectl` expects as the `tunnel_id`, even though the Sauce Labs UI refers to this value as the `Tunnel Name`.
+:::note
+Replaces the former `--tunnel-id` flag, which is deprecated.
 :::
 
 ```bash
-saucectl run --tunnel-id <tunnel-id>
+saucectl run --tunnel-name <tunnel-name>
 ```
 ---
 
+
+### `--tunnel-owner <string>`
+<p><small>| OPTIONAL | STRING | <span className="sauceDBlue">Sauce Cloud only</span> |</small></p>
+
+Identifies the Sauce Labs user who created the specified tunnel, which is required if the user running the tests did not create the tunnel.
+
+:::note
+Replaces the former `--tunnel-parent` flag, which is deprecated.
+:::
+
+```bash
+saucectl run --tunnel-owner <tunnel-owner-username>
+```
+---
+
+
 ### `--dry-run`
-<p><small>| OPTIONAL | BOOLEAN | <span class="highlight sauce-cloud">Sauce Cloud only</span> |</small></p>
+<p><small>| OPTIONAL | BOOLEAN | <span className="sauceDBlue">Sauce Cloud only</span> |</small></p>
 
 Simulate a test run without actually running any tests. This flag does not require a value; including it inline sets it to `true`.
 
@@ -441,7 +451,7 @@ If shell completion is not already enabled in your environment, enable it by exe
 ```bash
 $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 ```
-  
+
 To load completions for each session, execute once:
 
 ```bash


### PR DESCRIPTION
### Description
Deprecate all saucectl instances of `tunnelId` and `tunnelParent` and replace with `tunnelName` and `tunnelOwner`

### Motivation and Context
Resolvved DEVX-1243

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
