### PR TITLE
Add `--compressed` flag for curl used to download assets

### DIFF
--- a/docs/dev/api/jobs.md
+++ b/docs/dev/api/jobs.md
@@ -826,7 +826,7 @@ values={[
 <TabItem value="us">
 
 ```jsx title="Sample Request"
-curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location --compressed \
 --request GET 'https://api.us-west-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets/performance.json' | json_pp
 ```
 
@@ -835,7 +835,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 <TabItem value="eu">
 
 ```jsx title="Sample Request"
-curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location --compressed \
 --request GET 'https://api.eu-central-1.saucelabs.com/rest/v1/nancy.sweeney/jobs/bc3d1dbd96fd4479925f2afa8efbc090/assets/performance.json' | json_pp
 ```
 


### PR DESCRIPTION
Some assets might be compressed on s3, running curl on them will result in
compressed file downloaded.

### Description
`--compressed` flag enables automatic decompression of returned response if `Content-Encoding: gzip` is present in the response. Currently all network.har files are compressed on s3, without this flag curl writes compressed data to output file. The flag has no effect on uncompressed assets.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Clients expect uncompressed asset content.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
