### PR TITLE
Update for link for new BacktraceAndroid_UPL.xml

### DIFF
--- a/docs/error-reporting/platform-integrations/unreal/setup.md
+++ b/docs/error-reporting/platform-integrations/unreal/setup.md
@@ -137,7 +137,7 @@ To configure the crash reporter for a packaged build:
 
 Integrate the [backtrace-android](https://github.com/backtrace-labs/backtrace-android) error reporting library with your Unreal Engine game for Android written in Java or Kotlin.
 
-1. Download [BacktraceAndroid_UPL.xml](https://gist.github.com/lysannep/6c09a572baffede96cd250dbdf01279a#file-backtraceandroid_upl-xml).
+1. Download [BacktraceAndroid_UPL.xml](https://gist.github.com/ianrice07/36d8731f0d1af10af4803288c7c86c10).
 1. In the `BacktraceAndroid_UPL.xml` file, provide the name of your [subdomain and a submission token](/error-reporting/platform-integrations/unreal/setup/#what-youll-need) for `BacktraceCredentials`.
    - Java:
      ```java


### PR DESCRIPTION
- Updates to Backtrace-Android 3.7.6
- Adds ProGuard rules for Android release builds

### Description
Updated the link for the BacktraceAndroid_UPL.xml.  The new link updates the UPL to pull a newer version of Backtrace-Android and adds required ProGuard rules to Unreal Engine release builds for Android.

### Motivation and Context

- Customers have run into issues due to the old link using an old version of Backtrace-Android which has compatibility issues on later versions of Android.
- If doing a release build for Android with UE4/5 ProGuard rules are needed to ensure compatibility. 

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
