### PR TITLE
Adding tunnel server wildcard in the PAC file

### DIFF
--- a/docs/secure-connections/sauce-connect/setup-configuration/additional-proxies.md
+++ b/docs/secure-connections/sauce-connect/setup-configuration/additional-proxies.md
@@ -253,7 +253,7 @@ The Charles Proxy is useful for monitoring traffic passing between your Sauce VM
 4. Create a pac.js file for Sauce Connect Proxy:
   ```java
   function FindProxyForURL(url, host) {
-      if (shExpMatch(host, "*.miso.saucelabs.com") ||
+      if (shExpMatch(host, "*.miso.saucelabs.com*") ||
           shExpMatch(host, "*.saucelabs.com") ||
           shExpMatch(host, "saucelabs.com")) {
           // KGP and REST connections. Another proxy can also be specified.
@@ -296,7 +296,7 @@ If `curl -v --proxy external.proxy.com private.mysite.com` does not get a respon
 ```javascript title="multiproxy proxy.pac"
 function FindProxyForURL(url, host) {
     // Sauce domain calls required to start a tunnel
-    if (shExpMatch(host, "*.miso.saucelabs.com") ||
+    if (shExpMatch(host, "*.miso.saucelabs.com*") ||
         shExpMatch(host, "*.saucelabs.com") ||
         shExpMatch(host, "saucelabs.com")) {
         // Send the required Sauce Traffic


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Sauce Connect v4.8.0 uses host:port representation of the tunnel server. For example: `maki698.miso.saucelabs.com:443`.

In older versions, SC used `maki698.miso.saucelabs.com` without including the port.

As it turns out, it breaks PAC file's directive. Adding a wildcard to the matching condition fixes the issue.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
