### PR TITLE
Add note that Safari 15+ can't use `.local` domains

### DIFF
--- a/docs/secure-connections/sauce-connect/faq.md
+++ b/docs/secure-connections/sauce-connect/faq.md
@@ -66,9 +66,11 @@ Microsoft Edge, Chrome 71+ and the Safari browser on OS X 10.10+ and mobile iOS 
     9000, 9001, 9031, 9080, 9081, 9090, 9191, 9876, 9877, 9999,
     49221, 55001
 
-### Using `.local` domains
 
-*Note*: Using [Bonjour / ZeroConf](https://developer.apple.com/bonjour/) for hostnames on a local network does not work on Safari 15 or newer.
+:::note Using `.local` domains
+Using [Bonjour / ZeroConf](https://developer.apple.com/bonjour) for hostnames on a local network does not work on Safari 15 and above.
+:::
+
 
 ## If we have five users, should we use five instances of Sauce Connect Proxy or set up one shared instance?
 

--- a/docs/secure-connections/sauce-connect/faq.md
+++ b/docs/secure-connections/sauce-connect/faq.md
@@ -66,6 +66,9 @@ Microsoft Edge, Chrome 71+ and the Safari browser on OS X 10.10+ and mobile iOS 
     9000, 9001, 9031, 9080, 9081, 9090, 9191, 9876, 9877, 9999,
     49221, 55001
 
+### Using `.local` domains
+
+*Note*: Using [Bonjour / ZeroConf](https://developer.apple.com/bonjour/) for hostnames on a local network does not work on Safari 15 or newer.
 
 ## If we have five users, should we use five instances of Sauce Connect Proxy or set up one shared instance?
 


### PR DESCRIPTION
Safari 15 and newer doesn't pass `.local` traffic to our proxy.

See https://saucedev.atlassian.net/browse/SC-3671 for more details.