### PR TITLE
NPM Dependency Description

### DIFF
--- a/docs/dev/cli/saucectl/usage/use-cases.md
+++ b/docs/dev/cli/saucectl/usage/use-cases.md
@@ -288,3 +288,15 @@ npm:
     "@babel/preset-typescript": "7.12"
     "@cypress/react": "^5.0.1"
 ```
+
+Alternatively, you can let `saucectl` selectively include already installed dependencies from the `node_modules` folder.
+
+```jsx title= "config.yml npm dependencies"
+npm:
+  dependencies:
+    - lodash
+```
+
+:::caution
+This feature is highly experimental.
+:::


### PR DESCRIPTION
### Description
Add missing note in the use case section of the saucectl CLI. This experimental feature is already described in the framework specific config pages, like https://docs.saucelabs.com/web-apps/automated-testing/cypress/advanced/#set-npm-packages-in-configyml