### PR TITLE
[IAM-5752] Ability to filter entity list by multiple IDs

### DIFF
--- a/docs/dev/api/accounts.md
+++ b/docs/dev/api/accounts.md
@@ -823,12 +823,6 @@ You can narrow the results of your query using any of the following filtering pa
   </tbody>
   <tbody>
     <tr>
-     <td><code>team-name</code></td>
-     <td><p><small>| QUERY | OPTIONAL | STRING |</small></p><p>Limit results to users who belong to the specified team names. Specify multiple teams as comma-separated values.</p></td>
-    </tr>
-  </tbody>
-  <tbody>
-    <tr>
      <td><code>roles</code></td>
      <td><p><small>| QUERY | OPTIONAL | INTEGER |</small></p><p>Limit results to users who are assigned certain roles. Valid values are:
        <ul>

--- a/docs/dev/api/accounts.md
+++ b/docs/dev/api/accounts.md
@@ -811,6 +811,12 @@ You can narrow the results of your query using any of the following filtering pa
 <table id="table-api">
   <tbody>
     <tr>
+     <td><code>id</code></td>
+     <td><p><small>| QUERY | OPTIONAL | STRING |</small></p><p>Comma-separated user IDs. Allows to receive details of multiple user at once. For example, <code>id=3d60780314724ab8ac688b50aadd9ff9,f9acc7c5b1da4fd0902b184c4f0b6324</code> would return details of users with IDs included in the provided list.</p></td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
      <td><code>username</code></td>
      <td><p><small>| QUERY | OPTIONAL | STRING |</small></p><p>Limits the results to usernames that begin with the specified value. For example, <code>username=an</code> would return all users in the organization with usernames beginning with "an".</p></td>
     </tr>

--- a/docs/dev/api/accounts.md
+++ b/docs/dev/api/accounts.md
@@ -28,6 +28,12 @@ You can filter the results of your query using the `name` parameter below.
 <table id="table-api">
   <tbody>
     <tr>
+     <td><code>id</code></td>
+     <td><p><small>| QUERY | OPTIONAL | STRING |</small></p><p>Comma-separated team IDs. Allows to receive details of multiple teams at once. For example, <code>id=3d60780314724ab8ac688b50aadd9ff9,f9acc7c5b1da4fd0902b184c4f0b6324</code> would return details of teams with IDs included in the provided list.</p></td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
      <td><code>name</code></td>
      <td><p><small>| QUERY | OPTIONAL | STRING |</small></p><p>Returns the set of teams that begin with the specified name value. For example, <code>name=sauce</code> would return all teams in the organization with names beginning with "sauce".</p></td>
     </tr>


### PR DESCRIPTION
### Description
Add information about the new ability to filter user and team lists by multiple IDs. 

Additionally, the `team-name` filter has been removed from the official documentation since it hasn't been supported for more than 3 months now.

### Motivation and Context
In order to get information about multiple users/teams there are 2 approaches right now.
1. Paginate over the whole list of users/teams, load it to the memory, and then filter out the ones we need.
2. Perform a separate query for the details of each user/team.

Neither of those approaches provides a good performance. In order to make Saucelabs UI work smoother, it's needed to have the option to load details about multiple users/teams at once.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
