### PR TITLE
Removing note about Azure plugin being deprecated

### DIFF
--- a/docs/basics/integrations/azure.md
+++ b/docs/basics/integrations/azure.md
@@ -16,10 +16,6 @@ Azure DevOps (formerly Visual Studio Team Services or VSTS) is a Microsoft produ
 - Your Sauce Labs [Username and Access Key](https://app.saucelabs.com/user-settings)
 - An existing Azure DevOps pipeline
 
-:::note
-The Sauce Labs OnDemand plugin for Azure DevOps has been deprecated.
-:::
-
 ## Using Azure DevOps
 
 Follow the instructions below to integrate Sauce Labs testing into your Azure pipeline.


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->


<!--- Provide a general summary of your changes in the Title above -->

### Description
This page describes how to integrate with Azure **outside** of a plug-in, so there was no reason to keep the warning. If there are no references to it, and it was a long time ago, nobody should ever care (or even know) that we had a plugin.

### Motivation and Context
A customer halted their buying process with us because this "deprecation" message led them to believe we don't integrate with Azure at all. This message made them read no further on the page.

This note directly affected a 6-figure sales process. I want to make sure that doesn't happen again.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md) document.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
