### PR TITLE
Fixing link to point at production instead of staging

### DIFF
--- a/docs/basics/integrations/sumo.md
+++ b/docs/basics/integrations/sumo.md
@@ -56,7 +56,7 @@ Before you can push test data from Sauce Labs to Sumo Logic, you must create a c
 
 ## Enabling the Sumo Logic Integration in Sauce Labs
 
-1. From your Sauce Labs account, navigate to the [Account Integrations](https://app.staging.saucelabs.net/integrations) page.
+1. From your Sauce Labs account, navigate to the [Account Integrations](https://app.saucelabs.com/integrations) page.
 1. Click the Sumo Logic **Enable** button.
 1. Provide the source URL from your Sumo Logic Sauce Labs collector.
 1. Click **Save**.
@@ -69,7 +69,7 @@ The Sumo Logic integration is specific to the data center that is active for you
 
 ### Remove your Sumo Logic Integration
 
-1. From your Sauce Labs account, navigate to the [Account Integrations](https://app.staging.saucelabs.net/integrations) page.
+1. From your Sauce Labs account, navigate to the [Account Integrations](https://app.saucelabs.com/integrations) page.
 1. Click the Sumo Logic **Enable** button.
 1. Click **Remove Configurations**.
 


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->
The current sumo doc page links to app.staging.saucelabs.net instead of app.saucelabs.com. I'm fixing that.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
