### PR TITLE
Add tunnelName and tunnelOwner to test configuration options

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -773,15 +773,13 @@ See [Using Tunnel Names](/secure-connections/sauce-connect/setup-configuration/b
 
 ---
 ### `tunnelIdentifier`
-<p><small>| STRING |</small></p>
+<p><small>| STRING | <span className="sauceGold">DEPRECATED</span> |</small></p>
+
+Specify a [Sauce Connect tunnel name](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names) to establish connectivity with a Sauce Labs test platform. This is an alias for [tunnelName](#tunnelname).
 
 :::caution Deprecation notice
 `tunnelIdentifier` is being deprecated in favor of `tunnelName`.
 :::
-
-
-Specify a [Sauce Connect tunnel name](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names) to establish connectivity with a Sauce Labs test platform. This is alias for [tunnelName](#tunnelname).
-
 
 :::note Choose the Correct Tunnel Identifier
 The value expected here is the value shown under the **Tunnel Name** column on the Sauce Labs Tunnels page, _not_ the **Tunnel ID** numerical value.
@@ -810,13 +808,13 @@ If the [tunnelName](#tunnelname) (or [tunnelIdentifier](#tunnelidentifier)) you'
 
 ---
 ### `parentTunnel`
-<p><small>| STRING |</small></p>
+<p><small>| STRING | <span className="sauceGold">DEPRECATED</span> |</small></p>
+
+If the [tunnelName](#tunnelname) (or [tunnelIdentifier](#tunnelidentifier)) you've specified to establish connectivity with a Sauce Labs test platform is a shared tunnel, and you are _not_ the user who created the tunnel, you must identify the Sauce Labs user who did create the tunnel in order to use it for your test. This is an alias for [tunnelOwner](#tunnelowner).
 
 :::caution Deprecation notice
 `parentTunnel` is being deprecated in favor of `tunnelOwner`.
 :::
-
-If the [tunnelName](#tunnelname) (or [tunnelIdentifier](#tunnelidentifier)) you've specified to establish connectivity with a Sauce Labs test platform is a shared tunnel, and you are _not_ the user who created the tunnel, you must identify the Sauce Labs user who did create the tunnel in order to use it for your test. This is alias for [tunnelOwner](#tunnelowner).
 
 ```java
 "tunnelName": "MyTeamSharedTunnel"

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -199,7 +199,7 @@ Edge Driver is based on Chrome Driver, so the same caveats from [chromedriverVer
 
 ---
 ### `geckodriverVersion`
-<p><small>| STRING |</small></p>   
+<p><small>| STRING |</small></p>
 
 Specifies the Firefox GeckoDriver version. The default geckodriver version varies based on the version of Firefox specified. For a list of geckodriver versions and the Firefox versions they support, see [geckodriver Supported Platforms](https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html).
 
@@ -755,9 +755,8 @@ Available visibility modes are:
 "public": "team"
 ```
 
-
 ---
-### `tunnelIdentifier`
+### `tunnelName`
 <p><small>| STRING |</small></p>
 
 Specify a [Sauce Connect](/secure-connections/sauce-connect) tunnel to establish connectivity with a Sauce Labs test platform. Tunnels allow you to test an application that is behind a firewall or on your local machine by providing a secure connection to the Sauce Labs platform.
@@ -769,28 +768,65 @@ The value expected here is the value shown under the **Tunnel Name** column on t
 See [Using Tunnel Names](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names) for more information.
 
 ```java
+"tunnelName": "MyTunnel01"
+```
+
+---
+### `tunnelIdentifier`
+<p><small>| STRING |</small></p>
+
+:::caution Deprecation notice
+`tunnelIdentifier` is being deprecated in favor of `tunnelName`.
+:::
+
+
+Specify a [Sauce Connect](/secure-connections/sauce-connect) tunnel to establish connectivity with a Sauce Labs test platform. This is alias for [tunnelName](#tunnelname).
+
+
+:::note Choose the Correct Tunnel Identifier
+The value expected here is the value shown under the **Tunnel Name** column on the Sauce Labs Tunnels page, _not_ the **Tunnel ID** numerical value.
+:::
+
+See [Using Tunnel Names](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names) for more information.
+
+```java
 "tunnelIdentifier": "MyTunnel01"
 ```
 
-:::caution Breaking Change
+:::warning Breaking Change
 Appium tests for the Real Device Cloud using the W3C protocol MUST use `tunnelName` instead of `tunnelIdentifier`.
 :::
 
 ---
-### `parentTunnel`  
+### `tunnelOwner`
 <p><small>| STRING |</small></p>
 
-If the [tunnelIdentifier](#tunnelidentifier) you've specified to establish connectivity with a Sauce Labs test platform is a shared tunnel, and you are _not_ the user who created the tunnel, you must identify the Sauce Labs user who did create the tunnel in order to use it for your test.
+If the [tunnelName](#tunnelname) (or [tunnelIdentifier](#tunnelidentifier)) you've specified to establish connectivity with a Sauce Labs test platform is a shared tunnel, and you are _not_ the user who created the tunnel, you must identify the Sauce Labs user who did create the tunnel in order to use it for your test.
 
 ```java
-"tunnelIdentifier": "MyTeamSharedTunnel"
+"tunnelName": "MyTeamSharedTunnel"
+"tunnelOwner": "<username of tunnel originator>"
+```
+
+---
+### `parentTunnel`
+<p><small>| STRING |</small></p>
+
+:::caution Deprecation notice
+`parentTunnel` is being deprecated in favor of `tunnelOwner`.
+:::
+
+If the [tunnelName](#tunnelname) (or [tunnelIdentifier](#tunnelidentifier)) you've specified to establish connectivity with a Sauce Labs test platform is a shared tunnel, and you are _not_ the user who created the tunnel, you must identify the Sauce Labs user who did create the tunnel in order to use it for your test. This is alias for [tunnelOwner](#tunnelowner).
+
+```java
+"tunnelName": "MyTeamSharedTunnel"
 "parentTunnel": "<username of tunnel originator>"
 ```
 
-:::warning
-BREAKING CHANGE
-Appium tests for the Real Device Cloud using the W3C protocol MUST use tunnelOwner instead of parentTunnel.
+:::warning Breaking Change
+Appium tests for the Real Device Cloud using the W3C protocol MUST use `tunnelOwner` instead of `parentTunnel`.
 :::
+
 
 ---
 ### `recordVideo`

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -759,7 +759,7 @@ Available visibility modes are:
 ### `tunnelName`
 <p><small>| STRING |</small></p>
 
-Specify a [Sauce Connect](/secure-connections/sauce-connect) tunnel to establish connectivity with a Sauce Labs test platform. Tunnels allow you to test an application that is behind a firewall or on your local machine by providing a secure connection to the Sauce Labs platform.
+Specify a [Sauce Connect tunnel name](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names) to establish connectivity with a Sauce Labs test platform.
 
 :::note Choose the Correct Tunnel Identifier
 The value expected here is the value shown under the **Tunnel Name** column on the Sauce Labs Tunnels page, _not_ the **Tunnel ID** numerical value.

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -780,7 +780,7 @@ See [Using Tunnel Names](/secure-connections/sauce-connect/setup-configuration/b
 :::
 
 
-Specify a [Sauce Connect](/secure-connections/sauce-connect) tunnel to establish connectivity with a Sauce Labs test platform. This is alias for [tunnelName](#tunnelname).
+Specify a [Sauce Connect tunnel name](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names) to establish connectivity with a Sauce Labs test platform. This is alias for [tunnelName](#tunnelname).
 
 
 :::note Choose the Correct Tunnel Identifier


### PR DESCRIPTION
### Description

The current documentation does not mention `tunnelName` and `tunnelOwner` test configuration options
which were introduced months ago as a replacement for `tunnelIdentifier`
and `parentTunnel`, respectively. this change adds these new options
and also adds a note that the old options are being deprecated.

CC @waggledans 

### Motivation and Context
This change is required so one reading the documentation is actually informed about the new `tunnelName` and `tunnelOwner` options.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
