### PR TITLE
Update live-mobile-app-testing.md

### DIFF
--- a/docs/mobile-apps/live-testing/live-mobile-app-testing.md
+++ b/docs/mobile-apps/live-testing/live-mobile-app-testing.md
@@ -62,7 +62,7 @@ To view your recent configurations, click **Recents**.
 | Device Language | Use the dropdown to select the device language. The language selector will tell your application that the locale of the device and region is set to the selected parameter. You wont need to change the language of the OS manually during a session inside iOS/Android settings. ([Read more about Locale here](https://developer.apple.com/documentation/foundation/locale)).  |
 | Device Orientation | Use the dropdown to set the device orientation (Landscape or Portrait). |
 | Proxy | Enable/disable the use of a proxy. Enter the **Hostname** and **Port** and then click **Update**. |
-| Device Passcode <br/><p><span className="sauceDBlue">Android Only</span></p> | Enable/disable the device passcode for Android apps. If your app requires a device passcode to launch, you can enable this setting to run your tests on a passcode-protected device. |
+| Device Passcode <br/><p><span className="sauceDBlue">Real Devices Only</span></p> | Enable/disable the device passcode for your apps. If your app requires a device passcode/screenlock to launch, you can enable this setting to run your tests on a passcode-protected device. |
 | Instrumentation | Enable/disable device instrumentation. Enabling allows you to use advanced features when testing your app in the real device cloud, like image injection and taking screenshots of secure views.  |
 | Image Injection | Enable/disable image injection. Image injection allows you to mimic camera behavior when testing apps by letting you upload an image and present it to the app as if it were read by the device camera. |
 | Bypass Screenshot Restriction <br/><p><span className="sauceDBlue">Android Only</span></p> | Enable/disable Bypass Screenshot Restriction (not supported on apps uploaded to the legacy sauce storage). If you're testing Android mobile apps on Sauce Labs and see a black screen in your live testing session, you might need to enable the <b>Bypass Screenshot Restriction</b>. This allows Sauce Labs to work around a setting on those apps that prevents screenshots or videos from being taken. However, there are other details to keep in mind. To effectively test apps that have this setting, see [Bypass Screenshot Restriction](/mobile-apps/features/bypass-screenshot). |
@@ -260,22 +260,11 @@ To make Apple Pay work on Sauce Labs real private devices:
 
 ### Passcode
 
-One of the Apple Pay requirements is having a set passcode on your phone. Without it, you won't be able to add cards to your wallet. To learn more about setting a passcode, see [Adding the Testing Account](#add-the-testing-account) section.
-
-### Add the Testing Account
-1. On the device, go to **Settings** and then click **Sign in to your iPhone**. Sign in using your Apple sandbox tester account.
-
-<img src={useBaseUrl('img/live-testing/apple-pay-4.png')} alt="Apple Pay setup - sign in to account" width="250"/>
-
-2. If prompted, enter the device’s passcode.
-
-<img src={useBaseUrl('img/live-testing/apple-pay-5.png')} alt="Apple Pay setup - passcode" width="250"/>
-
-  If you weren’t prompted for a passcode, set it by going to **Settings > Face ID & Passcode** and tapping **Turn Passcode On**.
+One of the Apple Pay requirements is having a set passcode on your phone. Without it, you won't be able to add cards to your wallet. You need to use our Device Passcode capability.  
 
 ### Add Apple Sandbox Test Cards
 Apple test cards can be found on Apple’s [Sandbox Testing](https://developer.apple.com/apple-pay/sandbox-testing/) page.
-1. On your device, go to **Wallet**. If you didn’t set a passcode, Apple will show a notification.
+1. On your device, go to **Wallet**. If you didn’t set the passcode capability, Apple will show a notification.
 
 <img src={useBaseUrl('img/live-testing/apple-pay-6.png')} alt="Apple Pay setup - passcode notification" width="250"/>
 


### PR DESCRIPTION
new passcode capability, and removing option to manually update passcode in the apple payment testing part

- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
