### PR TITLE
Add correct label to mobile capability

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -803,7 +803,7 @@ capabilities.setCapability("sauce:options", sauceOptions);
 ---
 
 ### `setupDeviceLock`
-<p><small>| OPTIONAL | BOOLEAN | <span className="sauceDBlue">Real Devices Only</span> |</small></p>
+<p><small>| OPTIONAL | BOOLEAN | <span className="sauceDBlue">Real Devices Only</span> | <span className="sauceDBlue">Android only</span> |</small></p>
 
 Sets up the device pin code for the automated test session. Valid values are `true` and `false`.
 This capability sets your device in the state required for your application to launch successfully.


### PR DESCRIPTION
The pincode cap didn't had the "Android only" label