### PR TITLE
Remove reference to old SJC1 IP address

### DIFF
--- a/docs/secure-connections/sauce-connect/troubleshooting.md
+++ b/docs/secure-connections/sauce-connect/troubleshooting.md
@@ -26,7 +26,7 @@ You can enable verbose logging, which increases the logging level of Sauce Conne
 ## Network Configuration with Firewalls and Proxies
 
 Is there a firewall or proxy server in place between your machine running Sauce Connect Proxy and Sauce Labs (`*.saucelabs.com:443`)? You may need to allow access in your firewall rules or configure Sauce Connect Proxy to use an additional proxy. See [Setup with Additional Proxies](/secure-connections/sauce-connect/setup-configuration/additional-proxies)
-Sauce Connect Proxy needs to establish outbound connections to both \*.saucelabs.com (or a [specific data centre](/basics/data-center-endpoints)) on `port 443` and to a tunnel VM with an IP in the Sauce Labs ranges (`162.222.72.0/21`, `66.85.48.0/21`, `185.94.24.0/22`).
+Sauce Connect Proxy needs to establish outbound connections to both \*.saucelabs.com (or a [specific data center](/basics/data-center-endpoints)) on `port 443` and to a tunnel VM with an IP in the Sauce Labs ranges (`162.222.72.0/21`, `66.85.48.0/21`, `185.94.24.0/22`).
 
 For information on setting up Sauce Connect Proxy within various network environments, see [Security and Authentication](/secure-connections/sauce-connect/security-authentication).
 

--- a/docs/secure-connections/sauce-connect/troubleshooting.md
+++ b/docs/secure-connections/sauce-connect/troubleshooting.md
@@ -26,7 +26,7 @@ You can enable verbose logging, which increases the logging level of Sauce Conne
 ## Network Configuration with Firewalls and Proxies
 
 Is there a firewall or proxy server in place between your machine running Sauce Connect Proxy and Sauce Labs (`*.saucelabs.com:443`)? You may need to allow access in your firewall rules or configure Sauce Connect Proxy to use an additional proxy. See [Setup with Additional Proxies](/secure-connections/sauce-connect/setup-configuration/additional-proxies)
-Sauce Connect Proxy needs to establish outbound connections to both saucelabs.com (`162.222.73.28`) on `port 443` and to a tunnel VM with an IP in the Sauce Labs ranges (`162.222.72.0/21`, `66.85.48.0/21`, `185.94.24.0/22`).
+Sauce Connect Proxy needs to establish outbound connections to both \*.saucelabs.com (or a [specific data centre](/basics/data-center-endpoints)) on `port 443` and to a tunnel VM with an IP in the Sauce Labs ranges (`162.222.72.0/21`, `66.85.48.0/21`, `185.94.24.0/22`).
 
 For information on setting up Sauce Connect Proxy within various network environments, see [Security and Authentication](/secure-connections/sauce-connect/security-authentication).
 


### PR DESCRIPTION
### Description
Remove reference to old saucelabs.com IP address.

### Motivation and Context
This IP address isn't used any more, and we should encourage customers to whitelist by URL, since our load balancer IP addresses could change.