### PR TITLE
Mention that screenResolution is unreliable on Windows 7

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -276,7 +276,7 @@ Enables Performance Capture feature. Sauce Performance Testing can be enabled by
 Specifies the screen resolution to be used during your test session. Default screen resolution for Sauce tests is `1024x768`.
 
 :::note
-You cannot set screen resolution on Windows 7 with IE 9. Setting screen resolution for other browsers on Windows 7 is also unreliable. To define screen resolution, define a newer platform e.g. "Windows 10"
+You cannot set screen resolution on Windows 7 with IE 9. Setting screen resolution for other browsers on Windows 7 is also unreliable. To specify a screen resolution, define a newer platform e.g. "Windows 10"
 
 :::
 

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -276,7 +276,7 @@ Enables Performance Capture feature. Sauce Performance Testing can be enabled by
 Specifies the screen resolution to be used during your test session. Default screen resolution for Sauce tests is `1024x768`.
 
 :::note
-You cannot set screen resolution on Windows 7 with IE 9.
+You cannot set screen resolution on Windows 7 with IE 9. Setting screen resolution for other browsers on Windows 7 is also unreliable. To define screen resolution, define a newer platform e.g. "Windows 10"
 
 :::
 


### PR DESCRIPTION
### Description
According to Sauce labs support there is a "bug for the screenResolution issue" on Windows 7, which is the default platform

### Motivation and Context
Mentioning this would have saved us some hours or days of head scratching and debugging

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
- [X] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
