### PR TITLE
add "The New Session Request Redirect not Followed Timeout" error-message | TPT-245

### DIFF
--- a/docs/dev/error-messages.md
+++ b/docs/dev/error-messages.md
@@ -172,7 +172,7 @@ This error has a few potential causes:
 - Make sure you're launching an appropriate number of jobs for your account.
 - If you see this error with iOS Simulator tests, please make sure the timeouts in your test runner/framework are set to a sufficient duration to allow iOS Simulator tests to start up. We recommend a minimum of 2 minutes.
 
-### The New Session Request Redirect not Followed Timeout
+### The New Session Request Redirect Was Not Followed Before Timeout
 
 **Description**
 

--- a/docs/dev/error-messages.md
+++ b/docs/dev/error-messages.md
@@ -180,8 +180,8 @@ Your test session was abandoned because it took longer than 45 seconds to assign
 
 **Cause**
 
-- client-side requests throttling/errors. Please check logs from your test runner for any errors.
-- see related [New Session Request was Cancelled before a Sauce Labs Virtual Machine was Found](#the-new-session-request-was-cancelled-before-a-sauce-labs-virtual-machine-was-found) error for more hints
+The main cause for this error is client-side request throttling/errors. Make sure to check the logs from your test runner for any errors.
+See the related [New Session Request was Cancelled before a Sauce Labs Virtual Machine was Found](#the-new-session-request-was-cancelled-before-a-sauce-labs-virtual-machine-was-found) error message for more information.
 
 **How to Resolve**
 

--- a/docs/dev/error-messages.md
+++ b/docs/dev/error-messages.md
@@ -176,7 +176,7 @@ This error has a few potential causes:
 
 **Description**
 
-Your tests start took longer to assign a Sauce Labs Virtual Machine but your test runner did not follow new session redirect before timeout.
+Your test session was abandoned because it took longer than 45 seconds to assign a Sauce Labs Virtual Machine, and your test runner did not follow the new session redirect before timeout.
 
 **Cause**
 

--- a/docs/dev/error-messages.md
+++ b/docs/dev/error-messages.md
@@ -172,6 +172,22 @@ This error has a few potential causes:
 - Make sure you're launching an appropriate number of jobs for your account.
 - If you see this error with iOS Simulator tests, please make sure the timeouts in your test runner/framework are set to a sufficient duration to allow iOS Simulator tests to start up. We recommend a minimum of 2 minutes.
 
+### The New Session Request Redirect not Followed Timeout
+
+**Description**
+
+Your tests start took longer to assign a Sauce Labs Virtual Machine but your test runner did not follow new session redirect before timeout.
+
+**Cause**
+
+- client-side requests throttling/errors. Please check logs from your test runner for any errors.
+- see related [New Session Request was Cancelled before a Sauce Labs Virtual Machine was Found](#the-new-session-request-was-cancelled-before-a-sauce-labs-virtual-machine-was-found) error for more hints
+
+**How to Resolve**
+
+- Make sure your test runner is not running out of resources (CPU/Network).
+- Make sure your test runner has enough logging enabled to support troubleshooting.
+
 ### Selenium Didn't Complete Your Last Request on Time
 
 **Description**


### PR DESCRIPTION
### Description
Add a new [new-session error message docs](https://github.com/saucelabs/sauce-docs/blob/TPT-245-add-doc-for-new-session-request-redirect-not-followed-timeout/docs/dev/error-messages.md#the-new-session-request-redirect-not-followed-timeout).

### Motivation and Context
This is a new error type to help better use sauce VMs ( when user abandons session, force stop any resources/VMs)

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist

- [x] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.



[TPT-245]: https://saucedev.atlassian.net/browse/TPT-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ