### PR TITLE
Added new devicelock capability

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -443,6 +443,26 @@ For virtual device mobile tests, the capability is `deviceOrientation`, but for 
 ```
 
 ---
+
+
+---
+### `setupDeviceLock`
+<p><small>| BOOLEAN | <span className="sauceDBlue">Real Devices Only</span> |</small></p>
+
+Sets up the device pin code for the automated test session.  Valid values are `true` and `false`.
+By defining this capability in your Appium test, we are setting up the device for you in a state your application need to be successfully launched. 
+
+:::important
+The `setupDeviceLock` capability helps to bypass the Security requirements from your applications, like pincode requirements for launching and app or invoking certain activities/features within your app. Example: https://developer.android.com/reference/android/app/KeyguardManager 
+:::
+
+```java title="Real Device Setting"
+"setupDeviceLock": "true"
+```
+
+---
+
+
 ### `otherApps`
 <p><small>| ARRAY | <span className="sauceDBlue">Real Devices Only</span> |</small></p>
 

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -450,7 +450,7 @@ For virtual device mobile tests, the capability is `deviceOrientation`, but for 
 <p><small>| BOOLEAN | <span className="sauceDBlue">Real Devices Only</span> |</small></p>
 
 Sets up the device pin code for the automated test session. Valid values are `true` and `false`.
-By defining this capability in your Appium test, we are setting up the device for you in a state your application need to be successfully launched. 
+This capability sets your device in the state required for your application to launch successfully. 
 
 :::important
 The `setupDeviceLock` capability helps to bypass the Security requirements from your applications, like pincode requirements for launching and app or invoking certain activities/features within your app. Example: https://developer.android.com/reference/android/app/KeyguardManager 

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -449,7 +449,7 @@ For virtual device mobile tests, the capability is `deviceOrientation`, but for 
 ### `setupDeviceLock`
 <p><small>| BOOLEAN | <span className="sauceDBlue">Real Devices Only</span> |</small></p>
 
-Sets up the device pin code for the automated test session.  Valid values are `true` and `false`.
+Sets up the device pin code for the automated test session. Valid values are `true` and `false`.
 By defining this capability in your Appium test, we are setting up the device for you in a state your application need to be successfully launched. 
 
 :::important


### PR DESCRIPTION
new RDC feature capability documentation:



### Description
Exposing to customer the new setupDeviceLock capability.
Implemented in https://saucedev.atlassian.net/browse/MRE-423. 


### Motivation and Context
We have customer apps which requires devices to be setup with pincodes/certain security levels. 
We are gonna restrict the ability to setup pincodes manually in the settings app, so we are exposing a new capability called setupDeviceLock, where Saucelabs is setting up the device lock for the customers, so we can easily remove it.

### Types of changes
- [ ] New feature (non-breaking change which adds functionality)

