### PR TITLE
feat: add appium 2.0 migration guide

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -751,7 +751,7 @@ Optional, Sauce-specific capabilities that you can use in your Appium tests. The
 Specifies the Appium driver version you want to use. For most use cases, setting the `appiumVersion` is unnecessary because Sauce Labs defaults to the version that supports the broadest number of device combinations. Sauce Labs advises against setting this property unless you need to test a particular Appium feature or patch.
 
 :::note
-If you want to use Appium 2.0, see the [Migration Guide](/dev/test-configurations/appium/migrating-to-appium-2) for more information, you need to provide the value `2.0.0`.
+If you want to use Appium 2.0, see the [Migration Guide](/dev/test-configurations/appium/migrating-to-appium-2).
 :::
 
 ```java

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -751,7 +751,7 @@ Optional, Sauce-specific capabilities that you can use in your Appium tests. The
 Specifies the Appium driver version you want to use. For most use cases, setting the `appiumVersion` is unnecessary because Sauce Labs defaults to the version that supports the broadest number of device combinations. Sauce Labs advises against setting this property unless you need to test a particular Appium feature or patch.
 
 :::note
-If you want to use Appium 2.0, see the [Migration Guide](/dev/test-configurations/appium/migrating-to-appium-2).
+If you want to use Appium 2.0, see the [Migration Guide](/mobile-apps/automated-testing/appium/appium-2-migration/).
 :::
 
 ```java

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -751,7 +751,7 @@ Optional, Sauce-specific capabilities that you can use in your Appium tests. The
 Specifies the Appium driver version you want to use. For most use cases, setting the `appiumVersion` is unnecessary because Sauce Labs defaults to the version that supports the broadest number of device combinations. Sauce Labs advises against setting this property unless you need to test a particular Appium feature or patch.
 
 :::note
-Sauce Labs waits a week following new Appium releases before setting them as the default version to provide time to verify compatibility with your tests. You can find version details in the [Appium release notes](https://github.com/appium/appium/releases).
+If you want to use Appium 2.0, see the [Migration Guide](/dev/test-configurations/appium/migrating-to-appium-2) for more information, you need to provide the value `2.0.0`.
 :::
 
 ```java

--- a/docs/mobile-apps/automated-testing/appium.md
+++ b/docs/mobile-apps/automated-testing/appium.md
@@ -9,6 +9,12 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::warning Appium 1 End-of-life
+The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. All recent versions of officially supported platform drivers are not compatible to Appium 1.x anymore, and require Appium 2 to run.
+
+For more information on migrating to Appium 2, see [Migrating to Appium 2](/mobile-apps/automated-testing/appium/appium-migration). For more information on installing Appium 2, see [Installing Appium 2](https://appium.github.io/appium/docs/en/2.0/quickstart/install/).
+:::
+
 Looking to incorporate Appium in your mobile testing strategy? This page can help you understand the system architecture and installation requirements.
 
 [Appium](http://appium.io/) is an automation testing framework that allows you to write tests using the [Selenium](https://www.selenium.dev) syntax that are for use in testing native, mobile web, and hybrid apps on iOS and Android devices. Run your Appium tests on Sauce Labs to benefit from speed, parallelization, clear test result history, failure analysis, issue tracking, and more.

--- a/docs/mobile-apps/automated-testing/appium.md
+++ b/docs/mobile-apps/automated-testing/appium.md
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 :::warning Appium 1 End of Life
-The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. All recent versions of officially supported platform drivers are not compatible to Appium 1.x anymore, and require Appium 2 to run.
+The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. Recent versions of all officially supported platform drivers are no longer compatible with  Appium 1.x, and require Appium 2 to run.
 
 For more information on migrating to Appium 2, see [Migrating to Appium 2](/mobile-apps/automated-testing/appium/appium-2-migration). For more information on installing Appium 2, see [Installing Appium 2](https://appium.github.io/appium/docs/en/2.0/quickstart/install/).
 :::

--- a/docs/mobile-apps/automated-testing/appium.md
+++ b/docs/mobile-apps/automated-testing/appium.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::warning Appium 1 End-of-life
+:::warning Appium 1 End of Life
 The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. All recent versions of officially supported platform drivers are not compatible to Appium 1.x anymore, and require Appium 2 to run.
 
 For more information on migrating to Appium 2, see [Migrating to Appium 2](/mobile-apps/automated-testing/appium/appium-2-migration). For more information on installing Appium 2, see [Installing Appium 2](https://appium.github.io/appium/docs/en/2.0/quickstart/install/).

--- a/docs/mobile-apps/automated-testing/appium.md
+++ b/docs/mobile-apps/automated-testing/appium.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 :::warning Appium 1 End-of-life
 The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. All recent versions of officially supported platform drivers are not compatible to Appium 1.x anymore, and require Appium 2 to run.
 
-For more information on migrating to Appium 2, see [Migrating to Appium 2](/mobile-apps/automated-testing/appium/appium-migration). For more information on installing Appium 2, see [Installing Appium 2](https://appium.github.io/appium/docs/en/2.0/quickstart/install/).
+For more information on migrating to Appium 2, see [Migrating to Appium 2](/mobile-apps/automated-testing/appium/appium-2-migration). For more information on installing Appium 2, see [Installing Appium 2](https://appium.github.io/appium/docs/en/2.0/quickstart/install/).
 :::
 
 Looking to incorporate Appium in your mobile testing strategy? This page can help you understand the system architecture and installation requirements.

--- a/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. Recent versions of all officially supported platform drivers are no longer compatible with  Appium 1.x, and require Appium 2 to run.
 :::
 
-Appium 2.0 is the most major new release of Appium in the last years. The changes in Appium 2.0 are not primarily related to changes in automation behaviors for specific platforms. Instead, Appium 2.0 re-envisions Appium as a platform where "drivers" (code projects that introduce support for automation of a given platform) and "plugins" (code projects that allow for overriding, altering, extending, or adding behaviors to Appium) can be easily created and shared.
+The changes in Appium 2.0 are not primarily related to changes in automation behaviors for specific platforms. Instead, Appium 2.0 re-envisions Appium as a platform where "drivers" (code projects that introduce support for automation of a given platform) and "plugins" (code projects that allow for overriding, altering, extending, or adding behaviors to Appium) can be easily created and shared.
 
 At the same time, the Appium project is taking the opportunity to remove many old and deprecated bits of functionality. More information about this can be found in the [Appium 2.0 release notes](https://github.com/appium/appium/releases).
 

--- a/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
@@ -33,7 +33,7 @@ Up until Appium 2.0, Appium supported both protocols, so that older Selenium/App
 
 ### Appium capabilities
 
-One significant difference between old and new protocols is in the format of capabilities. Previously called "desired capabilities", and now called simply "capabilities", there is now a requirement for a so-called "vendor prefix" on any non-standard capabilities. The list of standard capabilities is given in the [WebDriver Protocol spec](https://www.w3.org/TR/webdriver/#capabilities), and includes a few commonly used capabilities such as browserName and platformName.
+One significant difference between old and new protocols is in the format of capabilities. Previously called "desired capabilities", and now called simply "capabilities", there is now a requirement for a so-called "vendor prefix" on any non-standard capabilities. The list of standard capabilities is given in the [WebDriver Protocol spec](https://www.w3.org/TR/webdriver/#capabilities), and includes a few commonly used capabilities such as [`browserName`](/dev/test-configuration-options/#browsername-1) and [`platformName`](/dev/test-configuration-options/#platformname-1).
 
 These standard capabilities continue to be used as-is. All other capabilities must include a "vendor prefix" in their name. A vendor prefix is a string followed by a colon, such as `appium:`. Most of Appium's capabilities go beyond the standard W3C capabilities and must therefore include vendor prefixes (we recommend that you use `appium:` unless directed otherwise by documentation). For example:
 

--- a/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 :::warning Appium 1 End-of-life
-The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. All recent versions of officially supported platform drivers are not compatible to Appium 1.x anymore, and require Appium 2 to run.
+The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. Recent versions of all officially supported platform drivers are no longer compatible with  Appium 1.x, and require Appium 2 to run.
 :::
 
 Appium 2.0 is the most major new release of Appium in the last years. The changes in Appium 2.0 are not primarily related to changes in automation behaviors for specific platforms. Instead, Appium 2.0 re-envisions Appium as a platform where "drivers" (code projects that introduce support for automation of a given platform) and "plugins" (code projects that allow for overriding, altering, extending, or adding behaviors to Appium) can be easily created and shared.

--- a/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
@@ -87,7 +87,7 @@ As mentioned above, the following breaking changes lead to using the following c
 
 ### Capabilities
 
-Below you can find an example of a capabilities object for running a test on Sauce Labs with Appium 2.0. The examples are created for Real Devices, for Virtual device we advice you to check out our [Platform Configurator](https://saucelabs.com/platform/platform-configurator#/).
+Below you can find an example of a capabilities object for running a test on Sauce Labs with Appium 2.0. The examples are created for Real Devices, for Virtual Devices we advise you to use our [Platform Configurator](https://saucelabs.com/platform/platform-configurator#/).
 
 <Tabs
 groupId="capability-ex"

--- a/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
@@ -89,47 +89,6 @@ As mentioned above, the following breaking changes lead to using the following c
 
 Below you can find an example of a capabilities object for running a test on Sauce Labs with Appium 2.0. The examples are created for Real Devices, for Virtual device we advice you to check out our [Platform Configurator](https://saucelabs.com/platform/platform-configurator#/).
 
-```json title="Android"
-{
-  "sauce:options": {
-    "appiumVersion": "2.0.0",
-    "deviceName": "Google Pixel 3 GoogleAPI Emulator",
-    "deviceOrientation": "portrait",
-    "platformVersion": "10.0",
-    "platformName": "Android",
-    "app": "sauce-storage:myapp.apk",
-    "automationName": "UiAutomator2"
-  }
-}
-```
-
-```json title="iOS"
-{
-  "sauce:options": {
-    "appiumVersion": "2.0.0",
-    "deviceName": "iPhone 11 Simulator",
-    "deviceOrientation": "portrait",
-    "platformVersion": "13.3",
-    "platformName": "iOS",
-    "app": "sauce-storage:myapp.ipa",
-    "automationName": "XCUITest"
-  }
-}
-```
-
-```json title="Capabilities for Appium 2.0"
-{
-  "sauce:options": {
-    "appiumVersion": "2.0.0",
-    "deviceName": "iPhone 11 Simulator",
-    "deviceOrientation": "portrait",
-    "platformVersion": "14.0",
-    "platformName": "iOS",
-    "app": "sauce-storage:myapp.zip"
-  }
-}
-```
-
 <Tabs
 groupId="capability-ex"
 defaultValue="java"

--- a/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
@@ -1,7 +1,7 @@
 ---
 id: appium-2-migration
 title: Migrating to Appium 2.0 on Sauce Labs
-sidebar_label: Appium 2 Migration
+sidebar_label: Appium 2.0 Migration
 description: Learn how to migrate you Appium 1 tests to Appium 2 on Sauce Labs.
 ---
 

--- a/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
@@ -87,7 +87,7 @@ As mentioned above, the following breaking changes lead to using the following c
 
 ### Capabilities
 
-Below you can find an example of a capabilities object for running a test on Sauce Labs with Appium 2.0. The examples are created for Real Devices, for Virtual Devices we advise you to use our [Platform Configurator](https://saucelabs.com/platform/platform-configurator#/).
+Below you can find an example of a capabilities object for running a test on Sauce Labs with Appium 2.0. The examples are created for Real Devices, for Virtual Devices you can use our [Platform Configurator](https://saucelabs.com/platform/platform-configurator#/).
 
 <Tabs
 groupId="capability-ex"

--- a/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
@@ -1,0 +1,407 @@
+---
+id: appium-2-migration
+title: Migrating to Appium 2.0 on Sauce Labs
+sidebar_label: Appium 2 Migration
+description: Learn how to migrate you Appium 1 tests to Appium 2 on Sauce Labs.
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+:::warning Appium 1 End-of-life
+The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. All recent versions of officially supported platform drivers are not compatible to Appium 1.x anymore, and require Appium 2 to run.
+:::
+
+Appium 2.0 is the most major new release of Appium in the last years. The changes in Appium 2.0 are not primarily related to changes in automation behaviors for specific platforms. Instead, Appium 2.0 re-envisions Appium as a platform where "drivers" (code projects that introduce support for automation of a given platform) and "plugins" (code projects that allow for overriding, altering, extending, or adding behaviors to Appium) can be easily created and shared.
+
+At the same time, the Appium project is taking the opportunity to remove many old and deprecated bits of functionality. More information about this can be found in the [Appium 2.0 release notes](https://github.com/appium/appium/releases).
+
+:::tip Appium 2.0 Documentation
+Appium is in the final stages of a major revision (to version 2.0). As such, the documentation found around the web may not be correct. The current Appium 2.0 documentation is very much in progress. Currently, it can be found [here](https://appium.github.io/appium/docs/en/2.0/).
+:::
+
+## Breaking Changes
+
+Before you get started with migrating your Appium 1 tests to Appium 2, you should have a look a the [Appium 2.0 release notes](https://github.com/appium/appium/releases). The breaking changes that are listed below are only a subset of the changes that are listed in the release notes, but also have an impact on running your tests on Sauce Labs.
+
+### Protocol changes
+
+Appium's API is based on the [W3C WebDriver Protocol](https://www.w3.org/TR/webdriver/), and it has supported this protocol for years. Before the W3C WebDriver Protocol was designed as a web standard, several other protocols were used for both Selenium and Appium. These protocols were the "JSONWP" (JSON Wire Protocol) and "MJSONWP" (Mobile JSON Wire Protocol). The W3C Protocol differs from the (M)JSONWP protocols in a few small ways.
+
+Up until Appium 2.0, Appium supported both protocols, so that older Selenium/Appium clients could still communicate with newer Appium servers. Moving forward, support for older protocols will be removed.
+
+### Appium capabilities
+
+One significant difference between old and new protocols is in the format of capabilities. Previously called "desired capabilities", and now called simply "capabilities", there is now a requirement for a so-called "vendor prefix" on any non-standard capabilities. The list of standard capabilities is given in the [WebDriver Protocol spec](https://www.w3.org/TR/webdriver/#capabilities), and includes a few commonly used capabilities such as browserName and platformName.
+
+These standard capabilities continue to be used as-is. All other capabilities must include a "vendor prefix" in their name. A vendor prefix is a string followed by a colon, such as `appium:`. Most of Appium's capabilities go beyond the standard W3C capabilities and must therefore include vendor prefixes (we recommend that you use `appium:` unless directed otherwise by documentation). For example:
+
+- `appium:app`
+- `appium:noReset`
+- `appium:deviceName`
+
+More information about the Appium Capabilities can be found [here](https://appium.github.io/appium/docs/en/2.0/guides/caps/).
+
+:::caution Warning
+Sauce Labs does not support the `appium:options` object value as a replacement for the repetitive `appium:`-prefix yet. Instead, you should use the `appium:` prefix for each capability.
+:::
+
+### `automationName` is now required
+
+Appium 1 automatically used the "default" automation backend for the platform being automated. For example, for iOS, Appium 1 would use the `XCUITest` automation backend unless otherwise specified. For Android, Appium 1 would use the `UiAutomator2` automation backend unless otherwise specified.
+
+Appium 2 does not have a default automation backend. Instead, the automation backend must be specified explicitly using the `automationName` capability. For example, to use the `XCUITest` automation backend for iOS, you would set the `appium:automationName` capability to `XCUITest`. For Android, you would set the `appium:automationName` capability to `UiAutomator2`.
+
+### Sauce Labs specific capabilities
+
+All Sauce Labs specific capabilities need to be put into a single object value which is called `sauce:options`. The Sauce Labs specific capabilities are can be found [here](/dev/test-configuration-options/#mobile-app-appium-capabilities-sauce-specific--optional)
+
+:::note Important
+To run your tests with Appium 2.0 you need to set the `appiumVersion` capability in your `sauce:options` object to `2.0.0`, see also [Appium Version](/dev/test-configuration-options/#appiumversion).
+:::
+
+### Driver-specific automation commands
+
+The definition of certain commands that pertain only to specific drivers has been moved to those drivers' implementations. For example, `pressKeyCode` is specific to the [`UiAutomator2` driver](https://github.com/appium/appium-uiautomator2-driver) and is now understood only by that driver.
+
+In practice, the only breaking change here is the kind of error you would encounter if the appropriate driver is not installed. Previously, you would get a `501 Not Yet Implemented error` if using a driver that didn't implement the command. Now, you will get a `404 Not Found` error because if a driver that doesn't know about the command is not active, the main Appium server will not define the route corresponding to the command
+
+## Getting started with Appium 2.0 on Sauce Labs
+
+:::caution Appium 2.0 progress on Sauce Labs
+Sauce Labs is currently in the process of implementing Appium 2.0 into our Virtual and Real Device cloud. We are working hard to make Appium 2.0 available for all our customers as soon as possible. Please check back here for updates.
+
+| Cloud           | Status                                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------ |
+| Real Devices    | Available, see [supported drivers](#supported-drivers) for all available drivers           |
+| Virtual Devices | Partially available, see [supported drivers](#supported-drivers) for all available drivers |
+
+:::
+
+As mentioned above, the following breaking changes lead to using the following capabilities:
+
+- [W3C capabilities](#appium-capabilities)
+- [Required `automationName`](#automationname-is-now-required)
+- [Sauce Labs specific capabilities](#sauce-labs-specific-capabilities)
+
+### Capabilities
+
+Below you can find an example of a capabilities object for running a test on Sauce Labs with Appium 2.0. The examples are created for Real Devices, for Virtual device we advice you to check out our [Platform Configurator](https://saucelabs.com/platform/platform-configurator#/).
+
+```json title="Android"
+{
+  "sauce:options": {
+    "appiumVersion": "2.0.0",
+    "deviceName": "Google Pixel 3 GoogleAPI Emulator",
+    "deviceOrientation": "portrait",
+    "platformVersion": "10.0",
+    "platformName": "Android",
+    "app": "sauce-storage:myapp.apk",
+    "automationName": "UiAutomator2"
+  }
+}
+```
+
+```json title="iOS"
+{
+  "sauce:options": {
+    "appiumVersion": "2.0.0",
+    "deviceName": "iPhone 11 Simulator",
+    "deviceOrientation": "portrait",
+    "platformVersion": "13.3",
+    "platformName": "iOS",
+    "app": "sauce-storage:myapp.ipa",
+    "automationName": "XCUITest"
+  }
+}
+```
+
+```json title="Capabilities for Appium 2.0"
+{
+  "sauce:options": {
+    "appiumVersion": "2.0.0",
+    "deviceName": "iPhone 11 Simulator",
+    "deviceOrientation": "portrait",
+    "platformVersion": "14.0",
+    "platformName": "iOS",
+    "app": "sauce-storage:myapp.zip"
+  }
+}
+```
+
+<Tabs
+groupId="capability-ex"
+defaultValue="java"
+values={[
+{label: 'Java', value: 'java'},
+{label: 'Node.js', value: 'js'},
+{label: 'Python', value: 'python'},
+{label: 'Ruby', value: 'ruby'},
+{label: 'C#', value: 'csharp'},
+]}>
+
+<TabItem value="java">
+<Tabs
+groupId="capability-java"
+defaultValue="android"
+values={[
+{label: 'Android', value: 'android'},
+{label: 'iOS', value: 'ios'},
+]}>
+<TabItem value="android">
+
+```java
+DesiredCapabilities capabilities = new DesiredCapabilities();
+
+capabilities.setCapability("platformName", "android");
+// W3C Protocol is mandatory for Appium 2.0
+capabilities.setCapability("appium:platformVersion", "12");
+capabilities.setCapability("appium:deviceName", "Google Pixel 6");
+// automationName for Appium 2.0
+capabilities.setCapability("appium:automationName", "UiAutomator2");
+
+HashMap<String, Object> sauceOptions = new HashMap<String, Object>();
+// appiumVersion is mandatory to use Appium 2.0 on Sauce Labs
+sauceOptions.put("appiumVersion", "2.0.0");
+capabilities.setCapability("sauce:options", sauceOptions);
+```
+
+</TabItem>
+<TabItem value="ios">
+
+```java
+DesiredCapabilities capabilities = new DesiredCapabilities();
+
+capabilities.setCapability("platformName", "ios");
+// W3C Protocol is mandatory for Appium 2.0
+capabilities.setCapability("appium:platformVersion", "16");
+capabilities.setCapability("appium:deviceName", "iPhone 14");
+// automationName for Appium 2.0
+capabilities.setCapability("appium:automationName", "XCUITest");
+
+HashMap<String, Object> sauceOptions = new HashMap<String, Object>();
+// appiumVersion is mandatory to use Appium 2.0 on Sauce Labs
+sauceOptions.put("appiumVersion", "2.0.0");
+capabilities.setCapability("sauce:options", sauceOptions);
+```
+
+</TabItem>
+</Tabs>
+</TabItem>
+<TabItem value="js">
+
+<Tabs
+groupId="capability-js"
+defaultValue="android"
+values={[
+{label: 'Android', value: 'android'},
+{label: 'iOS', value: 'ios'},
+]}>
+<TabItem value="android">
+
+```js
+const capabilities = {
+  platformName: 'android',
+  // W3C Protocol is mandatory for Appium 2.0
+  'appium:platformVersion': '12',
+  'appium:deviceName': 'Google Pixel 6',
+  // automationName for Appium 2.0
+  'appium:automationName': 'UiAutomator2',
+  'sauce:options': {
+    // appiumVersion is mandatory to use Appium 2.0 on Sauce Labs
+    appiumVersion: '2.0.0',
+  },
+};
+```
+
+</TabItem>
+<TabItem value="ios">
+
+```js
+const capabilities = {
+  platformName: 'ios',
+  // W3C Protocol is mandatory for Appium 2.0
+  'appium:platformVersion': '16',
+  'appium:deviceName': 'iPhone 14',
+  // automationName for Appium 2.0
+  'appium:automationName': 'XCUITest',
+  'sauce:options': {
+    // appiumVersion is mandatory to use Appium 2.0 on Sauce Labs
+    appiumVersion: '2.0.0',
+  },
+};
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="python">
+
+<Tabs
+groupId="capability-python"
+defaultValue="android"
+values={[
+{label: 'Android', value: 'android'},
+{label: 'iOS', value: 'ios'},
+]}>
+<TabItem value="android">
+
+```py
+capabilities = {
+    "platformName" : "android",
+    # W3C Protocol is mandatory for Appium 2.0
+    "appium:platformVersion" : "12",
+    "appium:deviceName" : "Google Pixel 6",
+    # automationName for Appium 2.0
+    'appium:automationName': 'UiAutomator2',
+    "sauce:options" : {
+        # appiumVersion is mandatory to use Appium 2.0 on Sauce Labs
+        "appiumVersion" : "2.0.0"
+    }
+}
+```
+
+</TabItem>
+<TabItem value="ios">
+
+```py
+capabilities = {
+    "platformName" : "ios",
+    # W3C Protocol is mandatory for Appium 2.0
+    "appium:platformVersion" : "16",
+    "appium:deviceName" : "iPhone 14",
+    # automationName for Appium 2.0
+    'appium:automationName': 'XCUItest',
+    "sauce:options" : {
+        # appiumVersion is mandatory to use Appium 2.0 on Sauce Labs
+        "appiumVersion" : "2.0.0"
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="ruby">
+
+<Tabs
+groupId="capability-ruby"
+defaultValue="android"
+values={[
+{label: 'Android', value: 'android'},
+{label: 'iOS', value: 'ios'},
+]}>
+<TabItem value="android">
+
+```ruby
+capabilities = {
+    "platformName" => "android",
+    # W3C Protocol is mandatory for Appium 2.0
+    "appium:platformVersion" => "12",
+    "appium:deviceName" => "Google Pixel 6",
+    # automationName for Appium 2.0
+    'appium:automationName'=> 'UiAutomator2',
+    "sauce:options" => {
+        # appiumVersion is mandatory to use Appium 2.0 on Sauce Labs
+        "appiumVersion" => "2.0.0"
+    }
+}
+```
+
+</TabItem>
+<TabItem value="ios">
+
+```ruby
+capabilities = {
+    "platformName" => "ios",
+    # W3C Protocol is mandatory for Appium 2.0
+    "appium:platformVersion" => "16",
+    "appium:deviceName" => "iPhone 14",
+    # automationName for Appium 2.0
+    'appium:automationName'=> 'XCUItest',
+    "sauce:options" => {
+        # appiumVersion is mandatory to use Appium 2.0 on Sauce Labs
+        "appiumVersion" => "2.0.0"
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="csharp">
+
+<Tabs
+groupId="capability-csharp"
+defaultValue="android"
+values={[
+{label: 'Android', value: 'android'},
+{label: 'iOS', value: 'ios'},
+]}>
+<TabItem value="android">
+
+```csharp
+AppiumOptions capabilities = new AppiumOptions();
+
+capabilities.AddAdditionalCapability("platformName", "android");
+// W3C Protocol is mandatory for Appium 2.0
+capabilities.AddAdditionalCapability("appium:platformVersion", "12");
+capabilities.AddAdditionalCapability("appium:deviceName", "Google Pixel 6");
+// automationName for Appium 2.0
+capabilities.AddAdditionalCapability("appium:automationName", "UiAutomator2");
+
+HashMap<String, Object> sauceOptions = new Dictionary<string, object>();
+// appiumVersion is mandatory to use Appium 2.0 on Sauce Labs
+sauceOptions.Add("appiumVersion", "2.0.0");
+capabilities.AddAdditionalCapability("sauce:options", sauceOptions);
+```
+
+</TabItem>
+<TabItem value="ios">
+
+```csharp
+AppiumOptions capabilities = new AppiumOptions();
+
+capabilities.AddAdditionalCapability("platformName", "ios");
+// W3C Protocol is mandatory for Appium 2.0
+capabilities.AddAdditionalCapability("appium:platformVersion", "16");
+capabilities.AddAdditionalCapability("appium:deviceName", "iPhone 14");
+// automationName for Appium 2.0
+capabilities.AddAdditionalCapability("appium:automationName", "XCUITest");
+
+HashMap<String, Object> sauceOptions = new Dictionary<string, object>();
+// appiumVersion is mandatory to use Appium 2.0 on Sauce Labs
+sauceOptions.Add("appiumVersion", "2.0.0");
+capabilities.AddAdditionalCapability("sauce:options", sauceOptions);
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>
+
+### Supported Drivers
+
+The following drivers are supported by Sauce Labs
+
+| Platform | Driver                                                               | Supported                                                                                                                                      |
+| -------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Android  | [UiAutomator2](https://github.com/appium/appium-uiautomator2-driver) | <span className="sauceDBlue">Real Devices Only</span>, Virtual Devices only support Appium 1 at the moment                                     |
+| Android  | [Flutter](https://github.com/appium-userland/appium-flutter-driver)  | <span className="sauceDBlue">Real Devices Only</span>, Virtual Devices only support Appium 1 at the moment                                     |
+| iOS      | [XCUITest](https://github.com/appium/appium-xcuitest-driver)         | <span className="sauceDBlue">Virtual and Real Devices</span>, Appium 2 for Virtual Devices on Sauce Labs is only supporting iOS 15 and higher. |
+| iOS      | [Flutter](https://github.com/appium-userland/appium-flutter-driver)  | <span className="sauceDBlue">Real Devices Only</span>, Virtual Devices only support Appium 1 at the moment                                     |
+
+### Supported Plugins
+
+Currently, we do not provide pre-installed and do not support passing custom plugins. We will keep monitoring the Appium community for the progress of the plugins and will update this page accordingly.
+
+If you have specific needs for a plugin, please reach out to our [support team](https://support.saucelabs.com/hc/en-us/requests/new) and provide all relevant information about this plugin.
+
+```
+
+```

--- a/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-2-migration.md
@@ -23,7 +23,7 @@ Appium is in the final stages of a major revision (to version 2.0). As such, the
 
 ## Breaking Changes
 
-Before you get started with migrating your Appium 1 tests to Appium 2, you should have a look a the [Appium 2.0 release notes](https://github.com/appium/appium/releases). The breaking changes that are listed below are only a subset of the changes that are listed in the release notes, but also have an impact on running your tests on Sauce Labs.
+Before you get started with migrating your Appium 1 tests to Appium 2, read the [Appium 2.0 release notes](https://github.com/appium/appium/releases). The breaking changes that are listed below have an impact on running your tests on Sauce Labs, but they are only a subset of the changes that are listed in the Appium 2.0 release notes. 
 
 ### Protocol changes
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -35,7 +35,10 @@ module.exports = {
           type: 'category',
           label: 'APIs and Webhooks (Legacy)',
           collapsed: true,
-          items: ['api-testing/on-prem/api/v3', 'api-testing/on-prem/api/using-the-api'],
+          items: [
+            'api-testing/on-prem/api/v3',
+            'api-testing/on-prem/api/using-the-api',
+          ],
         },
         {
           type: 'category',
@@ -275,7 +278,9 @@ module.exports = {
           type: 'category',
           label: 'Security Testing (Legacy)',
           collapsed: true,
-          items: ['api-testing/on-prem/security-testing/example-security-tests'],
+          items: [
+            'api-testing/on-prem/security-testing/example-security-tests',
+          ],
         },
         {
           type: 'category',
@@ -323,7 +328,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Low Code',
-      link: { type: 'doc', id:  'dev/low-code' },
+      link: { type: 'doc', id: 'dev/low-code' },
       collapsed: true,
       collapsible: false,
       items: [
@@ -332,16 +337,19 @@ module.exports = {
         {
           type: 'category',
           label: 'Plan',
-          link: { type: 'doc', id:  'dev/low-code/plan/plan-step' },
+          link: { type: 'doc', id: 'dev/low-code/plan/plan-step' },
           collapsed: true,
           items: [
             'dev/low-code/plan/plan-step',
             {
               type: 'category',
               label: 'Projects',
-              link: { type: 'doc', id:  'dev/low-code/plan/projects/projects' },
+              link: { type: 'doc', id: 'dev/low-code/plan/projects/projects' },
               collapsed: true,
-              items: ['dev/low-code/plan/projects/projects', 'dev/low-code/plan/projects/project-details-page'],
+              items: [
+                'dev/low-code/plan/projects/projects',
+                'dev/low-code/plan/projects/project-details-page',
+              ],
             },
             'dev/low-code/plan/test-suites',
             'dev/low-code/plan/test-cases',
@@ -350,7 +358,7 @@ module.exports = {
         {
           type: 'category',
           label: 'Execute',
-          link: { type: 'doc', id:  'dev/low-code/execute/execute-step' },
+          link: { type: 'doc', id: 'dev/low-code/execute/execute-step' },
           collapsed: true,
           items: [
             'dev/low-code/execute/execute-step',
@@ -371,7 +379,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Error and Crash Reporting',
-      link: { type: 'doc', id:  'error-reporting/getting-started' },
+      link: { type: 'doc', id: 'error-reporting/getting-started' },
       collapsed: true,
       collapsible: false,
       items: [
@@ -380,34 +388,46 @@ module.exports = {
         {
           type: 'category',
           label: 'Platform Integrations',
-          link: { type: 'doc', id:  'error-reporting/platform-integrations/android/setup' },
+          link: {
+            type: 'doc',
+            id: 'error-reporting/platform-integrations/android/setup',
+          },
           collapsed: true,
           items: [
-        {
-                type: 'category',
-                label: 'Android',
-                link: { type: 'doc', id:  'error-reporting/platform-integrations/android/setup' },
-                collapsed: true,
-                items: [
-                    'error-reporting/platform-integrations/android/setup',
-                    'error-reporting/platform-integrations/android/configuration',
-                    'error-reporting/platform-integrations/android/proguard-deobfuscation',
-                ],
+            {
+              type: 'category',
+              label: 'Android',
+              link: {
+                type: 'doc',
+                id: 'error-reporting/platform-integrations/android/setup',
+              },
+              collapsed: true,
+              items: [
+                'error-reporting/platform-integrations/android/setup',
+                'error-reporting/platform-integrations/android/configuration',
+                'error-reporting/platform-integrations/android/proguard-deobfuscation',
+              ],
             },
-        {
-                type: 'category',
-                label: 'iOS',
-                link: { type: 'doc', id:  'error-reporting/platform-integrations/ios/setup' },
-                collapsed: true,
-                items: [
-                    'error-reporting/platform-integrations/ios/setup',
-                    'error-reporting/platform-integrations/ios/configuration',
-                ],
+            {
+              type: 'category',
+              label: 'iOS',
+              link: {
+                type: 'doc',
+                id: 'error-reporting/platform-integrations/ios/setup',
+              },
+              collapsed: true,
+              items: [
+                'error-reporting/platform-integrations/ios/setup',
+                'error-reporting/platform-integrations/ios/configuration',
+              ],
             },
             {
               type: 'category',
               label: 'Unity',
-              link: { type: 'doc', id:  'error-reporting/platform-integrations/unity/setup' },
+              link: {
+                type: 'doc',
+                id: 'error-reporting/platform-integrations/unity/setup',
+              },
               collapsed: true,
               items: [
                 'error-reporting/platform-integrations/unity/setup',
@@ -418,7 +438,10 @@ module.exports = {
             {
               type: 'category',
               label: 'Unreal Engine',
-              link: { type: 'doc', id:  'error-reporting/platform-integrations/unreal/setup' },
+              link: {
+                type: 'doc',
+                id: 'error-reporting/platform-integrations/unreal/setup',
+              },
               collapsed: true,
               items: [
                 'error-reporting/platform-integrations/unreal/setup',
@@ -429,18 +452,24 @@ module.exports = {
             {
               type: 'category',
               label: 'Real Devices',
-              link: { type: 'doc', id:  'error-reporting/platform-integrations/real-devices/setup' },
+              link: {
+                type: 'doc',
+                id: 'error-reporting/platform-integrations/real-devices/setup',
+              },
               collapsed: true,
               items: [
-                  'error-reporting/platform-integrations/real-devices/setup',
+                'error-reporting/platform-integrations/real-devices/setup',
               ],
-          },
+            },
           ],
         },
         {
           type: 'category',
           label: 'Web Console Views',
-          link: { type: 'doc', id:  'error-reporting/web-console/getting-started' },
+          link: {
+            type: 'doc',
+            id: 'error-reporting/web-console/getting-started',
+          },
           collapsed: true,
           items: [
             'error-reporting/web-console/getting-started',
@@ -455,7 +484,7 @@ module.exports = {
         {
           type: 'category',
           label: 'Project Setup',
-          link: { type: 'doc', id:  'error-reporting/project-setup/attributes' },
+          link: { type: 'doc', id: 'error-reporting/project-setup/attributes' },
           collapsed: true,
           items: [
             'error-reporting/project-setup/attributes',
@@ -480,7 +509,10 @@ module.exports = {
         {
           type: 'category',
           label: 'Workflow Integrations',
-          link: { type: 'doc', id:  'error-reporting/workflow-integrations/overview' },
+          link: {
+            type: 'doc',
+            id: 'error-reporting/workflow-integrations/overview',
+          },
           collapsed: true,
           items: [
             'error-reporting/workflow-integrations/overview',
@@ -488,7 +520,10 @@ module.exports = {
             {
               type: 'category',
               label: 'Messaging',
-              link: { type: 'doc', id:  'error-reporting/workflow-integrations/messaging/slack' },
+              link: {
+                type: 'doc',
+                id: 'error-reporting/workflow-integrations/messaging/slack',
+              },
               collapsed: true,
               items: [
                 'error-reporting/workflow-integrations/messaging/slack',
@@ -502,7 +537,10 @@ module.exports = {
             {
               type: 'category',
               label: 'Issue Tracking',
-              link: { type: 'doc', id:  'error-reporting/workflow-integrations/issue-tracking/jira' },
+              link: {
+                type: 'doc',
+                id: 'error-reporting/workflow-integrations/issue-tracking/jira',
+              },
               collapsed: true,
               items: [
                 'error-reporting/workflow-integrations/issue-tracking/jira',
@@ -515,7 +553,10 @@ module.exports = {
             {
               type: 'category',
               label: 'Alerting and Operations',
-              link: { type: 'doc', id:  'error-reporting/workflow-integrations/alerting-ops/pagerduty' },
+              link: {
+                type: 'doc',
+                id: 'error-reporting/workflow-integrations/alerting-ops/pagerduty',
+              },
               collapsed: true,
               items: [
                 'error-reporting/workflow-integrations/alerting-ops/pagerduty',
@@ -526,7 +567,10 @@ module.exports = {
             {
               type: 'category',
               label: 'Monitoring',
-              link: { type: 'doc', id:  'error-reporting/workflow-integrations/monitoring/datadog' },
+              link: {
+                type: 'doc',
+                id: 'error-reporting/workflow-integrations/monitoring/datadog',
+              },
               collapsed: true,
               items: [
                 'error-reporting/workflow-integrations/monitoring/datadog',
@@ -539,7 +583,10 @@ module.exports = {
         {
           type: 'category',
           label: 'Privacy and Compliance',
-          link: { type: 'doc', id:  'error-reporting/security-compliance/common-questions' },
+          link: {
+            type: 'doc',
+            id: 'error-reporting/security-compliance/common-questions',
+          },
           collapsed: true,
           items: [
             'error-reporting/security-compliance/common-questions',
@@ -598,14 +645,14 @@ module.exports = {
                 'dev/cli/saucectl/completion',
                 'dev/cli/saucectl/storage/download',
                 'dev/cli/saucectl/storage/list',
-                'dev/cli/saucectl/storage/upload'
+                'dev/cli/saucectl/storage/upload',
               ],
             },
             'dev/cli/saucectl/usage/use-cases',
             {
               type: 'category',
               label: 'CI Integrations',
-              link: { type: 'doc', id: 'dev/cli/saucectl/usage/ci/circleci', },
+              link: { type: 'doc', id: 'dev/cli/saucectl/usage/ci/circleci' },
               collapsed: true,
               items: [
                 'dev/cli/saucectl/usage/ci/circleci',
@@ -617,16 +664,19 @@ module.exports = {
             {
               type: 'category',
               label: 'IDE Integrations',
-              link: { type: 'doc', id: 'dev/cli/saucectl/usage/ide/intellij', },
+              link: { type: 'doc', id: 'dev/cli/saucectl/usage/ide/intellij' },
               collapsed: true,
-              items: ['dev/cli/saucectl/usage/ide/intellij', 'dev/cli/saucectl/usage/ide/vscode'],
+              items: [
+                'dev/cli/saucectl/usage/ide/intellij',
+                'dev/cli/saucectl/usage/ide/vscode',
+              ],
             },
           ],
         },
         {
           type: 'category',
           label: 'Virtual USB CLI',
-          link: { type: 'doc', id: 'dev/cli/virtual-usb', },
+          link: { type: 'doc', id: 'dev/cli/virtual-usb' },
           collapsed: true,
           items: [
             'dev/cli/virtual-usb',
@@ -648,106 +698,124 @@ module.exports = {
       link: { type: 'doc', id: 'overview' },
       collapsed: true,
       items: [
-      'overview',
-      {
-        type: 'category',
-        label: 'Sauce Labs Basics',
-        link: { type: 'doc', id: 'sauce-basics' },
-        collapsed: true,
-        items: [
-          'sauce-basics',
-          'basics/quickstarts',
-          'basics/platform-configurator',
-          'basics/environment-variables',
-          {
-            type: 'category',
-            label: 'Account and Team Management',
-            link: { type: 'doc', id: 'basics/acct-team-mgmt-hub' },
-            collapsed: true,
-            items: [
-              'basics/acct-team-mgmt-hub',
-              'basics/acct-team-mgmt/org-settings',
-              {
-                type: 'category',
-                label: 'Managing Users and Accounts',
-                link: { type: 'doc', id: 'basics/acct-team-mgmt/concurrency-limits', },
-                collapsed: true,
-                items: [
-                  'basics/acct-team-mgmt/concurrency-limits',
-                  'basics/acct-team-mgmt/adding-deactivating-users',
-                  'basics/acct-team-mgmt/managing-user-info',
-                  'basics/acct-team-mgmt/viewing-exporting-usage-data',
-                ],
+        'overview',
+        {
+          type: 'category',
+          label: 'Sauce Labs Basics',
+          link: { type: 'doc', id: 'sauce-basics' },
+          collapsed: true,
+          items: [
+            'sauce-basics',
+            'basics/quickstarts',
+            'basics/platform-configurator',
+            'basics/environment-variables',
+            {
+              type: 'category',
+              label: 'Account and Team Management',
+              link: { type: 'doc', id: 'basics/acct-team-mgmt-hub' },
+              collapsed: true,
+              items: [
+                'basics/acct-team-mgmt-hub',
+                'basics/acct-team-mgmt/org-settings',
+                {
+                  type: 'category',
+                  label: 'Managing Users and Accounts',
+                  link: {
+                    type: 'doc',
+                    id: 'basics/acct-team-mgmt/concurrency-limits',
+                  },
+                  collapsed: true,
+                  items: [
+                    'basics/acct-team-mgmt/concurrency-limits',
+                    'basics/acct-team-mgmt/adding-deactivating-users',
+                    'basics/acct-team-mgmt/managing-user-info',
+                    'basics/acct-team-mgmt/viewing-exporting-usage-data',
+                  ],
+                },
+                {
+                  type: 'category',
+                  label: 'Managing Teams',
+                  link: {
+                    type: 'doc',
+                    id: 'basics/acct-team-mgmt/adding-deleting-teams',
+                  },
+                  collapsed: true,
+                  items: [
+                    'basics/acct-team-mgmt/adding-deleting-teams',
+                    'basics/acct-team-mgmt/assigning-removing-users-teams',
+                    'basics/acct-team-mgmt/private-device-mgmt',
+                    'basics/acct-team-mgmt/sauce-connect-proxy-tunnels',
+                  ],
+                },
+                {
+                  type: 'category',
+                  label: 'Billing and Subscriptions',
+                  link: {
+                    type: 'doc',
+                    id: 'basics/acct-team-mgmt/managing-subscription',
+                  },
+                  collapsed: true,
+                  items: [
+                    'basics/acct-team-mgmt/managing-subscription',
+                    'basics/acct-team-mgmt/updating-billing',
+                    'basics/acct-team-mgmt/plan-details',
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Single Sign-On',
+              link: { type: 'doc', id: 'basics/sso-hub' },
+              collapsed: true,
+              items: [
+                'basics/sso-hub',
+                'basics/sso/setting-up-single-sign-on',
+                'basics/sso/config-adfs',
+                'basics/sso/config-okta',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Test Configuration and Annotation',
+              link: {
+                type: 'doc',
+                id: 'basics/test-config-annotation/test-config',
               },
-              {
-                type: 'category',
-                label: 'Managing Teams',
-                link: { type: 'doc', id: 'basics/acct-team-mgmt/adding-deleting-teams' },
-                collapsed: true,
-                items: [
-                  'basics/acct-team-mgmt/adding-deleting-teams',
-                  'basics/acct-team-mgmt/assigning-removing-users-teams',
-                  'basics/acct-team-mgmt/private-device-mgmt',
-                  'basics/acct-team-mgmt/sauce-connect-proxy-tunnels',
-                ],
-              },
-              {
-                type: 'category',
-                label: 'Billing and Subscriptions',
-                link: { type: 'doc', id: 'basics/acct-team-mgmt/managing-subscription' },
-                collapsed: true,
-                items: [
-                  'basics/acct-team-mgmt/managing-subscription',
-                  'basics/acct-team-mgmt/updating-billing',
-                  'basics/acct-team-mgmt/plan-details',
-                ],
-              },
-            ],
-          },
-          {
-            type: 'category',
-            label: 'Single Sign-On',
-            link: { type: 'doc', id: 'basics/sso-hub' },
-            collapsed: true,
-            items: [
-              'basics/sso-hub',
-              'basics/sso/setting-up-single-sign-on',
-              'basics/sso/config-adfs',
-              'basics/sso/config-okta',
-            ],
-          },
-          {
-            type: 'category',
-            label: 'Test Configuration and Annotation',
-            link: { type: 'doc', id: 'basics/test-config-annotation/test-config' },
-            collapsed: true,
-            items: ['basics/test-config-annotation/test-config', 'basics/test-config-annotation/test-annotation'],
-          },
-          {
-            type: 'category',
-            label: 'Data Center Endpoints',
-            link: { type: 'doc', id: 'basics/data-center-endpoints' },
-            collapsed: true,
-            items: ['basics/data-center-endpoints', 'basics/data-center-endpoints/aust-early-access'],
-          },
-          {
-            type: 'category',
-            label: 'Integrations',
-            link: { type: 'doc', id: 'basics/integrations-overview' },
-            collapsed: true,
-            items: [
-              'basics/integrations-overview',
-              'basics/integrations/deque',
-              'basics/integrations/evinced',
-              'basics/integrations/jira',
-              'basics/integrations/slack',
-              'basics/integrations/uipath',
-              'basics/integrations/sumo',
-            ],
-          },
-        ],
-      },
-    ],
+              collapsed: true,
+              items: [
+                'basics/test-config-annotation/test-config',
+                'basics/test-config-annotation/test-annotation',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Data Center Endpoints',
+              link: { type: 'doc', id: 'basics/data-center-endpoints' },
+              collapsed: true,
+              items: [
+                'basics/data-center-endpoints',
+                'basics/data-center-endpoints/aust-early-access',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Integrations',
+              link: { type: 'doc', id: 'basics/integrations-overview' },
+              collapsed: true,
+              items: [
+                'basics/integrations-overview',
+                'basics/integrations/deque',
+                'basics/integrations/evinced',
+                'basics/integrations/jira',
+                'basics/integrations/slack',
+                'basics/integrations/uipath',
+                'basics/integrations/sumo',
+              ],
+            },
+          ],
+        },
+      ],
     },
     {
       type: 'category',
@@ -755,54 +823,60 @@ module.exports = {
       link: { type: 'doc', id: 'secure-connections' },
       collapsed: true,
       items: [
-      'secure-connections',
-      {
-        type: 'category',
-        label: 'Sauce Connect Proxy',
-        link: { type: 'doc', id: 'secure-connections/sauce-connect' },
-        collapsed: true,
-        items: [
-          'secure-connections/sauce-connect',
-          'secure-connections/sauce-connect/installation',
-          'secure-connections/sauce-connect/quickstart',
-          'secure-connections/sauce-connect/system-requirements',
+        'secure-connections',
+        {
+          type: 'category',
+          label: 'Sauce Connect Proxy',
+          link: { type: 'doc', id: 'secure-connections/sauce-connect' },
+          collapsed: true,
+          items: [
+            'secure-connections/sauce-connect',
+            'secure-connections/sauce-connect/installation',
+            'secure-connections/sauce-connect/quickstart',
+            'secure-connections/sauce-connect/system-requirements',
 
-          {
-            type: 'category',
-            label: 'Setup and Configuration',
-            link: { type: 'doc', id: 'secure-connections/sauce-connect/setup-configuration/basic-setup' },
-            collapsed: true,
-            items: [
-              'secure-connections/sauce-connect/setup-configuration/basic-setup',
-              'secure-connections/sauce-connect/setup-configuration/yaml-config',
-              'secure-connections/sauce-connect/setup-configuration/environment-variables',
-              'secure-connections/sauce-connect/setup-configuration/high-availability',
-              'secure-connections/sauce-connect/setup-configuration/additional-proxies',
-              'secure-connections/sauce-connect/setup-configuration/specialized-environments',
-              'secure-connections/sauce-connect/setup-configuration/docker',
-              'secure-connections/sauce-connect/setup-configuration/ci-cd-integration',
-            ],
-          },
-          'secure-connections/sauce-connect/proxy-tunnels',
-          'secure-connections/sauce-connect/security-authentication',
-          {
-            type: 'category',
-            label: 'Advanced',
-            link: { type: 'doc', id: 'secure-connections/sauce-connect/advanced/architecture' },
-            collapsed: true,
-            items: [
-              'secure-connections/sauce-connect/advanced/architecture',
-              'secure-connections/sauce-connect/advanced/kgp',
-              'secure-connections/sauce-connect/advanced/specifications',
-            ],
-          },
-          'secure-connections/sauce-connect/troubleshooting',
-          'secure-connections/sauce-connect/faq',
-          'secure-connections/sauce-connect/changelog',
-        ],
-      },
-      'secure-connections/ipsec-vpn',
-    ],
+            {
+              type: 'category',
+              label: 'Setup and Configuration',
+              link: {
+                type: 'doc',
+                id: 'secure-connections/sauce-connect/setup-configuration/basic-setup',
+              },
+              collapsed: true,
+              items: [
+                'secure-connections/sauce-connect/setup-configuration/basic-setup',
+                'secure-connections/sauce-connect/setup-configuration/yaml-config',
+                'secure-connections/sauce-connect/setup-configuration/environment-variables',
+                'secure-connections/sauce-connect/setup-configuration/high-availability',
+                'secure-connections/sauce-connect/setup-configuration/additional-proxies',
+                'secure-connections/sauce-connect/setup-configuration/specialized-environments',
+                'secure-connections/sauce-connect/setup-configuration/docker',
+                'secure-connections/sauce-connect/setup-configuration/ci-cd-integration',
+              ],
+            },
+            'secure-connections/sauce-connect/proxy-tunnels',
+            'secure-connections/sauce-connect/security-authentication',
+            {
+              type: 'category',
+              label: 'Advanced',
+              link: {
+                type: 'doc',
+                id: 'secure-connections/sauce-connect/advanced/architecture',
+              },
+              collapsed: true,
+              items: [
+                'secure-connections/sauce-connect/advanced/architecture',
+                'secure-connections/sauce-connect/advanced/kgp',
+                'secure-connections/sauce-connect/advanced/specifications',
+              ],
+            },
+            'secure-connections/sauce-connect/troubleshooting',
+            'secure-connections/sauce-connect/faq',
+            'secure-connections/sauce-connect/changelog',
+          ],
+        },
+        'secure-connections/ipsec-vpn',
+      ],
     },
     {
       type: 'category',
@@ -810,99 +884,111 @@ module.exports = {
       link: { type: 'doc', id: 'mobile-apps' },
       collapsed: true,
       items: [
-      'mobile-apps',
-      'mobile-apps/app-storage',
-      { 
-        type: 'category',
-        label: 'Supported Devices',
-        link: { type: 'doc', id: 'mobile-apps/supported-devices' },
-        collapsed: true,
-        items: [
-          'mobile-apps/supported-devices',
-          'mobile-apps/real-device-cleaning'
-        ],
+        'mobile-apps',
+        'mobile-apps/app-storage',
+        {
+          type: 'category',
+          label: 'Supported Devices',
+          link: { type: 'doc', id: 'mobile-apps/supported-devices' },
+          collapsed: true,
+          items: [
+            'mobile-apps/supported-devices',
+            'mobile-apps/real-device-cleaning',
+          ],
         },
-      {
-        type: 'category',
-        label: 'Features',
-        link: { type: 'doc', id: 'mobile-apps/features/bypass-screenshot' },
-        collapsed: true,
-        items: [
-          'mobile-apps/features/bypass-screenshot',
-          'mobile-apps/features/virtual-usb',
-          'mobile-apps/features/biometric-authentication',
-          'mobile-apps/features/camera-image-injection',
-          'mobile-apps/features/gestures',
-          'mobile-apps/features/network-capture',
-          'mobile-apps/features/audio-capture',
-          {
-            type: 'category',
-            label: 'Mobile App Diagnostics',
-            link: { type: 'doc', id: 'mobile-apps/features/mobile-app-diagnostics/device-vitals' },
-            collapsed: true,
-            items: [
-              'mobile-apps/features/mobile-app-diagnostics/device-vitals',
-              'mobile-apps/features/mobile-app-diagnostics/interactions',
-              'mobile-apps/features/mobile-app-diagnostics/view-tree',
-            ],
+        {
+          type: 'category',
+          label: 'Features',
+          link: { type: 'doc', id: 'mobile-apps/features/bypass-screenshot' },
+          collapsed: true,
+          items: [
+            'mobile-apps/features/bypass-screenshot',
+            'mobile-apps/features/virtual-usb',
+            'mobile-apps/features/biometric-authentication',
+            'mobile-apps/features/camera-image-injection',
+            'mobile-apps/features/gestures',
+            'mobile-apps/features/network-capture',
+            'mobile-apps/features/audio-capture',
+            {
+              type: 'category',
+              label: 'Mobile App Diagnostics',
+              link: {
+                type: 'doc',
+                id: 'mobile-apps/features/mobile-app-diagnostics/device-vitals',
+              },
+              collapsed: true,
+              items: [
+                'mobile-apps/features/mobile-app-diagnostics/device-vitals',
+                'mobile-apps/features/mobile-app-diagnostics/interactions',
+                'mobile-apps/features/mobile-app-diagnostics/view-tree',
+              ],
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Live Testing',
+          link: {
+            type: 'doc',
+            id: 'mobile-apps/live-testing/live-mobile-app-testing',
           },
-        ],
-      },
-      {
-        type: 'category',
-        label: 'Live Testing',
-        link: { type: 'doc', id: 'mobile-apps/live-testing/live-mobile-app-testing' },
-        collapsed: true,
-        items: ['mobile-apps/live-testing/live-mobile-app-testing'],
-      },
+          collapsed: true,
+          items: ['mobile-apps/live-testing/live-mobile-app-testing'],
+        },
 
-      {
-        type: 'category',
-        label: 'Automated Testing',
-        link: { type: 'doc', id: 'mobile-apps/automated-testing' },
-        collapsed: true,
-        items: [
-          'mobile-apps/automated-testing',
-          {
-            type: 'category',
-            label: 'Appium',
-            link: { type: 'doc', id: 'mobile-apps/automated-testing/appium' },
-            collapsed: true,
-            items: [
-              'mobile-apps/automated-testing/appium',
-              'mobile-apps/automated-testing/appium/quickstart',
-              'mobile-apps/automated-testing/appium/real-devices',
-              'mobile-apps/automated-testing/appium/virtual-devices',
-            ],
-          },
-          {
-            type: 'category',
-            label: 'Espresso and XCUITest',
-            link: { type: 'doc', id: 'mobile-apps/automated-testing/espresso-xcuitest' },
-            collapsed: true,
-            items: [
-              'mobile-apps/automated-testing/espresso-xcuitest',
-              'mobile-apps/automated-testing/espresso-xcuitest/espresso',
-              'mobile-apps/automated-testing/espresso-xcuitest/xcuitest',
+        {
+          type: 'category',
+          label: 'Automated Testing',
+          link: { type: 'doc', id: 'mobile-apps/automated-testing' },
+          collapsed: true,
+          items: [
+            'mobile-apps/automated-testing',
+            {
+              type: 'category',
+              label: 'Appium',
+              link: { type: 'doc', id: 'mobile-apps/automated-testing/appium' },
+              collapsed: true,
+              items: [
+                'mobile-apps/automated-testing/appium',
+                'mobile-apps/automated-testing/appium/appium-2-migration',
+                'mobile-apps/automated-testing/appium/quickstart',
+                'mobile-apps/automated-testing/appium/real-devices',
+                'mobile-apps/automated-testing/appium/virtual-devices',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Espresso and XCUITest',
+              link: {
+                type: 'doc',
+                id: 'mobile-apps/automated-testing/espresso-xcuitest',
+              },
+              collapsed: true,
+              items: [
+                'mobile-apps/automated-testing/espresso-xcuitest',
+                'mobile-apps/automated-testing/espresso-xcuitest/espresso',
+                'mobile-apps/automated-testing/espresso-xcuitest/xcuitest',
 
-              {
-                type: 'category',
-                label: 'Espresso Features',
-                link: { type: 'doc', id: 'mobile-apps/automated-testing/espresso-xcuitest/espresso-capture' },
-                collapsed: true,
-                items: [
-              'mobile-apps/automated-testing/espresso-xcuitest/espresso-capture',
-                ]
-              }
-
-            ],
-          },
-          'mobile-apps/automated-testing/ipa-files',
-        ],
-      },
-      'mobile-apps/ms-app-center',
-      'mobile-apps/faq',
-    ],
+                {
+                  type: 'category',
+                  label: 'Espresso Features',
+                  link: {
+                    type: 'doc',
+                    id: 'mobile-apps/automated-testing/espresso-xcuitest/espresso-capture',
+                  },
+                  collapsed: true,
+                  items: [
+                    'mobile-apps/automated-testing/espresso-xcuitest/espresso-capture',
+                  ],
+                },
+              ],
+            },
+            'mobile-apps/automated-testing/ipa-files',
+          ],
+        },
+        'mobile-apps/ms-app-center',
+        'mobile-apps/faq',
+      ],
     },
     {
       type: 'category',
@@ -910,105 +996,114 @@ module.exports = {
       link: { type: 'doc', id: 'web-apps' },
       collapsed: true,
       items: [
-      'web-apps',
-      {
-        type: 'category',
-        label: 'Live Testing',
-        link: { type: 'doc', id: 'web-apps/live-testing/live-cross-browser-testing' },
-        collapsed: true,
-        items: ['web-apps/live-testing/live-cross-browser-testing'],
-      },
-      {
-        type: 'category',
-        label: 'Automated Testing',
-        link: { type: 'doc', id: 'web-apps/automated-testing/selenium' },
-        collapsed: true,
-        items: [
-          {
-            type: 'category',
-            label: 'Selenium',
-            link: { type: 'doc', id: 'web-apps/automated-testing/selenium' },
-            collapsed: true,
-            items: [
-              'web-apps/automated-testing/selenium',
-              'web-apps/automated-testing/selenium/quickstart',
-              'web-apps/automated-testing/selenium/selenium4',
-              'web-apps/automated-testing/selenium/pre-run-executables',
-              'web-apps/automated-testing/selenium/sample-scripts',
-              'web-apps/automated-testing/selenium/selenium-grid',
-            ],
+        'web-apps',
+        {
+          type: 'category',
+          label: 'Live Testing',
+          link: {
+            type: 'doc',
+            id: 'web-apps/live-testing/live-cross-browser-testing',
           },
-          {
-            type: 'category',
-            label: 'Cypress',
-            link: { type: 'doc', id: 'web-apps/automated-testing/cypress' },
-            collapsed: true,
-            items: [
-              'web-apps/automated-testing/cypress',
-              'web-apps/automated-testing/cypress/quickstart',
-              {
-                type: 'category',
-                label: 'YAML Configuration',
-                link: { type: 'doc', id: 'web-apps/automated-testing/cypress/yaml' },
-                collapsed: true,
-                items: [
-                  'web-apps/automated-testing/cypress/yaml/v1',
-                  'web-apps/automated-testing/cypress/yaml/v1alpha',
-                ],
+          collapsed: true,
+          items: ['web-apps/live-testing/live-cross-browser-testing'],
+        },
+        {
+          type: 'category',
+          label: 'Automated Testing',
+          link: { type: 'doc', id: 'web-apps/automated-testing/selenium' },
+          collapsed: true,
+          items: [
+            {
+              type: 'category',
+              label: 'Selenium',
+              link: { type: 'doc', id: 'web-apps/automated-testing/selenium' },
+              collapsed: true,
+              items: [
+                'web-apps/automated-testing/selenium',
+                'web-apps/automated-testing/selenium/quickstart',
+                'web-apps/automated-testing/selenium/selenium4',
+                'web-apps/automated-testing/selenium/pre-run-executables',
+                'web-apps/automated-testing/selenium/sample-scripts',
+                'web-apps/automated-testing/selenium/selenium-grid',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Cypress',
+              link: { type: 'doc', id: 'web-apps/automated-testing/cypress' },
+              collapsed: true,
+              items: [
+                'web-apps/automated-testing/cypress',
+                'web-apps/automated-testing/cypress/quickstart',
+                {
+                  type: 'category',
+                  label: 'YAML Configuration',
+                  link: {
+                    type: 'doc',
+                    id: 'web-apps/automated-testing/cypress/yaml',
+                  },
+                  collapsed: true,
+                  items: [
+                    'web-apps/automated-testing/cypress/yaml/v1',
+                    'web-apps/automated-testing/cypress/yaml/v1alpha',
+                  ],
+                },
+                'web-apps/automated-testing/cypress/advanced',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Playwright',
+              link: {
+                type: 'doc',
+                id: 'web-apps/automated-testing/playwright',
               },
-              'web-apps/automated-testing/cypress/advanced',
-            ],
-          },
-          {
-            type: 'category',
-            label: 'Playwright',
-            link: { type: 'doc', id: 'web-apps/automated-testing/playwright' },
-            collapsed: true,
-            items: [
-              'web-apps/automated-testing/playwright',
-              'web-apps/automated-testing/playwright/quickstart',
-              'web-apps/automated-testing/playwright/yaml',
-              'web-apps/automated-testing/playwright/cucumber',
-              'web-apps/automated-testing/playwright/advanced',
-            ],
-          },
-          {
-            type: 'category',
-            label: 'TestCafe',
-            link: { type: 'doc', id: 'web-apps/automated-testing/testcafe' },
-            collapsed: true,
-            items: [
-              'web-apps/automated-testing/testcafe',
-              'web-apps/automated-testing/testcafe/quickstart',
-              'web-apps/automated-testing/testcafe/yaml',
-              'web-apps/automated-testing/testcafe/advanced',
-            ],
-          },
-          {
-            type: 'category',
-            label: 'Puppeteer',
-            link: { type: 'doc', id: 'web-apps/automated-testing/puppeteer' },
-            collapsed: true,
-            items: [
-              'web-apps/automated-testing/puppeteer',
-              'web-apps/automated-testing/puppeteer/quickstart',
-              'web-apps/automated-testing/puppeteer/yaml',
-            ],
-          },
-          {
-            type: 'category',
-            label: 'Replay',
-            link: { type: 'doc', id: 'web-apps/automated-testing/replay' },
-            collapsed: true,
-            items: [
-              'web-apps/automated-testing/replay',
-              'web-apps/automated-testing/replay/quickstart',
-              'web-apps/automated-testing/replay/yaml',
-            ],
-          },
-        ],
-      },
-    ],
+              collapsed: true,
+              items: [
+                'web-apps/automated-testing/playwright',
+                'web-apps/automated-testing/playwright/quickstart',
+                'web-apps/automated-testing/playwright/yaml',
+                'web-apps/automated-testing/playwright/cucumber',
+                'web-apps/automated-testing/playwright/advanced',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'TestCafe',
+              link: { type: 'doc', id: 'web-apps/automated-testing/testcafe' },
+              collapsed: true,
+              items: [
+                'web-apps/automated-testing/testcafe',
+                'web-apps/automated-testing/testcafe/quickstart',
+                'web-apps/automated-testing/testcafe/yaml',
+                'web-apps/automated-testing/testcafe/advanced',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Puppeteer',
+              link: { type: 'doc', id: 'web-apps/automated-testing/puppeteer' },
+              collapsed: true,
+              items: [
+                'web-apps/automated-testing/puppeteer',
+                'web-apps/automated-testing/puppeteer/quickstart',
+                'web-apps/automated-testing/puppeteer/yaml',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Replay',
+              link: { type: 'doc', id: 'web-apps/automated-testing/replay' },
+              collapsed: true,
+              items: [
+                'web-apps/automated-testing/replay',
+                'web-apps/automated-testing/replay/quickstart',
+                'web-apps/automated-testing/replay/yaml',
+              ],
+            },
+          ],
+        },
+      ],
     },
     {
       type: 'category',
@@ -1016,49 +1111,59 @@ module.exports = {
       link: { type: 'doc', id: 'api-testing' },
       collapsed: true,
       items: [
-      'api-testing',
-      'api-testing/quickstart',
-      'api-testing/sauce-connect',
-      'api-testing/build-from-spec',
-      'api-testing/import-postman-collection',
-      'api-testing/import-export-tests',
-      'api-testing/schedule-test',
-      {
-        type: 'category',
-        label: 'Test Composer',
-        link: { type: 'doc', id: 'api-testing/composer' },
-        collapsed: true,
-        items: [
-          'api-testing/composer',
-          'api-testing/composer/io-components',
-          'api-testing/composer/assertion-components',
-          'api-testing/composer/logical-components',
-          'api-testing/composer/other-components',
-          'api-testing/composer/expressions',
-        ],
-      },
-      {
-        type: 'category',
-        label: 'Vaults, Variables, Environments',
-        link: { type: 'doc', id: 'api-testing/vault' },
-        collapsed: true,
-        items: ['api-testing/vault', 'api-testing/environments', 'api-testing/variables-environment-overrides'],
-      },
-      {
-        type: 'category',
-        label: 'Integrations',
-        link: { type: 'doc', id: 'api-testing/integrations/apifctl-cicd-integration' },
-        collapsed: true,
-        items: ['api-testing/integrations/apifctl-cicd-integration', 'api-testing/integrations/pagerduty-webhooks'],
-      },
-      'api-testing/project-dashboard',
-      'api-testing/mocking',
-      'api-testing/load-testing',
-      'api-testing/contract-testing',
-      'api-testing/logger',
-      'api-testing/project-access',
-      'api-testing/legacy',
-    ],
+        'api-testing',
+        'api-testing/quickstart',
+        'api-testing/sauce-connect',
+        'api-testing/build-from-spec',
+        'api-testing/import-postman-collection',
+        'api-testing/import-export-tests',
+        'api-testing/schedule-test',
+        {
+          type: 'category',
+          label: 'Test Composer',
+          link: { type: 'doc', id: 'api-testing/composer' },
+          collapsed: true,
+          items: [
+            'api-testing/composer',
+            'api-testing/composer/io-components',
+            'api-testing/composer/assertion-components',
+            'api-testing/composer/logical-components',
+            'api-testing/composer/other-components',
+            'api-testing/composer/expressions',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Vaults, Variables, Environments',
+          link: { type: 'doc', id: 'api-testing/vault' },
+          collapsed: true,
+          items: [
+            'api-testing/vault',
+            'api-testing/environments',
+            'api-testing/variables-environment-overrides',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Integrations',
+          link: {
+            type: 'doc',
+            id: 'api-testing/integrations/apifctl-cicd-integration',
+          },
+          collapsed: true,
+          items: [
+            'api-testing/integrations/apifctl-cicd-integration',
+            'api-testing/integrations/pagerduty-webhooks',
+          ],
+        },
+        'api-testing/project-dashboard',
+        'api-testing/mocking',
+        'api-testing/load-testing',
+        'api-testing/contract-testing',
+        'api-testing/logger',
+        'api-testing/project-access',
+        'api-testing/legacy',
+      ],
     },
     {
       type: 'category',
@@ -1066,13 +1171,13 @@ module.exports = {
       link: { type: 'doc', id: 'ci' },
       collapsed: true,
       items: [
-      'ci',
-      'ci/azure',
-      'ci/bamboo',
-      'ci/bitbucket',
-      'ci/jenkins',
-      'ci/teamcity',
-    ],
+        'ci',
+        'ci/azure',
+        'ci/bamboo',
+        'ci/bitbucket',
+        'ci/jenkins',
+        'ci/teamcity',
+      ],
     },
     {
       type: 'category',
@@ -1080,13 +1185,13 @@ module.exports = {
       link: { type: 'doc', id: 'test-results' },
       collapsed: true,
       items: [
-      'test-results',
-      'test-results/viewing-test-results',
-      'test-results/sharing-test-results',
-      'test-results/archived-test-results',
-      'test-results/test-status',
-      'test-results/badges-browser-matrix',
-    ],
+        'test-results',
+        'test-results/viewing-test-results',
+        'test-results/sharing-test-results',
+        'test-results/archived-test-results',
+        'test-results/test-status',
+        'test-results/badges-browser-matrix',
+      ],
     },
     {
       type: 'category',
@@ -1094,14 +1199,14 @@ module.exports = {
       link: { type: 'doc', id: 'insights' },
       collapsed: true,
       items: [
-      'insights',
-      'insights/scope',
-      'insights/history',
-      'insights/trends',
-      'insights/coverage',
-      'insights/failure-analysis',
-      'insights/debug',
-    ],
+        'insights',
+        'insights/scope',
+        'insights/history',
+        'insights/trends',
+        'insights/coverage',
+        'insights/failure-analysis',
+        'insights/debug',
+      ],
     },
     {
       type: 'category',
@@ -1109,13 +1214,13 @@ module.exports = {
       link: { type: 'doc', id: 'performance' },
       collapsed: true,
       items: [
-      'performance',
-      'performance/about',
-      'performance/one-page',
-      'performance/transitions',
-      'performance/motion',
-      'performance/analyze',
-    ],
+        'performance',
+        'performance/about',
+        'performance/one-page',
+        'performance/transitions',
+        'performance/motion',
+        'performance/analyze',
+      ],
     },
     {
       type: 'category',
@@ -1130,89 +1235,101 @@ module.exports = {
       link: { type: 'doc', id: 'visual' },
       collapsed: true,
       items: [
-      'visual',
-      {
-        type: 'category',
-        label: 'E2E Testing',
-        link: { type: 'doc', id: 'visual/e2e-testing/setup' },
-        collapsed: true,
-        items: [
-          'visual/e2e-testing/setup',
-          {
-            type: 'category',
-            label: 'Integrations',
-            link: { type: 'doc', id: 'visual/e2e-testing/integrations/continuous-integration' },
-            collapsed: true,
-            items: [
-              'visual/e2e-testing/integrations/continuous-integration',
-              'visual/e2e-testing/integrations/slack',
-              'visual/e2e-testing/integrations/webhooks',
-            ],
-          },
-          {
-            type: 'category',
-            label: 'Workflow',
-            link: { type: 'doc', id: 'visual/e2e-testing/workflow/review-workflow' },
-            collapsed: true,
-            items: [
-              'visual/e2e-testing/workflow/review-workflow',
-              'visual/e2e-testing/workflow/baseline-branch',
-              'visual/e2e-testing/workflow/change-details',
-              'visual/e2e-testing/workflow/visual-history',
-              'visual/e2e-testing/workflow/ignoring-changes',
-            ],
-          },
-          'visual/e2e-testing/commands-options',
-          'visual/e2e-testing/code-examples',
-          'visual/e2e-testing/supported-browsers',
-          'visual/e2e-testing/troubleshooting',
-        ],
-      },
-      {
-        type: 'category',
-        label: 'Component Testing',
-        link: { type: 'doc', id: 'visual/component-testing/setup' },
-        collapsed: true,
-        items: [
-          'visual/component-testing/setup',
-          {
-            type: 'category',
-            label: 'Integrations',
-            link: { type: 'doc', id: 'visual/component-testing/integrations/sauce-labs' },
-            collapsed: true,
-            items: [
-              'visual/component-testing/integrations/sauce-labs',
-              'visual/component-testing/integrations/continuous-integration',
-              'visual/component-testing/integrations/slack',
-              'visual/component-testing/integrations/webhooks',
-              'visual/component-testing/integrations/github',
-              'visual/component-testing/integrations/visual-studio-team-services',
-            ],
-          },
-          {
-            type: 'category',
-            label: 'Workflow',
-            link: { type: 'doc', id: 'visual/component-testing/workflow/review-workflow' },
-            collapsed: true,
-            items: [
-              'visual/component-testing/workflow/review-workflow',
-              'visual/component-testing/workflow/baseline-branch',
-              'visual/component-testing/workflow/change-details',
-              'visual/component-testing/workflow/visual-history',
-              'visual/component-testing/workflow/ignoring-changes',
-              'visual/component-testing/workflow/include-exclude-settings',
-            ],
-          },
-          'visual/component-testing/supported-browsers',
-          'visual/component-testing/storybook-interactions-testing',
-          'visual/component-testing/storybook-static',
-        ],
-      },
-      'visual/css-animations',
-      'visual/acct-team-mgmt',
-      'visual/notifications',
-      'visual/faq',
-    ],
+        'visual',
+        {
+          type: 'category',
+          label: 'E2E Testing',
+          link: { type: 'doc', id: 'visual/e2e-testing/setup' },
+          collapsed: true,
+          items: [
+            'visual/e2e-testing/setup',
+            {
+              type: 'category',
+              label: 'Integrations',
+              link: {
+                type: 'doc',
+                id: 'visual/e2e-testing/integrations/continuous-integration',
+              },
+              collapsed: true,
+              items: [
+                'visual/e2e-testing/integrations/continuous-integration',
+                'visual/e2e-testing/integrations/slack',
+                'visual/e2e-testing/integrations/webhooks',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Workflow',
+              link: {
+                type: 'doc',
+                id: 'visual/e2e-testing/workflow/review-workflow',
+              },
+              collapsed: true,
+              items: [
+                'visual/e2e-testing/workflow/review-workflow',
+                'visual/e2e-testing/workflow/baseline-branch',
+                'visual/e2e-testing/workflow/change-details',
+                'visual/e2e-testing/workflow/visual-history',
+                'visual/e2e-testing/workflow/ignoring-changes',
+              ],
+            },
+            'visual/e2e-testing/commands-options',
+            'visual/e2e-testing/code-examples',
+            'visual/e2e-testing/supported-browsers',
+            'visual/e2e-testing/troubleshooting',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Component Testing',
+          link: { type: 'doc', id: 'visual/component-testing/setup' },
+          collapsed: true,
+          items: [
+            'visual/component-testing/setup',
+            {
+              type: 'category',
+              label: 'Integrations',
+              link: {
+                type: 'doc',
+                id: 'visual/component-testing/integrations/sauce-labs',
+              },
+              collapsed: true,
+              items: [
+                'visual/component-testing/integrations/sauce-labs',
+                'visual/component-testing/integrations/continuous-integration',
+                'visual/component-testing/integrations/slack',
+                'visual/component-testing/integrations/webhooks',
+                'visual/component-testing/integrations/github',
+                'visual/component-testing/integrations/visual-studio-team-services',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Workflow',
+              link: {
+                type: 'doc',
+                id: 'visual/component-testing/workflow/review-workflow',
+              },
+              collapsed: true,
+              items: [
+                'visual/component-testing/workflow/review-workflow',
+                'visual/component-testing/workflow/baseline-branch',
+                'visual/component-testing/workflow/change-details',
+                'visual/component-testing/workflow/visual-history',
+                'visual/component-testing/workflow/ignoring-changes',
+                'visual/component-testing/workflow/include-exclude-settings',
+              ],
+            },
+            'visual/component-testing/supported-browsers',
+            'visual/component-testing/storybook-interactions-testing',
+            'visual/component-testing/storybook-static',
+          ],
+        },
+        'visual/css-animations',
+        'visual/acct-team-mgmt',
+        'visual/notifications',
+        'visual/faq',
+      ],
     },
     {
       type: 'category',
@@ -1220,17 +1337,17 @@ module.exports = {
       link: { type: 'doc', id: 'dev/test-configuration-options' },
       collapsed: true,
       items: [
-      'dev/test-configuration-options',
-      'dev/error-messages',
-      'dev/w3c-webdriver-capabilities',
-      {
-        type: 'link',
-        label: 'Visual E2E Testing', // The label that should be displayed (string).
-        href: '/visual/e2e-testing/commands-options', // The target URL (string).
-      },
-      'dev/data-center-maint',
-      'dev/glossary',
-    ],
+        'dev/test-configuration-options',
+        'dev/error-messages',
+        'dev/w3c-webdriver-capabilities',
+        {
+          type: 'link',
+          label: 'Visual E2E Testing', // The label that should be displayed (string).
+          href: '/visual/e2e-testing/commands-options', // The target URL (string).
+        },
+        'dev/data-center-maint',
+        'dev/glossary',
+      ],
     },
     {
       type: 'category',
@@ -1238,10 +1355,10 @@ module.exports = {
       link: { type: 'doc', id: 'contributing' },
       collapsed: true,
       items: [
-      'contributing',
-      'contributing/style-guide',
-      'contributing/code-of-conduct'
-    ],
+        'contributing',
+        'contributing/style-guide',
+        'contributing/code-of-conduct',
+      ],
     },
   ],
 };


### PR DESCRIPTION
### Description
This PR will add an Appium 2 migration guide and contains the following

- add new menu item
- add breaking changes
- remove appium 1 upgrade note, Appium 1 will follow a different process which needs to be determined
- add appium 1 eol message

### Motivation and Context
Appium 2 is coming, we already have in in our cloud

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
