### PR TITLE
added a bunch of code examples to from demo repos

### DIFF
--- a/docs/web-apps/automated-testing/selenium/selenium4.md
+++ b/docs/web-apps/automated-testing/selenium/selenium4.md
@@ -8,9 +8,11 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This doc will guide you through how to upgrade to Selenium 4, which is slated for production release in late 2021.
+This doc will guide you through how to upgrade to Selenium 4, which has just been released!
 
-Although Selenium 4 is designed to be a straightforward drop-in replacement, you'll need to be aware of the new and deprecated features that may impact your Sauce Labs automated tests. This is especially important if you've built custom functionalities in your testing framework.
+Although Selenium 4 is designed to be a straightforward drop-in replacement,
+you'll need to be aware of the new and deprecated features that may impact your Sauce Labs automated tests. 
+This is especially important if you've built custom functionalities in your testing framework.
 
 ## What You'll Learn
 * Tips for adjusting your tests and dependencies.
@@ -22,135 +24,18 @@ Although Selenium 4 is designed to be a straightforward drop-in replacement, you
 * Strongly recommended: use one of the programming languages officially supported by Selenium 4 (Java, JavaScript, Python, Ruby, or C#).
 
 
-## New Features
+## W3C Compliant Sessions
 
-Below are features new to Selenium 4 that may impact your tests.
-
-<table>
-<tr>
-<td>New Feature</td>
-<td>Description</td>
-</tr>
-<tr>
-<td>Force W3C Usage</td>
-<td>Selenium 4 deprecates support for legacy JSON wire protocol and its static <code>DesiredCapabilities</code> browser methods, replacing it with <a href="/dev/w3c-webdriver-capabilities">W3C WebDriver-compliant protocol</a> and the use of <code>browserOptions</code>. You must completely switch from using JWP to W3C; Selenium will no longer be backwards-compatible. The W3C standard will be supported by default under the hood. </td>
-</tr>
-<tr>
-<td>Relative Locators</td>
-<td>New way of locating elements based on the visual placement on the page. Relative locators use more natural language friendly terms, such as “above”, “below”, “left of”, “right of”, and “near”. <a href="https://github.com/saucelabs-training/demo-java/blob/main/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/RelativeLocatorsTest.java">See a code example</a>.</td>
-</tr>
-<tr>
-<td>New Window and Tab Utilities</td>
-<td>New command that allows you to create and manage new tabs and new windows. <a href="https://github.com/saucelabs-training/demo-java/blob/main/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/NewWindowSauceTest.java">See a code example</a>.</td>
-</tr>
-<tr>
-<td>Print Page as PDF</td>
-<td>The ability to print a page as a PDF through Chrome and Firefox. See examples here.</td>
-</tr>
-<tr>
-<td>New Firefox Features</td>
-<td><ul>
-<li>Full page screenshot for bug reporting. <a href="https://github.com/saucelabs-training/demo-java/blob/main/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/ViewPageFirefoxTest.java">See a code example</a>.</li>
-<li>Simplified way to install/uninstall add-ons</li>
-<li>Updating browser preferences (such as the language) in the middle of the session. <a href="https://github.com/saucelabs-training/demo-java/blob/main/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/FirefoxAddonTest.java">See a code example</a>.</li>
-<li>Firefox Context If you want to change something like a profile where dirs are downloaded mid-test, you can change it on the fly. <a href="https://github.com/saucelabs-training/demo-java/blob/main/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/FirefoxContextTest.java">See a code example</a>.</li></ul></td>
-</tr>
-<tr>
-<td>Setting Network Conditions with Chrome and Edge</td>
-<td>Selenium 4 exposes a set of utilities to modify network conditions in Chromium-based browsers, such as: Going offline, Setting a latency for the connection, Alter the upload or download throughput. This can be useful to test web applications under different network conditions. Allows throttling (extended debugging) without executing JavaScript. <a href="https://github.com/saucelabs-training/demo-java/blob/main/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/ChromeNetworkTest.java">See a code example.</a></td>
-</tr>
-<tr>
-<td>Chromium Edge Options methods (Se3 technically only supported Edge HTML)</td>
-<td>?</td>
-</tr>
-<tr>
-<td>RemoteWebDriverBuilder (Java Only)</td>
-<td>Prior to Selenium 4, in order to use browser specific-options, you had to cast it and augment it (access local webdriver methods). There were a lot of defaults and you didn’t have many options for starting a driver. With Selenium 4's new <code>.builder()</code> method, you can send <code>browser.options</code>, timeouts, and create a hashmap instead of having mutable capabilities. <a href="https://github.com/saucelabs-training/demo-java/blob/main/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/RemoteWebDriverBuilderTest.java">See a code example</a>.</td>
-</tr>
-<tr>
-<td>New Element Attribute and Property methods</td>
-<td>Two new methods have been added to more precisely get a given element attribute or a property. These are especially useful for performance and preciseness in Sauce Labs tests. <a href="https://github.com/saucelabs-training/demo-java/blob/main/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/AttributePropertyTest.java">See a code example</a>.</td>
-</tr>
-</table>
-
-
-## Preparing Your Test Code
-
-Because Selenium 4 deprecates support for legacy JWP (`DesiredCapabilities`) &#8212; replacing it with W3C WebDriver-compliant (`browserOptions`) &#8212; you'll need to prepare your test code accordingly. Using W3C `browserOptions`:
+Selenium 4 deprecates support for legacy JSON Wire Protocol (JWP). As part of this change, Selenium is moving
+away from the less structured Desired Capabilities classes to Browser Options classes.
+* Facilitates creation of W3C Compliant [WebDriver Capabilites](/dev/w3c-webdriver-capabilities)
 * Simplifies the configuration needed to start a new session.
-* Allows you to set browser-specific settings (like headless in Chrome).
+* Allows you to set both defined W3C Capabilities, and browser-specific settings.
 * Reduces the chances of browser misconfiguration.
 
-### W3C WebDriver-Compliant Capabilities
+### W3C Defined WebDriver Capabilities
 
-You must structure your test capabilities to be W3C-compliant and switch from `DesiredCapabilities` (JWP) to `browserOptions` (W3C), otherwise they'll be ignored.
-
-<Tabs
-  defaultValue="Chrome"
-  values={[
-    {label: 'Chrome', value: 'Chrome'},
-    {label: 'Edge', value: 'Edge'},
-    {label: 'Firefox', value: 'Firefox'},
-    {label: 'IE', value: 'IE'},
-    {label: 'Safari', value: 'Safari'},
-  ]}>
-
-<TabItem value="Chrome">
-
-```java title="DesiredCapabilities"
-DesiredCapabilities caps = DesiredCapabilities.chrome();
-```
-
-```java title="browserOptions"
-ChromeOptions browserOptions = new ChromeOptions();
-```
-
-</TabItem>
-<TabItem value="Edge">
-
-```java title="DesiredCapabilities"
-DesiredCapabilities caps = DesiredCapabilities.edge();
-```
-
-```java title="browserOptions"
-EdgeOptions browserOptions = new EdgeOptions();
-```
-
-</TabItem>
-<TabItem value="Firefox">
-
-```java title="DesiredCapabilities"
-DesiredCapabilities caps = DesiredCapabilities.firefox();
-```
-
-```java title="browserOptions"
-FirefoxOptions browserOptions = new FirefoxOptions();
-```
-
-</TabItem>
-<TabItem value="IE">
-
-```java title="DesiredCapabilities"
-DesiredCapabilities caps = DesiredCapabilities.internetExplorer();
-```
-```java title="browserOptions"
-InternetExplorerOptions browserOptions = new InternetExplorerOptions();
-```
-
-</TabItem>
-<TabItem value="Safari">
-
-```java title="DesiredCapabilities"
-DesiredCapabilities caps = DesiredCapabilities.safari();
-```
-```java title="browserOptions"
-SafariOptions browserOptions = new SafariOptions();
-```
-
-</TabItem>
-</Tabs>
-
-List of [W3C WebDriver standard capabilities](https://www.w3.org/TR/webdriver1/#capabilities):
+List of [W3C WebDriver capabilities](https://www.w3.org/TR/webdriver1/#capabilities) applicable to Sauce Labs:
 * `browserName`
 * `browserVersion`
 * `platformName`
@@ -160,26 +45,32 @@ List of [W3C WebDriver standard capabilities](https://www.w3.org/TR/webdriver1/#
 * `timeouts`
 * `unhandledPromptBehavior`
 
-Any capability not in this list must include a vendor prefix. This rule applies to browser-specific capabilities as well as Sauce Labs-specific capabilities. For example, if you want use the `build` and `name` capabilities in for your Sauce Labs tests, you'll need to wrap them in a `sauce:options` block ([see the examples below](/web-apps/automated-testing/selenium/selenium4/#platform-configuration-examples)).
+Any capability not in this list must include a vendor prefix.
+This rule applies to browser-specific capabilities as well as Sauce Labs-specific capabilities. 
+So, Firefox specific capabilities need to be nested inside a `moz:firefoxOptions` or other `moz:XXX` keys. If
+you use a Browser Options class this is all handled for you. For Sauce Labs, though, we need you to create a Hash or
+Dictionary of Sauce Labs specific settings and place it inside a `sauce:options` object. 
+See the examples in the next section.
 
-#### Platform Configuration Examples
+#### Converting from Capabilities to Options
 
-Below are examples comparing the usage of legacy `DesiredCapabilities` with the new `browserOptions`.
+To customize your default settings, check out the new "Selenium 4" 
+Tab on the [Sauce Labs platform configurator](https://saucelabs.com/platform/platform-configurator).
+All the valid `sauce:options` parameters are described on the [Test Configurations](/dev/test-configuration-options/index.html) page.
 
 <Tabs
-  defaultValue="Java"
-  values={[
-    {label: 'Java', value: 'Java'},
-    {label: 'JavaScript', value: 'JavaScript'},
-    {label: 'Python', value: 'Python'},
-    {label: 'Ruby', value: 'Ruby'},
-    {label: 'C#', value: 'C#'},
-  ]}>
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
 
 <TabItem value="Java">
 
-DesiredCapabilities
-```java
+```java title="Deprecated Code"
 DesiredCapabilities caps = DesiredCapabilities.firefox();
 caps.setCapability("platform", "Windows 10");
 caps.setCapability("version", "92");
@@ -188,49 +79,14 @@ caps.setCapability("name", myTestName);
 WebDriver driver = new RemoteWebDriver(new URL(sauceUrl), caps);
 ```
 
-browserOptions
-```java
-FirefoxOptions browserOptions = new FirefoxOptions();
-browserOptions.setCapability("platformName", "Windows 10");
-browserOptions.setCapability("browserVersion", "92");
-Map<String, Object> sauceOptions = new HashMap<>();
-sauceOptions.put("build", myTestBuild);
-sauceOptions.put("name", myTestName);
-browserOptions.setCapability("sauce:options", sauceOptions);
-WebDriver driver = new RemoteWebDriver(new URL(sauceUrl), browserOptions);
-```
-
-</TabItem>
-<TabItem value="JavaScript">
-
-DesiredCapabilities
-```js
-caps = {};
-caps['browserName'] = 'Firefox';
-caps['platform'] = 'Windows 10';
-caps['version'] = '92';
-caps['build'] = myTestBuild;
-caps['name'] = myTestName;
-```
-
-browserOptions
-```js
-capabilities = {
-  browserName: 'firefox',
-  browserVersion: '92',
-  platformName: 'Windows 10',
-  'sauce:options': {
-     build: myTestBuild,
-     name: myTestName,
-  }
-}
+```java reference title="Recommended Code"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/selenium-examples/src/test/java/com/saucedemo/selenium/demo/SeleniumTest.java#L34-L43
 ```
 
 </TabItem>
 <TabItem value="Python">
 
-DesiredCapabilities
-```py
+```py title="Deprecated Code"
 caps = {}
 caps['browserName'] = 'firefox'
 caps['platform'] = 'Windows 10'
@@ -240,24 +96,14 @@ caps['name'] = my_test_name
 driver = webdriver.Remote(sauce_url, desired_capabilities=caps)
 ```
 
-browserOptions
-```py
-from selenium.webdriver.firefox.options import Options as FirefoxOptions
-options = FirefoxOptions()
-options.browser_version = '92'
-options.platform_name = 'Windows 10'
-sauce_options = {}
-sauce_options['build'] = my_test_build
-sauce_options['name'] = my_test_name
-options.set_capability('sauce:options', sauce_options)
-driver = webdriver.Remote(sauce_url, options=options)
+```py reference title="Recommended Code"
+https://github.com/saucelabs-training/demo-python/blob/docs-1.1/examples/selenium/conftest.py#L12-L21
 ```
 
 </TabItem>
 <TabItem value="Ruby">
 
-DesiredCapabilities
-```rb
+```rb title="Deprecated Code"
 caps = Selenium::WebDriver::Remote::Capabilities.firefox
 caps[:platform] = 'Windows 10'
 caps[:version] = '92'
@@ -266,23 +112,14 @@ caps[:name] = my_test_name
 driver = Selenium::WebDriver.for :remote, url: sauce_url, desired_capabilities: caps
 ```
 
-browserOptions
-```rb
-options = Selenium::WebDriver::Options.firefox
-options.browser_version = 'latest'
-options.platform_name = 'Windows 10'
-sauce_options = {}
-sauce_options[:build] = my_test_build
-sauce_options[:name] = my_test_name
-options.add_option('sauce:options', sauce_options)
-driver = Selenium::WebDriver.for :remote, url: sauce_url, capabilities: options
+```rb reference title="Recommended Code"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/selenium-examples/rspec/spec/spec_helper.rb#L9-L16
 ```
 
 </TabItem>
 <TabItem value="C#">
 
-DesiredCapabilities
-```csharp
+```csharp title="Deprecated Code"
 DesiredCapabilities caps = new DesiredCapabilities();
 caps.SetCapability("browserName", "firefox");
 caps.SetCapability("platform", "Windows 10");
@@ -292,21 +129,569 @@ caps.SetCapability("name", myTestName);
 var driver = new RemoteWebDriver(new Uri(SauceURL), capabilities);
 ```
 
-browserOptions
-```csharp
-var browserOptions = new FirefoxOptions();
-browserOptions.PlatformName = "Windows 10";
-browserOptions.BrowserVersion = "92";
-var sauceOptions = new Dictionary<string, object>();
-sauceOptions.Add("build", myTestBuild);
-sauceOptions.Add("name", myTestName);
-browserOptions.AddAdditionalOption("sauce:options", sauceOptions);
-var driver = ​​new RemoteWebDriver(new Uri(SauceURL), options);
+```cs reference title="Recommended Code"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4Demo.cs#L21-L30
 ```
+
 </TabItem>
 </Tabs>
 
-For more information, see [W3C WebDriver Capabilities Support](/dev/w3c-webdriver-capabilities). To view all possible platform configurations, see the [Sauce Labs platform configurator](https://saucelabs.com/platform/platform-configurator).
+#### Remote WebDriverBuilder
+<p><span className="sauceDBlue">Java only</span></p>
+
+An alternate way to start your session in Java is with the `RemoteWebDriverBuilder`.
+This class has a few advantages for Sauce Labs users, including automatic driver augmentation 
+(driver augmentation is required for several of the new features below), and the ability to set HTTP Client
+settings like read timeouts.
+
+<details>
+  <summary>
+    <strong>Click here</strong> to see an example of using the RemoteWebDriverBuilder.<br />
+  </summary>
+
+```java reference title="RemoteWebDriverBuilder"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/RemoteWebDriverBuilderTest.java#L29-L51
+```
+</details>
+
+
+## New Features
+
+Here are 10 new features in Selenium 4 that you can use in your Sauce Labs Tests, with examples in each language.
+
+#### 1. Relative Locators
+
+Relative locators allow you to identify elements in relationship to each other as they are displayed on the page
+using more natural language friendly terms, such as “above”, “below”, “left of”, “right of”, and “near”.
+
+:::caution
+Changing the size of browser window or adding or removing things on the page can change which element 
+is located.
+:::
+
+<Tabs
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
+
+<TabItem value="Java">
+
+```java reference title="Relative Locators"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/RelativeLocatorsTest.java#L15-L21
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```py reference title="Relative Locators"
+https://github.com/saucelabs-training/demo-python/blob/docs-1.1/examples/selenium/new_features/test_relative_locators.py#L6-L13
+```
+
+</TabItem>
+<TabItem value="Ruby">
+
+```rb reference title="Relative Locators"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/training-sessions/selenium4/spec/relative_locators_spec.rb#L7-L13
+```
+
+</TabItem>
+<TabItem value="C#">
+
+```cs reference title="Relative Locators"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/RelativeLocators.cs#L39-L47
+```
+
+</TabItem>
+
+</Tabs>
+
+#### 2. New Window
+
+Create and Switch to a new (blank) tab or window.
+
+<Tabs
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
+
+<TabItem value="Java">
+
+```java reference title="Create New Window"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/NewWindowTest.java#L13-L16
+```
+
+```java reference title="Create New Tab"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/NewWindowTest.java#L21-L23
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```py reference title="Create New Window"
+https://github.com/saucelabs-training/demo-python/blob/docs-1.1/examples/selenium/new_features/test_new_window.py#L5-L8
+```
+
+```py reference title="Create New Tab"
+https://github.com/saucelabs-training/demo-python/blob/docs-1.1/examples/selenium/new_features/test_new_window.py#L12-L14
+```
+
+</TabItem>
+<TabItem value="Ruby">
+
+```rb reference title="Create New Window"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/training-sessions/selenium4/spec/new_window_spec.rb#L7-L9
+```
+
+```rb reference title="Create New Tab"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/training-sessions/selenium4/spec/new_window_spec.rb#L13-L14
+```
+
+</TabItem>
+<TabItem value="C#">
+
+```cs reference title="Create New Window"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/NewWindow.cs#L39-L42
+```
+
+```cs reference title="Create New Tab"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/NewWindow.cs#L48-L50
+```
+</TabItem>
+
+</Tabs>
+
+#### 3. Print Page
+
+The ability to print a page as a PDF in Chrome, Firefox and Edge. There are quite a few customizations that can be
+made including page size, range, margins, background, and shrink to fit. Here are code examples with the defaults:
+
+:::note
+For Chrome and Edge, this only works in Headless mode.
+:::
+
+<Tabs
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
+
+<TabItem value="Java">
+
+```java reference title="Print Page"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/ViewPageFirefoxTest.java#L38-L41
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```py reference title="Print Page"
+https://github.com/saucelabs-training/demo-python/blob/docs-1.1/examples/selenium/new_features/test_print_page.py#L8-L13
+```
+
+</TabItem>
+<TabItem value="Ruby">
+
+```rb reference title="Print Page"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/ViewPageFirefox.cs#L39-L44
+```
+
+</TabItem>
+<TabItem value="C#">
+
+```cs reference title="Print Page"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/RelativeLocators.cs#L39-L47
+```
+
+</TabItem>
+
+</Tabs>
+
+#### 4. Element Attribute vs Property 
+
+The Selenium 3 method for getting an element's attribute does not actually give you the element's attribute.
+Because most people don't know the difference between an element and an attribute, Selenium created a way
+to provide the user with whichever value they probably wanted. Because this magic can not be precisely
+specified for the W3C, two new methods were created. The original method hasn't changed, but using it will
+be slightly less performant on Sauce Labs, as well as less precise. The new methods are named slightly differently in
+each language.:
+
+<details>
+  <summary>
+    <strong>Click here</strong> to see multiple examples of the behavior of these attribute and property methods.
+  </summary>
+
+<Tabs
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
+
+<TabItem value="Java">
+
+```java reference title="Attributes vs Properties"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/AttributePropertyTest.java
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```py reference title="Attributes vs Properties"
+https://github.com/saucelabs-training/demo-python/blob/docs-1.1/examples/selenium/new_features/test_attribute_property.py
+```
+
+</TabItem>
+<TabItem value="Ruby">
+
+```rb reference title="Attributes vs Properties"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/training-sessions/selenium4/spec/attribute_property_spec.rb
+```
+
+</TabItem>
+<TabItem value="C#">
+
+```cs reference title="Attributes vs Properties"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/AttributeProperty.cs
+```
+
+</TabItem>
+
+</Tabs>
+</details>
+
+#### 5. Chromium Edge Options
+
+When the latest version of Selenium 3 was released, Microsoft Edge was still implemented with the now deprecated
+EdgeHTML browser engine. So none of the custom options for working with the Chromium version of Edge were available
+in Selenium 3.
+
+<Tabs
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
+
+<TabItem value="Java">
+
+```java reference title="Chromium Edge Options"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/MSEdgeTest.java#L15-L21
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```py reference title="Chromium Edge Options"
+https://github.com/saucelabs-training/demo-python/blob/docs-1.1/examples/selenium/new_features/test_ms_edge.py#L8-L11
+```
+
+</TabItem>
+<TabItem value="Ruby">
+
+```rb reference title="Chromium Edge Options"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/training-sessions/selenium4/spec/ms_edge_spec.rb#L11-L18
+```
+
+</TabItem>
+<TabItem value="C#">
+
+```cs reference title="Chromium Edge Options"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/MSEdge.cs#L20-L23
+```
+
+</TabItem>
+
+</Tabs>
+
+#### 6. Timeout Getters
+
+This is a long requested feature. Selenium 3 allowed you to set timeouts whenever you liked, but provided
+no way to query the driver for the current timeout values. Selenium 4 provides that ability now.
+
+:::tip
+Best practice is to set the timeout values in the Options class when starting the session and then ignore
+them during the test (do not use the setters or getters)
+:::
+
+<Tabs
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
+
+<TabItem value="Java">
+
+```java reference title="Get Timeouts"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/TimeoutsTest.java#L13-L22
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```py reference title="Get Timeouts"
+https://github.com/saucelabs-training/demo-python/blob/docs-1.1/examples/selenium/new_features/test_timeouts.py#L6-L12
+```
+
+</TabItem>
+<TabItem value="Ruby">
+
+```rb reference title="Get Timeouts"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/training-sessions/selenium4/spec/timeouts_spec.rb#L7-L11
+```
+
+</TabItem>
+<TabItem value="C#">
+
+```cs reference title="Get Timeouts"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/Timeouts.cs#L38-L42
+```
+
+</TabItem>
+
+</Tabs>
+
+#### 7. Network Conditions
+<p><span className="sauceDBlue">Chrome and Edge only</span></p>
+
+Selenium 4 provides a set of parameters to modify network conditions, such as: 
+* Going offline
+* Setting a latency for the connection
+* Altering the upload or download throughput. 
+
+This can be useful to test web applications under different network conditions.
+
+:::note
+Sauce Labs has provided the means for our users to [throttle network settings](/insights/debug/#saucethrottlenetwork) for 
+several years now through our [Extended Debugging](/insights/debug/) feature
+:::
+
+<Tabs
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
+
+<TabItem value="Java">
+
+```java reference title="Network Conditions"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/ChromeNetworkTest.java#L16-L28
+```
+
+</TabItem>
+<TabItem value="Python">
+
+**Python does not support this feature in Remote driver sessions**
+
+</TabItem>
+<TabItem value="Ruby">
+
+```rb reference title="Network Conditions"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/training-sessions/selenium4/spec/chrome_network_spec.rb#L8-L12
+```
+
+</TabItem>
+<TabItem value="C#">
+
+<details>
+  <summary>
+    <strong>Click here</strong> to see the full example of setting Network Conditions.<br />
+    (The C# implementation of this is a little more complex).
+  </summary>
+
+```cs reference title="Network Conditions"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/ChromeNetwork.cs#L39-L86
+```
+</details>
+
+
+</TabItem>
+
+</Tabs>
+
+#### 8. Full Page Screenshots
+<p><span className="sauceDBlue">Firefox only</span></p>
+
+Features like "infinite scroll" makes it impossible to explicitly define what a "full page" entails for 
+a W3C specification. As such, the default screenshot method in Selenium 3 only returns what is visible in the Viewport. 
+Mozilla implemented a separate method to allow for a full page screenshot. 
+
+<Tabs
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
+
+<TabItem value="Java">
+
+```java reference title="Full Page Screenshot"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/ViewPageFirefoxTest.java#L55-L59
+```
+
+</TabItem>
+<TabItem value="Python">
+
+**Python does not support this feature in Remote driver sessions**
+
+</TabItem>
+<TabItem value="Ruby">
+
+```rb reference title="Full Page Screenshot"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/training-sessions/selenium4/spec/view_page_firefox_spec.rb#L17-L18
+```
+
+</TabItem>
+<TabItem value="C#">
+
+```cs reference title="Full Page Screenshot"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/ViewPageFirefox.cs#L59-L73
+```
+
+</TabItem>
+
+</Tabs>
+
+#### 9. Install and Uninstall Addons
+<p><span className="sauceDBlue">Firefox only</span></p>
+
+All the other browsers drivers allow you to install extensions with the Browser Options class. Firefox
+requires a separate method after the browser has been started.
+
+<Tabs
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
+
+<TabItem value="Java">
+
+```java reference title="Install and Uninstall Addons"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/FirefoxAddonTest.java#L23-L32
+```
+
+</TabItem>
+<TabItem value="Python">
+
+**Python does not support this feature in Remote driver sessions**
+
+</TabItem>
+<TabItem value="Ruby">
+
+```rb reference title="Install and Uninstall Addons"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/training-sessions/selenium4/spec/firefox_addon_spec.rb#L7-L15
+```
+
+</TabItem>
+<TabItem value="C#">
+
+<details>
+  <summary>
+    <strong>Click here</strong> to see the full example of Installing and Uninstalling Addons.<br />
+    (The C# implementation of this is a little more complex).
+  </summary>
+
+```cs reference title="Install and Uninstall Addons"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/FirefoxAddon.cs#L41-L93
+```
+</details>
+
+</TabItem>
+
+</Tabs>
+
+#### 10. Change Preferences During Session
+<p><span className="sauceDBlue">Firefox only</span></p>
+
+In Selenium 3, you can only set preferences in the Capabilities at the beginning of a test. Firefox
+has provided a way in Selenium 4 to update things whenever you want during a session. This is done
+by toggling the *context* between "chrome" and "content".
+
+Here are some examples of using the "chrome" context to change the default accepted language of the browser:
+
+:::caution
+Most Selenium commands are not valid in the "chrome" context, so make sure you switch back after using it 
+:::
+
+<Tabs
+groupId="lang-ex"
+defaultValue="Java"
+values={[
+{label: 'Java', value: 'Java'},
+{label: 'Python', value: 'Python'},
+{label: 'Ruby', value: 'Ruby'},
+{label: 'C#', value: 'C#'},
+]}>
+
+<TabItem value="Java">
+
+```java reference title="Change Context"
+https://github.com/saucelabs-training/demo-java/blob/docs-1.1/training-sessions/selenium4/src/test/java/com/saucelabs/selenium4/new_/FirefoxContextTest.java#L25-L39
+```
+
+</TabItem>
+<TabItem value="Python">
+
+**Python does not support this feature in Remote driver sessions**
+
+</TabItem>
+<TabItem value="Ruby">
+
+```rb reference title="Change Context"
+https://github.com/saucelabs-training/demo-ruby/blob/docs-1.1/training-sessions/selenium4/spec/firefox_context_spec.rb#L6-L23
+```
+
+</TabItem>
+<TabItem value="C#">
+
+<details>
+  <summary>
+    <strong>Click here</strong> to see the full example of Changing Preferences During a Session.<br />
+    (The C# implementation of this is a little more complex).
+  </summary>
+
+```cs reference title="Change Context"
+https://github.com/saucelabs-training/demo-csharp/blob/docs-1.1/DotnetCore/Sauce.Demo/Core.Selenium.Examples/Selenium4/NewFeatures/FirefoxContext.cs#L41-L96
+```
+</details>
+
+</TabItem>
+
+</Tabs>
 
 
 ## Upgrading Your Dependencies


### PR DESCRIPTION
I moved the New Features below the Capabilities section, and then went crazy pointing to code for all of it. I tried to identify the places where it was too much code and put it inside a `details` element, so it should still be easy to scroll down the page I think.

So, I'm not sure this all belongs on this page, but then I'm also not sure where else it would go, and it does need to go somewhere. The marketing pages can't do tabbed languages, so everything is just Java. I'm currently thinking it would make sense to link from the blog articles, etc to the applicable section on this selenium4 doc where it is relatively easy to see.

There are also more things that *should* get added at some point. Actions class examples being a major one. As part of writing these examples I found a lot of little issues in Selenium code base I needed to fix, and I'm pretty sure the implementations of Actions class by the different bindings have a lot of problems. Python also deprecated the `find_element_by_*` methods, and arguably this will be a bigger deal for them than for Java users. Also, some of this remaining code probably should get moved into a demo-* repo, but I'm at my limit of things right now.

Let me know what you think of what's here. Thanks.