### PR TITLE
Add 'Enterprise Plans only' tag to concurrency-limits.md

### DIFF
--- a/docs/basics/acct-team-mgmt/concurrency-limits.md
+++ b/docs/basics/acct-team-mgmt/concurrency-limits.md
@@ -6,6 +6,8 @@ sidebar_label: Concurrency Limits and Team Accounts
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+<p><span className="sauceDBlue">Enterprise Plans only</span></p>
+
 If your organization has multiple teams sharing a Sauce Labs account, it's important to monitor your concurrency limits--the number of virtual machines that you can run tests on simultaneously. You'll need to ensure that your organization's concurrency is distributed among your accounts.
 
 If you are an org admin, you can view your organization's concurrency limits:


### PR DESCRIPTION
As this section of documentation relates to Concurrency Limits and Team Accounts, this should have the 'Enterprise Only' tag, which is provided on the three other pages in this section:

https://docs.saucelabs.com/basics/acct-team-mgmt/adding-deactivating-users/ https://docs.saucelabs.com/basics/acct-team-mgmt/managing-user-info/ https://docs.saucelabs.com/basics/acct-team-mgmt/viewing-exporting-usage-data/

<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
