### PR TITLE
Document inverse sauceignore rules

### DIFF
--- a/docs/dev/cli/saucectl/usage/use-cases.md
+++ b/docs/dev/cli/saucectl/usage/use-cases.md
@@ -233,7 +233,7 @@ Sometimes it's easier to do the inverse: Including files for the bundle.
 !cypress.config.js
 
 # Since the whole '/cypress' folder is now included, this would also include any
-# subdirectories that potentially contain auto generated test artifacts from
+# subdirectories that potentially contain auto-generated test artifacts from
 # the local dev environment.
 # It'd be wasteful to include them in the payload, so let's ignore those subfolders.
 /cypress/videos/

--- a/docs/dev/cli/saucectl/usage/use-cases.md
+++ b/docs/dev/cli/saucectl/usage/use-cases.md
@@ -221,6 +221,26 @@ node_modules/
 credentials.yml
 ```
 
+Sometimes it's easier to do the inverse: Including files for the bundle.
+
+```bash
+# Ignore all files by default.
+/*
+
+# Re-include files we selectively want as part of the payload by prefixing the lines with '!'.
+!/node_modules
+!/cypress
+!cypress.config.js
+
+# Since the whole '/cypress' folder is now included, this would also include any
+# subdirectories that potentially contain auto generated test artifacts from
+# the local dev environment.
+# It'd be wasteful to include them in the payload, so let's ignore those subfolders.
+/cypress/videos/
+/cypress/results/
+/cypress/screenshots/
+```
+
 ### Including Node Dependencies
 
 The default `.sauceignore` file lists `node_modules/` so locally installed node dependencies are excluded from the bundle. If your tests require node dependencies to run, you can either:

--- a/docs/web-apps/automated-testing/_partials/_advanced.md
+++ b/docs/web-apps/automated-testing/_partials/_advanced.md
@@ -64,7 +64,7 @@ Sometimes it's easier to do the inverse: Including files for the bundle.
 !cypress.config.js
 
 # Since the whole '/cypress' folder is now included, this would also include any
-# subdirectories that potentially contain auto generated test artifacts from
+# subdirectories that potentially contain auto-generated test artifacts from
 # the local dev environment.
 # It'd be wasteful to include them in the payload, so let's ignore those subfolders.
 /cypress/videos/

--- a/docs/web-apps/automated-testing/_partials/_advanced.md
+++ b/docs/web-apps/automated-testing/_partials/_advanced.md
@@ -52,6 +52,26 @@ node_modules/
 credentials.yml
 ```
 
+Sometimes it's easier to do the inverse: Including files for the bundle.
+
+```bash
+# Ignore all files by default.
+/*
+
+# Re-include files we selectively want as part of the payload by prefixing the lines with '!'.
+!/node_modules
+!/cypress
+!cypress.config.js
+
+# Since the whole '/cypress' folder is now included, this would also include any
+# subdirectories that potentially contain auto generated test artifacts from
+# the local dev environment.
+# It'd be wasteful to include them in the payload, so let's ignore those subfolders.
+/cypress/videos/
+/cypress/results/
+/cypress/screenshots/
+```
+
 ### Including Node Dependencies
 
 The default `.sauceignore` file lists `node_modules/` so locally installed node dependencies are excluded from the bundle. If your tests require node dependencies to run, you can either:

--- a/docs/web-apps/automated-testing/puppeteer/yaml.md
+++ b/docs/web-apps/automated-testing/puppeteer/yaml.md
@@ -669,16 +669,13 @@ Sometimes it's easier to do the inverse: Including files for the bundle.
 
 # Re-include files we selectively want as part of the payload by prefixing the lines with '!'.
 !/node_modules
-!/cypress
-!cypress.config.js
+!/tests
 
-# Since the whole '/cypress' folder is now included, this would also include any
+# Since the whole '/tests' folder is now included, this would also include any
 # subdirectories that potentially contain auto generated test artifacts from
 # the local dev environment.
 # It'd be wasteful to include them in the payload, so let's ignore those subfolders.
-/cypress/videos/
-/cypress/results/
-/cypress/screenshots/
+/tests/results/
 ```
 
 #### Including Node Dependencies

--- a/docs/web-apps/automated-testing/puppeteer/yaml.md
+++ b/docs/web-apps/automated-testing/puppeteer/yaml.md
@@ -672,7 +672,7 @@ Sometimes it's easier to do the inverse: Including files for the bundle.
 !/tests
 
 # Since the whole '/tests' folder is now included, this would also include any
-# subdirectories that potentially contain auto generated test artifacts from
+# subdirectories that potentially contain auto-generated test artifacts from
 # the local dev environment.
 # It'd be wasteful to include them in the payload, so let's ignore those subfolders.
 /tests/results/

--- a/docs/web-apps/automated-testing/puppeteer/yaml.md
+++ b/docs/web-apps/automated-testing/puppeteer/yaml.md
@@ -661,6 +661,26 @@ node_modules/
 credentials.yml
 ```
 
+Sometimes it's easier to do the inverse: Including files for the bundle.
+
+```bash
+# Ignore all files by default.
+/*
+
+# Re-include files we selectively want as part of the payload by prefixing the lines with '!'.
+!/node_modules
+!/cypress
+!cypress.config.js
+
+# Since the whole '/cypress' folder is now included, this would also include any
+# subdirectories that potentially contain auto generated test artifacts from
+# the local dev environment.
+# It'd be wasteful to include them in the payload, so let's ignore those subfolders.
+/cypress/videos/
+/cypress/results/
+/cypress/screenshots/
+```
+
 #### Including Node Dependencies
 
 The default `.sauceignore` file lists `node_modules/` so locally installed node dependencies are excluded from the bundle. If your tests require node dependencies to run, you can either:


### PR DESCRIPTION
### Description

When a user has a large repo (e.g. monorepo), it may be easier to specifically specify which files _should_ be included in the payload bundle by using the inverse ruleset of sauceignore (same behavior as gitignore).