### PR TITLE
Add description of Get icon API for App Storage

### DIFF
--- a/docs/dev/api/storage.md
+++ b/docs/dev/api/storage.md
@@ -287,7 +287,7 @@ Returns an array of groups (apps containing multiple files) currently in storage
   <tbody>
     <tr>
      <td><code>icon_repr</code></td>
-     <td><p><small>| QUERY | OPTIONAL | STRING |</small></p><p>Available values are: <ul><li><code>base64</code></li><li><code>hash</code></li>. The default value is <code>base64</code>. If set to <code>hash</code>, then only the <code>icon_hash</code> field will be populated in the file metadata, while the <code>icon</code> field will always be <code>null</code>. This helps to reduce the overall size of the JSON response significantly.</p></td>
+     <td><p><small>| QUERY | OPTIONAL | STRING |</small></p><p>Available values are: <ul><li><code>base64</code></li><li><code>hash</code></li></ul>. The default value is <code>base64</code>. If set to <code>hash</code>, then only the <code>icon_hash</code> field will be populated in the file metadata, while the <code>icon</code> field will always be <code>null</code>. This helps to reduce the overall size of the JSON response significantly.</p></td>
     </tr>
   </tbody>
   <tbody>


### PR DESCRIPTION
### Description
The PR documents the recently added App Storage feature, which allows to reduce overall sizes of list files responses by only having icon hashes in them instead of base64-encoded payloads.


### Motivation and Context
See https://saucedev.atlassian.net/browse/LT-3044

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
