### PR TITLE
Removing links to all 4.6.x versions

### DIFF
--- a/docs/secure-connections/sauce-connect/installation.md
+++ b/docs/secure-connections/sauce-connect/installation.md
@@ -192,56 +192,9 @@ The launch of Sauce Connect 4.8.2 makes it the officially supported version of t
     <a href="https://saucelabs.com/downloads/sc-4.7.0-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.7.0-osx.zip">Mac</a>
    </td>
   </tr>
-  <tr>
-   <td rowspan="6" >4.6
-   </td>
-   <td>4.6.5
-   </td>
-   <td>
-    <a href="https://saucelabs.com/downloads/sc-4.6.5-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.6.5-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.6.5-win32.zip">Windows</a>
-   </td>
-   <td rowspan="6" >Nov. 30, 2022
-   </td>
-  </tr>
-  <tr>
-   <td>4.6.4
-   </td>
-   <td>
-    <a href="https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.6.4-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.6.4-win32.zip">Windows</a>
-   </td>
-  </tr>
-  <tr>
-   <td>4.6.3
-   </td>
-   <td>
-    <a href="https://saucelabs.com/downloads/sc-4.6.3-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.6.3-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.6.3-win32.zip">Windows</a>
-   </td>
-  </tr>
-  <tr>
-   <td>4.6.2
-   </td>
-   <td>
-    <a href="https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.6.2-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.6.2-win32.zip">Windows</a>
-   </td>
-  </tr>
-  <tr>
-   <td>4.6.1
-   </td>
-   <td>
-   <a href="https://saucelabs.com/downloads/sc-4.6.1-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.6.1-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.6.1-win32.zip">Windows</a>
-   </td>
-  </tr>
-  <tr>
-   <td>4.6.0<sup><a href="#sauce-connect-proxy-versions-below-461-which-were-supporting-private-certificates-reached-end-of-life-and-are-no-longer-available-for-download">**</a></sup>
-   </td>
-   <td>
-   &#8212;
-   </td>
-  </tr>
 </table>
 
 ##### <sup>*</sup>Windows version no longer available for download.
-##### <sup>**</sup>Sauce Connect Proxy versions below 4.6.1, which were supporting Private Certificates, reached end of life and are no longer available for download.
 
 ## Using Sauce Connect in Docker
 


### PR DESCRIPTION
### Description
We have EOL'd all 4.6.x versions of SC Client Proxy, so we need to remove the links that allow those to be downloaded.

### Motivation and Context
We want to reduce the number of SC Client Proxy versions being used by customers to ease Support and Engineering's burden of having to remember an additional 5 versions of functionality differences.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [N/A] I have added tests to cover my changes.
- [N/A] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
