### PR TITLE
[IAM-5429] add a warning about the legacy SSO Okta app

### DIFF
--- a/docs/basics/sso/configuring-sso-in-okta.md
+++ b/docs/basics/sso/configuring-sso-in-okta.md
@@ -20,7 +20,7 @@ Complete the following steps to set up SAML SSO integration between Okta and Sau
 1. Log into **Okta** administrator panel, go to **Applications** and click **Browse App Catalog**.
    <img src={useBaseUrl('img/basics/sso/idp-config/okta/browse-app-catalog.png')} alt="Browse App Catalog" width="850" />
 
-2. Enter **Sauce Labs** in the search box and choose the app **Sauce Labs**.
+2. Search for **Sauce Labs**, then select the [**Sauce Labs**](https://www.okta.com/integrations/sauce-labs-0/) app.
    :::caution
    Ensure that you install the new Sauce Labs app featuring the green logo. The app with the previous red logo is considered a legacy version and should not be used for new SSO integrations. It is integrated with the deprecated SSO implementation.
    :::

--- a/docs/basics/sso/configuring-sso-in-okta.md
+++ b/docs/basics/sso/configuring-sso-in-okta.md
@@ -21,6 +21,10 @@ Complete the following steps to set up SAML SSO integration between Okta and Sau
    <img src={useBaseUrl('img/basics/sso/idp-config/okta/browse-app-catalog.png')} alt="Browse App Catalog" width="850" />
 
 2. Enter **Sauce Labs** in the search box and choose the app **Sauce Labs**.
+   :::caution
+   Ensure that you install the new Sauce Labs app featuring the green logo. The app with the previous red logo is considered a legacy version and should not be used for new SSO integrations. It is integrated with the deprecated SSO implementation.
+   :::
+   <br/>
    <img src={useBaseUrl('img/basics/sso/idp-config/okta/search-app.png')} alt="Search For Sauce Labs" width="800" />
 
 3. Click **Add Integration**.


### PR DESCRIPTION
### Description
Some customers mistakenly choose the legacy Okta app (with the red logo) which is integrated with the depreacted SSO implementation. New SSO integrations should be created using the new app featuring the new green Sauce Labs logo.

https://saucedev.atlassian.net/browse/IAM-5429?focusedCommentId=434689

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
