### PR TITLE
Decreased default font size not to break flex

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -168,7 +168,6 @@ html[data-theme='dark'] .navbar-sidebar {
 }
 
 .navbar__items {
-  font-size: 110%;
   font-weight: 500;
   color: var(--ds-gray-600);
   text-decoration-color: var(--ds-gray-600);


### PR DESCRIPTION
Small fix, decreased navbar fontsize to default 100% to avoid overlapping in some breakpoints.