### PR TITLE
Remove deprecated releases

### DIFF
--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -156,25 +156,6 @@ values={[
     </tbody>
     <tbody>
     <tr>
-      <td rowspan='2'>9.3.1</td>
-      <td><b>macOS:</b> 11.00</td>
-      <td rowspan='2'>Chrome, Firefox, Microsoft Edge</td>
-      <td rowspan='2'>Feb 2, 2023</td>
-    </tr>
-    <tr>
-      <td><b>Windows:</b> 10</td>
-    </tr>
-    </tbody>
-    <tbody>
-    <tr>
-      <td rowspan='1'>9.1.0</td>
-      <td><b>Windows:</b> 10</td>
-      <td>Chrome, Firefox, Microsoft Edge</td>
-      <td rowspan='2'>Nov 29, 2022</td>
-    </tr>
-    </tbody>
-    <tbody>
-    <tr>
       <td rowspan='1'>8.6.0</td>
       <td><b>Windows:</b> 10</td>
       <td>Chrome, Firefox, Microsoft Edge</td>

--- a/docs/web-apps/automated-testing/playwright.md
+++ b/docs/web-apps/automated-testing/playwright.md
@@ -156,26 +156,6 @@ values={[
       <td><b>Windows:</b> 10, 11</td>
     </tr>
     </tbody>
-    <tbody>
-    <tr>
-      <td rowspan='2'>1.18.1</td>
-      <td><b>macOS:</b> 11.00</td>
-      <td>Chromium, Firefox</td>
-      <td rowspan='2'>Feb 2, 2023</td>
-    </tr>
-    <tr>
-      <td><b>Windows:</b> 10</td>
-      <td>Chromium, Firefox, Webkit</td>
-    </tr>
-    </tbody>
-    <tbody>
-    <tr>
-      <td rowspan='1'>1.17.1</td>
-      <td><b>Windows:</b> 10</td>
-      <td>Chromium, Firefox, Webkit</td>
-      <td>Nov 29, 2022</td>
-    </tr>
-    </tbody>
   </table>
 
  </TabItem>

--- a/docs/web-apps/automated-testing/testcafe.md
+++ b/docs/web-apps/automated-testing/testcafe.md
@@ -195,54 +195,6 @@ values={[
       <td>Safari</td>
     </tr>
     </tbody>
-    <tbody>
-    <tr>
-      <td rowspan='3'>1.18.3</td>
-      <td><b>macOS:</b> 11.00</td>
-      <td>Safari, Chrome, Firefox, Microsoft Edge</td>
-      <td rowspan='3'>Feb 2, 2023</td>
-    </tr>
-    <tr>
-      <td><b>Windows:</b> 10</td>
-      <td>Chrome, Firefox, Microsoft Edge</td>
-    </tr>
-    <tr>
-      <td><b>iOS:</b> 13.4, 14.0, 14.3</td>
-      <td>Safari</td>
-    </tr>
-    </tbody>
-    <tbody>
-    <tr>
-      <td rowspan='3'>1.17.1</td>
-      <td><b>macOS:</b> 11.00</td>
-      <td>Safari, Chrome, Firefox, Microsoft Edge</td>
-      <td rowspan='3'>Nov 29, 2022</td>
-    </tr>
-    <tr>
-      <td><b>Windows:</b> 10</td>
-      <td>Chrome, Firefox, Microsoft Edge</td>
-    </tr>
-    <tr>
-      <td><b>iOS:</b> 13.4, 14.0, 14.3</td>
-      <td>Safari</td>
-    </tr>
-    </tbody>
-    <tbody>
-    <tr>
-      <td rowspan='3'>1.16.1</td>
-      <td><b>macOS:</b> 11.00</td>
-      <td>Safari, Chrome, Firefox, Microsoft Edge</td>
-      <td rowspan='3'>Oct 13, 2022</td>
-    </tr>
-    <tr>
-      <td><b>Windows:</b> 10</td>
-      <td>Chrome, Firefox, Microsoft Edge</td>
-    </tr>
-    <tr>
-      <td><b>iOS:</b> 13.4, 14.0, 14.3</td>
-      <td>Safari</td>
-    </tr>
-    </tbody>
   </table>
 
 </TabItem>


### PR DESCRIPTION
Just a little cleanup on deprecated releases. Cypress 8.6.0 is deliberately kept around due to performance issues that some customers experience when using newer versions of Cypress.