### PR TITLE
Create electron.md for Electron support beta

### DIFF
--- a/docs/web-apps/automated-testing/electron.md
+++ b/docs/web-apps/automated-testing/electron.md
@@ -1,0 +1,105 @@
+---
+id: electron
+title: Electron Support on Sauce Labs [Beta]
+sidebar_label: Electron
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+[Electron](https://electronjs.org/) embeds Chromium and Node.js to enable web developers to create desktop applications. Sauce Labs is beta trialing support for automated testing with Electron-based apps on Windows 10 and 11, available to all users with VDC concurrency at US West or EU Central.
+
+## Supported Testing Platforms
+
+Sauce Labs currently supports the following test configurations for Electron.
+### Platforms
+Windows 10, Windows 11 (Linux and MacOS 13 support to come)
+### Electron versions
+versions 5 - 25
+
+## How to Get Started
+
+### App management
+
+Upload a zip file containing your Electron app via [REST API](/mobile-apps/app-storage/#uploading-apps-via-rest-api). You can refer to uploaded apps by either the app_id or app_name. Note that as with mobile apps, Electron apps are accessible only to members of the same team, and retained for 60 days.
+
+### Binary location
+
+The binary location is the folderpath and filename of your Electron executable within your zip file structure.
+
+For example, if your zip file is structured like this:
+```
+SauceLabsElectronAppv1.zip
+-- [ Sauce Labs Test ]
+  -- SauceLabsElectronApp.exe
+  -- mobi.dll
+  -- [ resources ]
+      -- ffmpeg.dll  
+  [ guide ]
+  -- config.yaml
+  -- readme.txt
+```
+
+then the `binary` value is `'Sauce Labs Test\SauceLabsElecronApp.exe'`.
+
+### Configuring your tests
+
+You need to specify Electron as the browser name along with the Electron version needed as the browser version. You will also need to include either the file_id or file_name of your uploaded zip file containing your Electron app, with the path to the binary inside that zip.
+Examples with an Electron app test running on Windows 11 with Chromedriver 19 at US West:
+
+<Tabs
+  defaultValue="JavaScript"
+  values={[
+  {label: 'JavaScript', value: 'JavaScript'},
+  {label: 'Python', value: 'Python'},
+  ]}>
+  
+<TabItem value="Javascript">
+```
+driver = new Builder()
+        .usingServer('https://ondemand.us-west-1.saucelabs.com:443/wd/hub')
+        .withCapabilities({
+            browserName: 'electron',
+            browserVersion: '19',
+            platformName: 'Windows 11',
+            'goog:chromeOptions': {
+                binary: '<app_folder_name>\<app_file_name.exe>',
+                   ]
+            },
+            'sauce:options': {
+                username: '<username>’,
+                accessKey: ‘<accesskey>',
+                app: 'storage:<file_id>',
+            }
+        })
+        .forBrowser('electron')
+        .build();
+```
+</TabItem>
+
+<TabItem value="Python">
+```
+options = ChromeOptions()
+options.set_capability('browserName', 'electron')
+options.browser_version = '19'
+options.platform_name = 'Windows 11'
+options.binary_location='<app_folder_name>\<app_file_name.exe>'
+sauce_options = {}
+sauce_options['username'] = ‘<username>’
+sauce_options['accessKey'] = ‘<accesskey>’
+sauce_options['app'] = 'storage:<file_id>'
+options.set_capability('sauce:options', sauce_options)
+url = 'https://ondemand.us-west-1.saucelabs.com:443/wd/hub'
+driver = webdriver.Remote(command_executor=url, options=options)
+```
+</TabItem>
+</Tabs>
+  
+## Viewing results
+
+Test results are visible on the UI under “Automated Tests > Test Results.’ You can filter directly for Electron test results by selecting “Electron” from the “Browser” drop-down.
+
+## Limitations
+
+Electron support is currently enabled only for automated testing on Windows 10 and 11. Electron apps uploaded via REST API are not currently visible within the App Management of the UI. Live testing and UI enhancements to come in a future release.


### PR DESCRIPTION
Added documentation for Electron beta testing. Not currently adding this to the sidebar until we're closer to launch, as we might also want to move it from webapps to a different section.

### Description
Added a new page for Electron beta testing.

### Motivation and Context
Electron is a framework for desktop, Chromium-based apps (like Slack) that are in between our current web app and mobile app offerings. Need to have a page to point customers to on how to use this feature during the beta period.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
