### PR TITLE
Renaming tunnelIdentifier to tunnelName in SC examples

### DIFF
--- a/docs/dev/cli/sauce-connect-proxy.md
+++ b/docs/dev/cli/sauce-connect-proxy.md
@@ -91,7 +91,7 @@ __Shorthand__: `-s`
 
 __Description__: Assigns a name to a Sauce Connect Proxy tunnel. It can also assign a name to a group of tunnels in the same [High Availability pool](/secure-connections/sauce-connect/setup-configuration/high-availability), when used with [`--tunnel-pool`](#--tunnel-pool). Must be in ASCII format.
 
-You can run tests using this tunnel by specifying the [`tunnelIdentifier`](/dev/test-configuration-options/#tunnelidentifier) or `tunnelName` in your test capabilities. To learn about the syntax for setting this as a capability, see [Test Configuration Options](/dev/test-configuration-options).<br/>
+You can run tests using this tunnel by specifying the [`tunnelName`](/dev/test-configuration-options/#tunnelname) in your test capabilities. To learn about the syntax for setting this as a capability, see [Test Configuration Options](/dev/test-configuration-options).<br/>
 __Enviroment variable__: `SAUCE_TUNNEL_IDENTIFIER`<br/>
 __Shorthand__: `-i`
 
@@ -105,7 +105,7 @@ This value populates the **Tunnel Name** field on the Sauce Labs Tunnels page, _
 
 __Description__: Assigns a name to a Sauce Connect Proxy tunnel. It can also assign a name to a group of tunnels in the same [High Availability pool](/secure-connections/sauce-connect/setup-configuration/high-availability), when used with [`--tunnel-pool`](#--tunnel-pool). Must be in ASCII format.
 
-You can run tests using this tunnel by specifying the [`tunnelIdentifier`](/dev/test-configuration-options/#tunnelidentifier) or `tunnelName` in your test capabilities. To learn about the syntax for setting this as a capability, see [Test Configuration Options](/dev/test-configuration-options).<br/>
+You can run tests using this tunnel by specifying the [`tunnelName`](/dev/test-configuration-options/#tunnelname) in your test capabilities. To learn about the syntax for setting this as a capability, see [Test Configuration Options](/dev/test-configuration-options).<br/>
 __Enviroment variable__: `SAUCE_TUNNEL_NAME`<br/>
 __Shorthand__: n/a
 

--- a/docs/dev/glossary.md
+++ b/docs/dev/glossary.md
@@ -624,7 +624,7 @@ See: [Tunnel Name](#tunnel-name)
 
 ### Tunnel Name
 
-The Sauce Connect Proxy test configuration option that allows you to assign a name to your tunnel(s), giving you more control and monitoring capability over the tunnel. If you launch a tunnel without naming it, your test traffic will default to running through that unnamed tunnel. More information: [Using Sauce Connect Tunnel Identifiers](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names).
+The Sauce Connect Proxy test configuration option that allows you to assign a name to your tunnel(s), giving you more control and monitoring capability over the tunnel. If you launch a tunnel without naming it, your test traffic will default to running through that unnamed tunnel. More information: [Using Tunnel Names](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names).
 
 See also: _[colliding tunnels](#colliding-tunnels)_.
 

--- a/docs/dev/glossary.md
+++ b/docs/dev/glossary.md
@@ -619,7 +619,7 @@ See also: _[sauce connect proxy](#sauce-connect-proxy)._
 
 ### Tunnel Identifier
 
-The Sauce Connect Proxy test configuration option that allows you to assign a name to your tunnel(s), giving you more control and monitoring capability over the tunnel. If you launch a tunnel without naming it, your test traffic will default to running through that unnamed tunnel. More information: [Using Sauce Connect Tunnel Names](/secure-connections/sauce-connect/setup-configuration/basic-setup#using-tunnel-names).
+See: [Tunnel Name](#tunnel-name)
 
 See also: _[colliding tunnels](#colliding-tunnels)_.
 

--- a/docs/dev/glossary.md
+++ b/docs/dev/glossary.md
@@ -619,7 +619,7 @@ See also: _[sauce connect proxy](#sauce-connect-proxy)._
 
 ### Tunnel Identifier
 
-The Sauce Connect Proxy test configuration option that allows you to assign a name to your tunnel(s), giving you more control and monitoring capability over the tunnel. If you launch a tunnel without naming it, your test traffic will default to running through that unnamed tunnel. More information: [Using Sauce Connect Tunnel Identifiers](/secure-connections/sauce-connect/setup-configuration/basic-setup#using-tunnel-identifiers).
+The Sauce Connect Proxy test configuration option that allows you to assign a name to your tunnel(s), giving you more control and monitoring capability over the tunnel. If you launch a tunnel without naming it, your test traffic will default to running through that unnamed tunnel. More information: [Using Sauce Connect Tunnel Names](/secure-connections/sauce-connect/setup-configuration/basic-setup#using-tunnel-names).
 
 See also: _[colliding tunnels](#colliding-tunnels)_.
 

--- a/docs/dev/glossary.md
+++ b/docs/dev/glossary.md
@@ -621,11 +621,12 @@ See also: _[sauce connect proxy](#sauce-connect-proxy)._
 
 See: [Tunnel Name](#tunnel-name)
 
-See also: _[colliding tunnels](#colliding-tunnels)_.
 
 ### Tunnel Name
 
-See: [Tunnel Identifier](#tunnel-identifier)
+The Sauce Connect Proxy test configuration option that allows you to assign a name to your tunnel(s), giving you more control and monitoring capability over the tunnel. If you launch a tunnel without naming it, your test traffic will default to running through that unnamed tunnel. More information: [Using Sauce Connect Tunnel Identifiers](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names).
+
+See also: _[colliding tunnels](#colliding-tunnels)_.
 
 
 ### Tunnel Pool

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -199,7 +199,7 @@ Edge Driver is based on Chrome Driver, so the same caveats from [chromedriverVer
 
 ---
 ### `geckodriverVersion`
-<p><small>| STRING |</small></p>   
+<p><small>| STRING |</small></p>
 
 Specifies the Firefox GeckoDriver version. The default geckodriver version varies based on the version of Firefox specified. For a list of geckodriver versions and the Firefox versions they support, see [geckodriver Supported Platforms](https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html).
 
@@ -755,12 +755,31 @@ Available visibility modes are:
 "public": "team"
 ```
 
+---
+### `tunnelName`
+<p><small>| STRING |</small></p>
+
+Specify a [Sauce Connect tunnel name](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names) to establish connectivity with a Sauce Labs test platform.
+
+:::note Choose the Correct Tunnel Identifier
+The value expected here is the value shown under the **Tunnel Name** column on the Sauce Labs Tunnels page, _not_ the **Tunnel ID** numerical value.
+:::
+
+See [Using Tunnel Names](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names) for more information.
+
+```java
+"tunnelName": "MyTunnel01"
+```
 
 ---
 ### `tunnelIdentifier`
-<p><small>| STRING |</small></p>
+<p><small>| STRING | <span className="sauceGold">DEPRECATED</span> |</small></p>
 
-Specify a [Sauce Connect](/secure-connections/sauce-connect) tunnel to establish connectivity with a Sauce Labs test platform. Tunnels allow you to test an application that is behind a firewall or on your local machine by providing a secure connection to the Sauce Labs platform.
+Specify a [Sauce Connect tunnel name](/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names) to establish connectivity with a Sauce Labs test platform. This is an alias for [tunnelName](#tunnelname).
+
+:::caution Deprecation notice
+`tunnelIdentifier` is being deprecated in favor of `tunnelName`.
+:::
 
 :::note Choose the Correct Tunnel Identifier
 The value expected here is the value shown under the **Tunnel Name** column on the Sauce Labs Tunnels page, _not_ the **Tunnel ID** numerical value.
@@ -772,25 +791,40 @@ See [Using Tunnel Names](/secure-connections/sauce-connect/setup-configuration/b
 "tunnelIdentifier": "MyTunnel01"
 ```
 
-:::caution Breaking Change
+:::warning Breaking Change
 Appium tests for the Real Device Cloud using the W3C protocol MUST use `tunnelName` instead of `tunnelIdentifier`.
 :::
 
 ---
-### `parentTunnel`  
+### `tunnelOwner`
 <p><small>| STRING |</small></p>
 
-If the [tunnelIdentifier](#tunnelidentifier) you've specified to establish connectivity with a Sauce Labs test platform is a shared tunnel, and you are _not_ the user who created the tunnel, you must identify the Sauce Labs user who did create the tunnel in order to use it for your test.
+If the [tunnelName](#tunnelname) (or [tunnelIdentifier](#tunnelidentifier)) you've specified to establish connectivity with a Sauce Labs test platform is a shared tunnel, and you are _not_ the user who created the tunnel, you must identify the Sauce Labs user who did create the tunnel in order to use it for your test.
 
 ```java
-"tunnelIdentifier": "MyTeamSharedTunnel"
+"tunnelName": "MyTeamSharedTunnel"
+"tunnelOwner": "<username of tunnel originator>"
+```
+
+---
+### `parentTunnel`
+<p><small>| STRING | <span className="sauceGold">DEPRECATED</span> |</small></p>
+
+If the [tunnelName](#tunnelname) (or [tunnelIdentifier](#tunnelidentifier)) you've specified to establish connectivity with a Sauce Labs test platform is a shared tunnel, and you are _not_ the user who created the tunnel, you must identify the Sauce Labs user who did create the tunnel in order to use it for your test. This is an alias for [tunnelOwner](#tunnelowner).
+
+:::caution Deprecation notice
+`parentTunnel` is being deprecated in favor of `tunnelOwner`.
+:::
+
+```java
+"tunnelName": "MyTeamSharedTunnel"
 "parentTunnel": "<username of tunnel originator>"
 ```
 
-:::warning
-BREAKING CHANGE
-Appium tests for the Real Device Cloud using the W3C protocol MUST use tunnelOwner instead of parentTunnel.
+:::warning Breaking Change
+Appium tests for the Real Device Cloud using the W3C protocol MUST use `tunnelOwner` instead of `parentTunnel`.
 :::
+
 
 ---
 ### `recordVideo`

--- a/docs/secure-connections/ipsec-vpn.md
+++ b/docs/secure-connections/ipsec-vpn.md
@@ -119,11 +119,11 @@ Depending on the type of framework you're using and the device you're testing on
 #### Appium and Selenium Frameworks
 In your test script, you'll need to:
 1. Specify the [data center endpoint](/basics/data-center-endpoints) location of the device you're testing on. See the [Sauce Labs Training Repo](https://github.com/saucelabs-training) for examples in JavaScript, Java, Python, Ruby, and C#.
-2. Use the `tunnelIdentifier` capability to specify the name of your organization's Sauce IPSec Proxy tunnel, and then set the `parentTunnel` capability to the Sauce Labs username of your organization admin.
+2. Use the [`tunnelName`](/dev/test-configuration-options#tunnelName) capability to specify the name of your organization's Sauce IPSec Proxy tunnel, and then set the [`tunnelOwner`](/dev/test-configuration-options#tunnelOwner) capability to the Sauce Labs username of your organization admin.
   ```java title="Java example"
   MutableCapabilities caps = new MutableCapabilities();
-  caps.setCapability("tunnelIdentifier", "$TUNNEL_IDENTIFIER");
-  caps.setCapability("parentTunnel","$SAUCE_USERNAME");
+  caps.setCapability("tunnelName", "$TUNNEL_IDENTIFIER");
+  caps.setCapability("tunnelOwner","$SAUCE_USERNAME");
   ```
 
 #### Espresso and XCUITest Frameworks

--- a/docs/secure-connections/sauce-connect/setup-configuration/basic-setup.md
+++ b/docs/secure-connections/sauce-connect/setup-configuration/basic-setup.md
@@ -66,24 +66,24 @@ See [Sauce Connect Proxy Quickstart](/secure-connections/sauce-connect/quickstar
    <TabItem value="Mac/Linux">
 
    ```bash
-   ./sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --region $SAUCE_DC --tunnel-identifier $TUNNEL_IDENTIFIER
+   ./sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --region $SAUCE_DC --tunnel-name $TUNNEL_IDENTIFIER
    ```
 
    </TabItem>
    <TabItem value="Windows">
 
    ```bash
-   .\sc.exe -u %SAUCE_USERNAME% -k %SAUCE_ACCESS_KEY% --region %SAUCE_DC% --tunnel-identifier $TUNNEL_IDENTIFIER
+   .\sc.exe -u %SAUCE_USERNAME% -k %SAUCE_ACCESS_KEY% --region %SAUCE_DC% --tunnel-name $TUNNEL_IDENTIFIER
    ```
 
    </TabItem>
    </Tabs>
 
-   [`-u (--user)`](/dev/cli/sauce-connect-proxy/#--user) and [`-k (--api-key)`](/dev/cli/sauce-connect-proxy/#--api-key) are required. While the [`-r` (`--region`)](/dev/cli/sauce-connect-proxy/#--region) and [`--tunnel-identifier`](/dev/cli/sauce-connect-proxy/#--tunnel-identifier) flags are technically not required, we strongly recommend them for best performance.
+   [`-u (--user)`](/dev/cli/sauce-connect-proxy/#--user) and [`-k (--api-key)`](/dev/cli/sauce-connect-proxy/#--api-key) are required. While the [`-r` (`--region`)](/dev/cli/sauce-connect-proxy/#--region) and [`--tunnel-name`](/dev/cli/sauce-connect-proxy/#--tunnel-name) flags are technically not required, we strongly recommend them for best performance.
 3. Select an appropriate test script. Options might include:
    * An existing test, if available.
    * Create a new test using an example from [Sauce Labs Demonstration Scripts](https://github.com/saucelabs-training). Follow those instructions to configure the test before proceeding to the next step.
-4. If you are using a name for your tunnel, add the [`TUNNEL_IDENTIFIER`](/dev/test-configuration-options/#tunnelIdentifier) to the capabilities section of your test script. Use the same name you used in Step 1.
+4. If you are using a name for your tunnel, add the [`TUNNEL_NAME`](/dev/test-configuration-options/#tunnelName) to the capabilities section of your test script. Use the same name you used in Step 1.
 
 <Tabs
   defaultValue="Java"
@@ -98,7 +98,7 @@ See [Sauce Connect Proxy Quickstart](/secure-connections/sauce-connect/quickstar
 <TabItem value="Java">
 
 ```java
-caps.SetCapability("tunnelIdentifier", "TUNNEL_IDENTIFIER");
+caps.SetCapability("tunnelName", "TUNNEL_NAME");
 ```
 
 </TabItem>
@@ -106,7 +106,7 @@ caps.SetCapability("tunnelIdentifier", "TUNNEL_IDENTIFIER");
 <TabItem value="Node.js">
 
 ```javascript
-'tunnelIdentifier': 'TUNNEL_IDENTIFIER'
+'tunnelName': 'TUNNEL_IDENTIFIER'
 ```
 
 </TabItem>
@@ -114,7 +114,7 @@ caps.SetCapability("tunnelIdentifier", "TUNNEL_IDENTIFIER");
 <TabItem value="C#">
 
 ```csharp
-caps.SetCapability("tunnelIdentifier", "TUNNEL_IDENTIFIER");
+caps.SetCapability("tunnelName", "TUNNEL_NAME");
 ```
 
 </TabItem>
@@ -122,7 +122,7 @@ caps.SetCapability("tunnelIdentifier", "TUNNEL_IDENTIFIER");
 <TabItem value="Python">
 
 ```py
-'tunnelIdentifier': 'TUNNEL_IDENTIFIER'
+'tunnelName': 'TUNNEL_NAME'
 ```
 
 </TabItem>
@@ -130,7 +130,7 @@ caps.SetCapability("tunnelIdentifier", "TUNNEL_IDENTIFIER");
 <TabItem value="Ruby">
 
 ```rb
-'tunnelIdentifier': 'TUNNEL_IDENTIFIER'
+'tunnelName': 'TUNNEL_NAME'
 ```
 
 </TabItem>
@@ -158,14 +158,14 @@ For troubleshooting specific errors or common issues, see [Troubleshooting](/sec
 When launching a Sauce Connect Proxy tunnel for automated web and mobile app tests, you have two options:
 * Launch a Sauce Connect tunnel as-is, without naming it. That default, unnamed tunnel will automatically be used for all automated tests. This can be useful for small organizations with a limited number of tests.
 * **Recommended**: Assign a name to help distinguish tunnels in a way that is meaningful to your organization. To accomplish this:
-  * Use the [ `--tunnel-identifier` flag](/dev/cli/sauce-connect-proxy/#--tunnel-identifier-or---tunnel-identifier) when you launch a tunnel.
-  * Specify the named tunnel in your automated tests by adding the [`tunnelIdentifier`](/dev/test-configuration-options#tunnelIdentifier) capability.
+  * Use the [ `--tunnel-name` flag](/dev/cli/sauce-connect-proxy/#--tunnel-name) when you launch a tunnel.
+  * Specify the named tunnel in your automated tests by adding the [`tunnelName`](/dev/test-configuration-options#tunnelName) capability.
 
 #### Example Configurations
 
 The following code samples demonstrate specifying a tunnel name when launching a tunnel and then referencing that tunnel in your automated test.
 
-Launch a new tunnel on the `SC_HOST` using the [Sauce Connect Proxy CLI](/dev/cli/sauce-connect-proxy) and the `--tunnel-identifier` flag:
+Launch a new tunnel on the `SC_HOST` using the [Sauce Connect Proxy CLI](/dev/cli/sauce-connect-proxy) and the `--tunnel-name` flag:
 
 <Tabs
   defaultValue="macOS/Linux"
@@ -177,7 +177,7 @@ Launch a new tunnel on the `SC_HOST` using the [Sauce Connect Proxy CLI](/dev/cl
 <TabItem value="macOS/Linux">
 
 ```bash
-./sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -r $SAUCE_DC --tunnel-identifier sc-proxy-tunnel
+./sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -r $SAUCE_DC --tunnel-name sc-proxy-tunnel
 ```
 
 </TabItem>
@@ -185,7 +185,7 @@ Launch a new tunnel on the `SC_HOST` using the [Sauce Connect Proxy CLI](/dev/cl
 <TabItem value="Windows">
 
 ```bash
-.\sc.exe -u %SAUCE_USERNAME% -k %SAUCE_ACCESS_KEY% -r %SAUCE_DC% --tunnel-identifier sc-proxy-tunnel
+.\sc.exe -u %SAUCE_USERNAME% -k %SAUCE_ACCESS_KEY% -r %SAUCE_DC% --tunnel-name sc-proxy-tunnel
 ```
 
 </TabItem>
@@ -193,7 +193,7 @@ Launch a new tunnel on the `SC_HOST` using the [Sauce Connect Proxy CLI](/dev/cl
 
 * Ensure that your network configuration allows for communication between the `SC Host`, the Tunnel VM, and the SUT (site under test). See the basic network configuration diagram for further explanation.
 * Select an example from [Sauce Labs Demonstration Scripts](https://github.com/saucelabs-training) and follow the instructions to configure the test in your dev environment.
-* Navigate to the desired test script and add the [`tunnelIdentifier`](/dev/test-configuration-options#tunnelIdentifier) capability to your [`sauce:options`](/dev/w3c-webdriver-capabilities).
+* Navigate to the desired test script and add the [`tunnelName`](/dev/test-configuration-options#tunnelName) capability to your [`sauce:options`](/dev/w3c-webdriver-capabilities).
 
 <Tabs
   defaultValue="Java"
@@ -208,7 +208,7 @@ Launch a new tunnel on the `SC_HOST` using the [Sauce Connect Proxy CLI](/dev/cl
 <TabItem value="Java">
 
 ```java
-caps.SetCapability("tunnelIdentifier", "sc-proxy-tunnel");
+caps.SetCapability("tunnelName", "sc-proxy-tunnel");
 ```
 
 </TabItem>
@@ -216,7 +216,7 @@ caps.SetCapability("tunnelIdentifier", "sc-proxy-tunnel");
 <TabItem value="Node.js">
 
 ```js
-'tunnelIdentifier': 'sc-proxy-tunnel'
+'tunnelName': 'sc-proxy-tunnel'
 ```
 
 </TabItem>
@@ -224,7 +224,7 @@ caps.SetCapability("tunnelIdentifier", "sc-proxy-tunnel");
 <TabItem value="C#">
 
 ```csharp
-caps.SetCapability("tunnelIdentifier", "sc-proxy-tunnel");
+caps.SetCapability("tunnelName", "sc-proxy-tunnel");
 ```
 
 </TabItem>
@@ -232,7 +232,7 @@ caps.SetCapability("tunnelIdentifier", "sc-proxy-tunnel");
 <TabItem value="Python">
 
 ```py
-'tunnelIdentifier': 'sc-proxy-tunnel'
+'tunnelName': 'sc-proxy-tunnel'
 ```
 
 </TabItem>
@@ -240,7 +240,7 @@ caps.SetCapability("tunnelIdentifier", "sc-proxy-tunnel");
 <TabItem value="Ruby">
 
 ```rb
-tunnelIdentifier: 'sc-proxy-tunnel',
+tunnelName: 'sc-proxy-tunnel',
 ```
 
 </TabItem>

--- a/docs/secure-connections/sauce-connect/setup-configuration/high-availability.md
+++ b/docs/secure-connections/sauce-connect/setup-configuration/high-availability.md
@@ -45,9 +45,9 @@ Exclusive to our HA Sauce Connect Proxy Setup, you can launch multiple tunnels a
 
 #### Launching Tunnel Pools
 
-* In your test script configuration, provide the name of the Sauce Connect Proxy tunnel by using the [`tunnelIdentifier`](/secure-connections/sauce-connect/setup-configuration/basic-setup#using-tunnel-identifiers) capability:
+* In your test script configuration, provide the name of the Sauce Connect Proxy tunnel by using the [`tunnelName`](/secure-connections/sauce-connect/setup-configuration/basic-setup#using-tunnel-names) capability:
   ```java
-  "tunnelIdentifier": "tunnel_name_here"
+  "tunnelName": "tunnel_name_here"
   ```
 * In your CLI, tunnels in the individual pools need to be started with both the [`--tunnel-identifier`](/dev/cli/sauce-connect-proxy#--tunnel-identifier) and [`--tunnel-pool`](/dev/cli/sauce-connect-proxy#--tunnel-pool) flags.
   ```bash

--- a/docs/secure-connections/sauce-connect/setup-configuration/specialized-environments.md
+++ b/docs/secure-connections/sauce-connect/setup-configuration/specialized-environments.md
@@ -47,17 +47,17 @@ While rare, there are some test cases that will require you to disable SSL Bumpi
 ### Selecting the Tunnel to Use
 Sauce Connect Proxy can have multiple tunnels running simultaneously, as described in [High Availability Setup](/secure-connections/sauce-connect/setup-configuration/high-availability). You can select which tunnel to use in a real device test in the same way as you would any other type of automated test.
 
-1. Start Sauce Command Proxy from the command line, using the [`-u (--user)`](/dev/cli/sauce-connect-proxy/#--user), [`-k (--api-key)`](/dev/cli/sauce-connect-proxy/#--api-key), [`-r (--region`)](/dev/cli/sauce-connect-proxy/#--region), and [`--tunnel-identifier`](/dev/cli/sauce-connect-proxy/#--tunnel-identifier) flags.
+1. Start Sauce Command Proxy from the command line, using the [`-u (--user)`](/dev/cli/sauce-connect-proxy/#--user), [`-k (--api-key)`](/dev/cli/sauce-connect-proxy/#--api-key), [`-r (--region`)](/dev/cli/sauce-connect-proxy/#--region), and [`--tunnel-name`](/dev/cli/sauce-connect-proxy/#--tunnel-name) flags.
   ```bash
-  ./sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -r $SAUCE_DATA_CENTER --tunnel-identifier $TUNNEL_IDENTIFIER
+  ./sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -r $SAUCE_DATA_CENTER --tunnel-name $TUNNEL_IDENTIFIER
   ```
 
   In this example, we'll [set our credentials (username/access key) as environment variables](/secure-connections/sauce-connect/setup-configuration/environment-variables/), start a tunnel in US West Data Center and name the tunnel `rdc-on-sauce-tunnel-us`.
   ```bash
-  ./sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -r us-west --tunnel-identifier rdc-on-sauce-tunnel-us
+  ./sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -r us-west --tunnel-name rdc-on-sauce-tunnel-us
   ```
 
-2. In your device testing script, specify the tunnel name with `tunnelIdentifier` in your capabilities, as shown in this Java example:
+2. In your device testing script, specify the tunnel name with `tunnelName` in your capabilities, as shown in this Java example:
 
 ```java
 final DesiredCapabilities capabilities = new DesiredCapabilities();
@@ -66,7 +66,7 @@ final DesiredCapabilities capabilities = new DesiredCapabilities();
     capabilities.setCapability("platformName", "Android");
     capabilities.setCapability("platformVersion,"  "81.0");
     capabilities.setCapability("deviceName", "Samsung_Galaxy_Note_5_real"); // Will only run on the specified device
-    capabilities.setCapability("tunnelIdentifier", "rdc-on-sauce-tunnel-us");
+    capabilities.setCapability("tunnelName", "rdc-on-sauce-tunnel-us");
 final AndroidDriver driver = new AndroidDriver(new URL("https://ondemand.us-west-1.saucelabs.com/wd/hub"), capabilities);
 ```
 


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Following https://github.com/saucelabs/sauce-docs/pull/1414.

SC CLI flag `--tunnel-name` is fully supported in SC versions 4.7.x/4.8.x and the corresponding capability `tunnelName` is supported by all Sauce Labs testing platforms. Those are preferred options. This MR updates code snippets in all docs from `--tunnel-identifier` to `--tunnel-name` and, also, most of tunnelIdentifier/parentTunnel in test capabilities examples.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
