### PR TITLE
add more info about supported identity providers in the new SSO

### DIFF
--- a/docs/basics/sso/setting-up-sso.md
+++ b/docs/basics/sso/setting-up-sso.md
@@ -53,9 +53,20 @@ We provide preconfigured SAML applications for some identity providers. They all
 - [OneLogin](/basics/sso/configuring-sso-in-onelogin)
 - [PingOne](/basics/sso/configuring-sso-in-pingone)
 
+We support also a manual setup for any other identity provider which implements SAML 2.0, for example:
+
+- Microsoft Active Directory Federation Services (MS ADFS)
+- Google Workspace (formerly G Suite)
+- Oracle Identity Cloud Service
+- ForgeRock
+- Salesforce
+- JumpCloud
+- CyberArk
+- KeyCloak
+
 :::
 
-If you use a custom identity provider or your provider does not appear in the list above, please complete the manual setup:
+If you use a custom identity provider or if we do not provide a preconfigured Sauce Labs SAML application for your identity provider, please complete the manual setup:
 
 1. Obtain SAML metadata from Sauce Labs Service Provider, which is served under [this link](https://accounts.saucelabs.com/am/sso/metadata/https%3A%2F%2Faccounts.saucelabs.com%2Fsp).
 2. Log in to your identity provider administrator panel.


### PR DESCRIPTION
### Description

It might be confusing for our customers that we limit support for the new SSO to only the identity providers for which we offer preconfigured SAML apps. We should communicate that the new SSO is compatible with any identity provider that supports SAML 2.0. Additionally, we should provide a list of examples for clarity.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
