### PR TITLE
End of Life for DevX Runners

### DIFF
--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -141,3 +141,7 @@ If you would prefer to stay in Cypress, try the new [Cypress Sauce Labs Plugin](
 :::caution Special Characters in Test Names
 We recommend that you avoid the use of special characters when naming your tests. If your test name contains any special characters, your test may not run or its artifacts may not be visible in our platform.
 :::
+
+:::caution Firefox 101 + Windows
+Cypress does currently not work with Firefox 101 on Windows.
+:::

--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -61,12 +61,14 @@ You can run `saucectl` locally via Docker ([Installation Requirements](https://d
       <th>Cypress Version</th>
       <th>Supported Platforms</th>
       <th>Supported Browsers</th>
+      <th>End of Life</th>
     </tr>
     <tbody>
     <tr>
       <td rowspan='2'>9.7.0</td>
       <td><b>macOS:</b> 11.00, 12</td>
       <td rowspan='2'>Chrome, Firefox, MicrosoftEdge</td>
+      <td rowspan='2'>Jun 6, 2023</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10, 11</td>
@@ -77,6 +79,7 @@ You can run `saucectl` locally via Docker ([Installation Requirements](https://d
       <td rowspan='2'>9.5.3</td>
       <td><b>macOS:</b> 11.00, 12</td>
       <td rowspan='2'>Chrome, Firefox, MicrosoftEdge</td>
+      <td rowspan='2'>Apr 16, 2023</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10, 11</td>
@@ -87,6 +90,7 @@ You can run `saucectl` locally via Docker ([Installation Requirements](https://d
       <td rowspan='2'>9.3.1</td>
       <td><b>macOS:</b> 11.00</td>
       <td rowspan='2'>Chrome, Firefox, MicrosoftEdge</td>
+      <td rowspan='2'>Feb 2, 2023</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10</td>
@@ -97,6 +101,7 @@ You can run `saucectl` locally via Docker ([Installation Requirements](https://d
       <td rowspan='1'>9.1.0</td>
       <td><b>Windows:</b> 10</td>
       <td>Chrome, Firefox, MicrosoftEdge</td>
+      <td rowspan='2'>Nov 29, 2022</td>
     </tr>
     </tbody>
     <tbody>
@@ -104,6 +109,7 @@ You can run `saucectl` locally via Docker ([Installation Requirements](https://d
       <td rowspan='1'>8.6.0</td>
       <td><b>Windows:</b> 10</td>
       <td>Chrome, Firefox, MicrosoftEdge</td>
+      <td rowspan='2'>Oct 13, 2022</td>
     </tr>
     </tbody>
   </table>

--- a/docs/web-apps/automated-testing/playwright.md
+++ b/docs/web-apps/automated-testing/playwright.md
@@ -62,12 +62,14 @@ You can run `saucectl` locally via Docker ([Installation Requirements](https://d
       <th>Playwright Version</th>
       <th>Supported Platforms</th>
       <th>Supported Browsers</th>
+      <th>End of Life</th>
     </tr>
     <tbody>
     <tr>
       <td rowspan='2'>1.22.2</td>
       <td><b>macOS:</b> 11.00, 12</td>
       <td rowspan='2'>Chromium, Firefox, Webkit</td>
+      <td rowspan='2'>Jun 6, 2023</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10, 11</td>
@@ -78,6 +80,7 @@ You can run `saucectl` locally via Docker ([Installation Requirements](https://d
       <td rowspan='2'>1.20.2</td>
       <td><b>macOS:</b> 11.00, 12</td>
       <td rowspan='2'>Chromium, Firefox, Webkit</td>
+      <td rowspan='2'>Apr 16, 2023</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10, 11</td>
@@ -88,6 +91,7 @@ You can run `saucectl` locally via Docker ([Installation Requirements](https://d
       <td rowspan='2'>1.18.1</td>
       <td><b>macOS:</b> 11.00</td>
       <td>Chromium, Firefox</td>
+      <td rowspan='2'>Feb 2, 2023</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10</td>
@@ -99,6 +103,7 @@ You can run `saucectl` locally via Docker ([Installation Requirements](https://d
       <td rowspan='1'>1.17.1</td>
       <td><b>Windows:</b> 10</td>
       <td>Chromium, Firefox, Webkit</td>
+      <td>Nov 29, 2022</td>
     </tr>
     </tbody>
   </table>

--- a/docs/web-apps/automated-testing/testcafe.md
+++ b/docs/web-apps/automated-testing/testcafe.md
@@ -61,12 +61,14 @@ Sauce Labs supports the following test configurations for TestCafe:
       <th>TestCafe Version</th>
       <th>Supported Platforms</th>
       <th>Supported Browsers</th>
+      <th>End of Life</th>
     </tr>
     <tbody>
     <tr>
       <td rowspan='3'>1.19.0</td>
       <td><b>macOS:</b> 11.00, 12</td>
       <td>Safari, Chrome, Firefox, MicrosoftEdge</td>
+      <td rowspan='3'>Jun 6, 2023</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10, 11</td>
@@ -82,6 +84,7 @@ Sauce Labs supports the following test configurations for TestCafe:
       <td rowspan='3'>1.18.5</td>
       <td><b>macOS:</b> 11.00, 12</td>
       <td>Safari, Chrome, Firefox, MicrosoftEdge</td>
+      <td rowspan='3'>Apr 16, 2023</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10, 11</td>
@@ -97,6 +100,7 @@ Sauce Labs supports the following test configurations for TestCafe:
       <td rowspan='3'>1.18.3</td>
       <td><b>macOS:</b> 11.00</td>
       <td>Safari, Chrome, Firefox, MicrosoftEdge</td>
+      <td rowspan='3'>Feb 2, 2023</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10</td>
@@ -112,6 +116,7 @@ Sauce Labs supports the following test configurations for TestCafe:
       <td rowspan='3'>1.17.1</td>
       <td><b>macOS:</b> 11.00</td>
       <td>Safari, Chrome, Firefox, MicrosoftEdge</td>
+      <td rowspan='3'>Nov 29, 2022</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10</td>
@@ -127,6 +132,7 @@ Sauce Labs supports the following test configurations for TestCafe:
       <td rowspan='3'>1.16.1</td>
       <td><b>macOS:</b> 11.00</td>
       <td>Safari, Chrome, Firefox, MicrosoftEdge</td>
+      <td rowspan='3'>Oct 13, 2022</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10</td>


### PR DESCRIPTION
### Description
Document the end of life for each runner release.

Also add the currently known limitation around cypress + firefox 101 + windows.