### PR TITLE
Fixed corrupt copyright symbol

### DIFF
--- a/static/404.html
+++ b/static/404.html
@@ -14,7 +14,7 @@
             <img class="gif" src="/img/Manual_Bot_EXPORT.gif" alt="Sauce Bot Animated GIF">
         </div>
         <div class="flex message">
-                <p>Oops, it looks like the page you're looking for either no longer exists or moved.</p>
+                <p>Oops! It looks like the page you're looking for no longer exists or has been moved.</p>
         </div>
     </div>
     <div class="button_base slide_in">
@@ -24,6 +24,6 @@
     </div>
 </body>
 <footer>
-    <p><small>© 2021 Sauce Labs Inc., all rights reserved. SAUCE and SAUCE LABS are registered trademarks owned by Sauce Labs Inc. in the United States, EU, and may be registered in other jurisdictions.</small></p>
+    <p><small>&#169; 2021 Sauce Labs Inc., all rights reserved. SAUCE and SAUCE LABS are registered trademarks owned by Sauce Labs Inc. in the United States, EU, and may be registered in other jurisdictions.</small></p>
 </footer>
 </html>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

Hi @spider-sauce @sweeneyskirt-sl: in the 404 page, I was seeing a corrupt character that looked like the Anaheim Angels logo lol. I swapped out the copyright symbol with the html code (`&#169;`) and it seems to be ok now.

<img width="439" alt="Screen Shot 2021-10-22 at 11 25 48 PM" src="https://user-images.githubusercontent.com/56411016/138545515-40d05c76-5c94-4fcb-b426-2c6560c57eb3.png">


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
