### PR TITLE
Update teams docs

### DIFF
--- a/docs/dev/api/accounts.md
+++ b/docs/dev/api/accounts.md
@@ -229,7 +229,7 @@ Creates a new team under the organization of the requesting account.
   <tbody>
     <tr>
      <td><code>description</code></td>
-     <td><p><small>| BODY | REQUIRED | STRING |</small></p><p>A description to distinguish the team within the organization.</p></td>
+     <td><p><small>| BODY | OPTIONAL | STRING |</small></p><p>A description to distinguish the team within the organization.</p></td>
     </tr>
   </tbody>
 </table>
@@ -419,7 +419,7 @@ Replaces all values of the specified team with the new set of parameters passed 
   <tbody>
     <tr>
      <td><code>description</code></td>
-     <td><p><small>| BODY | REQUIRED | STRING |</small></p><p>A description to distinguish the team within the organization. If the previous team definition included a description, omitting the parameter in the update will delete it from the team record.</p></td>
+     <td><p><small>| BODY | OPTIONAL | STRING |</small></p><p>A description to distinguish the team within the organization. If the previous team definition included a description, omitting the parameter in the update will delete it from the team record.</p></td>
     </tr>
   </tbody>
 </table>

--- a/docs/dev/api/accounts.md
+++ b/docs/dev/api/accounts.md
@@ -229,7 +229,7 @@ Creates a new team under the organization of the requesting account.
   <tbody>
     <tr>
      <td><code>description</code></td>
-     <td><p><small>| BODY | OPTIONAL | STRING |</small></p><p>A description to distinguish the team within the organization.</p></td>
+     <td><p><small>| BODY | OPTIONAL | STRING |</small></p><p>A description to distinguish the team in the organization.</p></td>
     </tr>
   </tbody>
 </table>
@@ -419,7 +419,7 @@ Replaces all values of the specified team with the new set of parameters passed 
   <tbody>
     <tr>
      <td><code>description</code></td>
-     <td><p><small>| BODY | OPTIONAL | STRING |</small></p><p>A description to distinguish the team within the organization. If the previous team definition included a description, omitting the parameter in the update will delete it from the team record.</p></td>
+     <td><p><small>| BODY | OPTIONAL | STRING |</small></p><p>A description to distinguish the team in the organization. If the previous team definition included a description, omitting the parameter in the update will delete it from the team record.</p></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
### Description
Update teams create and update methods after changes in the backend.
From now on we will not require sending team descriptions in creation/update.

### Motivation and Context
Currently, we don't display descriptions in the client UI.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
