### PR TITLE
remove not existing capability

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -1108,22 +1108,6 @@ capabilities.setCapability("sauce:options", sauceOptions);
 
 ---
 
-### `deviceType`
-
-<p><small>| OPTIONAL | STRING | <span className="sauceDBlue">Real Devices Only</span> |</small></p>
-
-Specifies the type of device type to emulate. Options are: `tablet` and `phone`.
-
-```java
-MutableCapabilities capabilities = new MutableCapabilities();
-//...
-MutableCapabilities sauceOptions = new MutableCapabilities();
-sauceOptions.setCapability("deviceType", "tablet");
-capabilities.setCapability("sauce:options", sauceOptions);
-```
-
----
-
 ### `setupDeviceLock`
 
 <p><small>| OPTIONAL | BOOLEAN | <span className="sauceDBlue">Real Devices Only</span> | </small></p>


### PR DESCRIPTION
`deviceType` is not an officially supported option in our RDC code. Removing it. Customers should use the [tabletOnly](https://docs.saucelabs.com/dev/test-configuration-options/#tabletonly) or [phoneOnly](https://docs.saucelabs.com/dev/test-configuration-options/#phoneonly) which will be easer.