### PR TITLE
Clarify showConsoleLog usage

### DIFF
--- a/docs/mobile-apps/automated-testing/espresso-xcuitest/espresso.md
+++ b/docs/mobile-apps/automated-testing/espresso-xcuitest/espresso.md
@@ -60,7 +60,7 @@ kind: espresso
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
 
-Generates the `console.log` as local output and as a test asset in Sauce Labs for all tests. By default, `console.log` is only included in results for failed tests.
+Controls whether the contents of `console.log` are always shown in the local output of saucectl. By default (false), `console.log` is only shown for failed suites.
 
 ```yaml
 showConsoleLog: true

--- a/docs/mobile-apps/automated-testing/espresso-xcuitest/xcuitest.md
+++ b/docs/mobile-apps/automated-testing/espresso-xcuitest/xcuitest.md
@@ -62,7 +62,7 @@ kind: xcuitest
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
 
-Generates the `console.log` as local output and as a test asset in Sauce Labs for all tests. By default, `console.log` is only included in results for failed tests.
+Controls whether the contents of `console.log` are always shown in the local output of saucectl. By default (false), `console.log` is only shown for failed suites.
 
 ```yaml
 showConsoleLog: true

--- a/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
+++ b/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
@@ -60,7 +60,7 @@ kind: playwright-cucumberjs
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
 
-Generates the `console.log` as local output and as a test asset in Sauce Labs for all tests. By default, `console.log` is only included in results for failed tests.
+Controls whether the contents of `console.log` are always shown in the local output of saucectl. By default (false), `console.log` is only shown for failed suites.
 
 ```yaml
 showConsoleLog: true

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -70,7 +70,7 @@ kind: cypress
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
 
-Generates the `console.log` as local output and as a test asset in Sauce Labs for all tests. By default, `console.log` is only included in results for failed tests.
+Controls whether the contents of `console.log` are always shown in the local output of saucectl. By default (false), `console.log` is only shown for failed suites.
 
 ```yaml
 showConsoleLog: true

--- a/docs/web-apps/automated-testing/cypress/yaml/v1alpha.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1alpha.md
@@ -68,7 +68,7 @@ kind: cypress
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
 
-Generates the `console.log` as local output and as a test asset in Sauce Labs for all tests. By default, `console.log` is only included in results for failed tests.
+Controls whether the contents of `console.log` are always shown in the local output of saucectl. By default (false), `console.log` is only shown for failed suites.
 
 ```yaml
 showConsoleLog: true

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -60,7 +60,7 @@ kind: playwright
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
 
-Generates the `console.log` as local output and as a test asset in Sauce Labs for all tests. By default, `console.log` is only included in results for failed tests.
+Controls whether the contents of `console.log` are always shown in the local output of saucectl. By default (false), `console.log` is only shown for failed suites.
 
 ```yaml
 showConsoleLog: true

--- a/docs/web-apps/automated-testing/puppeteer/yaml.md
+++ b/docs/web-apps/automated-testing/puppeteer/yaml.md
@@ -60,7 +60,7 @@ kind: puppeteer
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
 
-Generates the `console.log` as local output and as a test asset in Sauce Labs for all tests. By default, `console.log` is only included in results for failed tests.
+Controls whether the contents of `console.log` are always shown in the local output of saucectl. By default (false), `console.log` is only shown for failed suites.
 
 ```yaml
 showConsoleLog: true

--- a/docs/web-apps/automated-testing/replay/yaml.md
+++ b/docs/web-apps/automated-testing/replay/yaml.md
@@ -60,7 +60,7 @@ kind: puppeteer-replay
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
 
-Show the contents of the remote `console.log` as local output. By default, the contents of `console.log` are only displayed locally on failure.
+Controls whether the contents of `console.log` are always shown in the local output of saucectl. By default (false), `console.log` is only shown for failed suites.
 
 ```yaml
 showConsoleLog: true

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -60,7 +60,7 @@ kind: testcafe
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
 
-Generates the `console.log` as local output and as a test asset in Sauce Labs for all tests. By default, `console.log` is only included in results for failed tests.
+Controls whether the contents of `console.log` are always shown in the local output of saucectl. By default (false), `console.log` is only shown for failed suites.
 
 ```yaml
 showConsoleLog: true


### PR DESCRIPTION
### Description
Clarify usage of `showConsoleLog`. It wasn't very clear to users what happened when this setting is `false`, since the console log output was still shown (on failure), which is by design.