### PR TITLE
remove outdated oauth method

### DIFF
--- a/docs/mobile-apps/faq.md
+++ b/docs/mobile-apps/faq.md
@@ -86,7 +86,7 @@ It is of great importance for us to make sure that no other user can have access
 
 #### **Do you support SSO (Single Sign-On)?**
 
-Yes. We support OAuth login via LinkedIn, Google and GitHub.
+Yes. We support OAuth login via Google and GitHub.
 
 
 ### Automated Testing


### PR DESCRIPTION
linkedin is not actually supported, legacy holdover from previous docs

### Description
remove mention of linkedin oauth

### Motivation and Context
linkedin is not actually supported 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
