### PR TITLE
error-reporting/advanced/dwarf: update references

### DIFF
--- a/docs/error-reporting/advanced/dwarf.md
+++ b/docs/error-reporting/advanced/dwarf.md
@@ -121,7 +121,5 @@ You can utilize the other techniques mentioned in this article to further compre
 
 ## More Information
 
-- [Symbolic Debugging with DWARF](https://backtrace.io/blog/symbolic-debugging-with-dwarf/)
-- [Debugger Internals](https://backtrace.io/blog/debugger-internals/)
-- [How Debuggers Work](https://eli.thegreenplace.net/2011/01/23/how-debuggers-work-part-1)
-- [Debugging Memory Allocation](https://backtrace.io/blog/debugging-memory-allocation/)
+- [DWARF Debugging Standard](https://dwarfstd.org/index.html)
+- [Introduction to the DWARF Debugging Format](http://www.dwarfstd.org/doc/Debugging%20using%20DWARF-2012.pdf)


### PR DESCRIPTION
### Description
Remove broken references linked at bottom of page. Replaced these with links to the DWARF standards home page and an article that gives a high-level overview of the format.

### Motivation and Context
Eliminates broken links; adds links to relevant supplementary documentation.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
