### PR TITLE
Remove obsolete note

### DIFF
--- a/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
+++ b/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
@@ -261,9 +261,6 @@ A property containing one or more environment variables that are global for all 
     hello: world
     my_var: $MY_VAR  # You can also pass through existing environment variables through parameter expansion
 ```
-:::caution
-Currently, `env` only supports lowercase keys on `macOS` platform. The workaround is either passing the env through cli `saucectl run --env FOO=BAR` or setting `env` on suite level.
-:::
 
 ---
 

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -279,10 +279,6 @@ A property containing one or more environment variables that are global for all 
 Since environment variables are provided to Cypress directly, avoid using `CYPRESS_` as a prefix.
 :::
 
-:::caution
-Currently, `env` only supports lowercase keys on `macOS` platform. The workaround is either passing the env through cli `saucectl run --env FOO=BAR` or setting `env` on suite level. 
-:::
-
 ---
 
 ## `docker`

--- a/docs/web-apps/automated-testing/cypress/yaml/v1alpha.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1alpha.md
@@ -277,10 +277,6 @@ A property containing one or more environment variables that are global for all 
 Since environment variables are provided to Cypress directly, avoid using `CYPRESS_` as a prefix.
 :::
 
-:::caution
-Currently, `env` only supports lowercase keys on `macOS` platform. The workaround is either passing the env through cli `saucectl run --env FOO=BAR` or setting `env` on suite level. 
-:::
-
 ---
 
 ## `docker`

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -262,10 +262,6 @@ A property containing one or more environment variables that are global for all 
     my_var: $MY_VAR  # You can also pass through existing environment variables through parameter expansion
 ```
 
-:::caution
-Currently, `env` only supports lowercase keys on `macOS` platform. The workaround is either passing the env through cli `saucectl run --env FOO=BAR` or setting `env` on suite level.
-:::
-
 ---
 
 ## `docker`

--- a/docs/web-apps/automated-testing/puppeteer/yaml.md
+++ b/docs/web-apps/automated-testing/puppeteer/yaml.md
@@ -169,10 +169,6 @@ A property containing one or more environment variables that are global for all 
     my_var: $MY_VAR
 ```
 
-:::caution
-Currently, `env` only supports lowercase keys on `macOS` platform. The workaround is either passing the env through cli `saucectl run --env FOO=BAR` or setting `env` on suite level. 
-:::
-
 ---
 
 ## `docker`

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -262,9 +262,6 @@ A property containing one or more environment variables that are global for all 
     hello: world
     my_var: $MY_VAR  # You can also pass through existing environment variables through parameter expansion
 ```
-:::caution
-Currently, `env` only supports lowercase keys on `macOS` platform. The workaround is either passing the env through cli `saucectl run --env FOO=BAR` or setting `env` on suite level. 
-:::
 
 ---
 


### PR DESCRIPTION
### Description

Environment variables are now properly case-sensitive: https://github.com/saucelabs/saucectl/releases/tag/v0.114.0