### PR TITLE
there is no app-storage in us-east | TPT-107

### DIFF
--- a/docs/mobile-apps/app-storage.md
+++ b/docs/mobile-apps/app-storage.md
@@ -44,7 +44,6 @@ groupId="dc-url"
 defaultValue="usw"
 values={[
 {label: 'US West', value: 'usw'},
-{label: 'US East', value: 'use'},
 {label: 'Europe', value: 'eu'},
 ]}>
 
@@ -53,16 +52,6 @@ values={[
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 --request POST 'https://api.us-west-1.saucelabs.com/v1/storage/upload' \
---form 'payload=@"<path/to/your/file>"' \
---form 'name="<filename.ext>"'
-```
-
-</TabItem>
-<TabItem value="use">
-
-```jsx title="Sample Request"
-curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request POST 'https://api.us-east-1.saucelabs.com/v1/storage/upload' \
 --form 'payload=@"<path/to/your/file>"' \
 --form 'name="<filename.ext>"'
 ```


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->


<!--- Provide a general summary of your changes in the Title above -->

### Description
https://docs.saucelabs.com/mobile-apps/app-storage/#considerations

- drop invlid US-EAST instructions (no app-storage in us-east)
- plus EOL on us-east to-be-confirmed ~soon

### Motivation and Context
I noticed this while working on storage service monitoring. 

Also see 
- [TPT-107](https://saucedev.atlassian.net/browse/TPT-107)
- [slack](https://saucelabs.slack.com/archives/CEJNAEWP6/p1665603659742349)

```sh
curl -v -u "lukmdo:X" --location \
--request POST 'https://api.us-east-1.saucelabs.com/v1/storage/upload' \
--form 'payload=@"./ok.txt"' \
--form 'name="ok.txt"'

HTTP/1.1 404 Not Found
date: Wed, 12 Oct 2022 19:36:58 GMT
server: envoy
connection: close
content-length: 0
```
> 
VS
```sh
curl -v -u "lukmdo:X" --location \
--request POST 'https://api.eu-central-1.saucelabs.com/v1/storage/upload' \
--form 'payload=@"./ok.txt"' \
--form 'name="ok.txt"'

### OK/expected as not valid auth

HTTP/1.1 401 Unauthorized
cache-control: no-cache
strict-transport-security: max-age=63072000; includeSubDomains
www-authenticate: Basic realm="SauceLabs"
content-length: 33
content-type: text/plain
date: Wed, 12 Oct 2022 19:37:50 GMT
server: envoy
 
{"detail":"Authorization failed"}
```
 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
