### PR TITLE
docs: highlight node version

### DIFF
--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -29,6 +29,7 @@ Sauce Labs supports the following test configurations for Cypress:
 <table id="table-fw">
   <tr>
     <th>Cypress Version</th>
+    <th>Node.js Version</th>
     <th>Supported Platforms</th>
     <th>Supported Browsers</th>
     <th>End of Life</th>
@@ -36,6 +37,7 @@ Sauce Labs supports the following test configurations for Cypress:
   <tbody>
     <tr>
       <td rowspan='2'>13.3.0</td>
+      <td rowspan='2'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>September 28, 2024</td>
@@ -47,6 +49,7 @@ Sauce Labs supports the following test configurations for Cypress:
   <tbody>
     <tr>
       <td rowspan='2'>12.17.4</td>
+      <td rowspan='2'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>August 31, 2024</td>
@@ -58,6 +61,7 @@ Sauce Labs supports the following test configurations for Cypress:
   <tbody>
     <tr>
       <td rowspan='2'>12.17.2</td>
+      <td rowspan='2'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>August 1, 2024</td>
@@ -69,6 +73,7 @@ Sauce Labs supports the following test configurations for Cypress:
   <tbody>
     <tr>
       <td rowspan='2'>12.14.0</td>
+      <td rowspan='2'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>June 16, 2024</td>
@@ -80,6 +85,7 @@ Sauce Labs supports the following test configurations for Cypress:
   <tbody>
     <tr>
       <td rowspan='2'>12.11.0</td>
+      <td rowspan='2'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>May 11, 2024</td>
@@ -91,6 +97,7 @@ Sauce Labs supports the following test configurations for Cypress:
   <tbody>
     <tr>
       <td rowspan='2'>12.6.0</td>
+      <td rowspan='2'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>Mar 01, 2024</td>
@@ -102,6 +109,7 @@ Sauce Labs supports the following test configurations for Cypress:
   <tbody>
     <tr>
       <td rowspan='2'>12.3.0</td>
+      <td rowspan='2'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>Jan 15, 2024</td>
@@ -113,6 +121,7 @@ Sauce Labs supports the following test configurations for Cypress:
   <tbody>
     <tr>
       <td rowspan='2'>11.2.0</td>
+      <td rowspan='2'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>Nov 30, 2023</td>
@@ -124,6 +133,7 @@ Sauce Labs supports the following test configurations for Cypress:
   <tbody>
     <tr>
       <td rowspan='2'>10.10.0</td>
+      <td rowspan='2'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>Oct 20, 2023</td>

--- a/docs/web-apps/automated-testing/playwright.md
+++ b/docs/web-apps/automated-testing/playwright.md
@@ -30,6 +30,7 @@ Sauce Labs supports the following test configurations for Playwright:
 <table id="table-fw">
   <tr>
     <th>Playwright Version</th>
+    <th>Node.js Version</th>
     <th>Supported Platforms</th>
     <th>Supported Browsers</th>
     <th>End of Life</th>
@@ -37,6 +38,7 @@ Sauce Labs supports the following test configurations for Playwright:
   <tbody>
     <tr>
       <td rowspan='2'>1.38.1</td>
+      <td rowspan='2'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
       <td rowspan='2'>September 28, 2024</td>
@@ -48,6 +50,7 @@ Sauce Labs supports the following test configurations for Playwright:
   <tbody>
     <tr>
       <td rowspan='2'>1.37.1</td>
+      <td rowspan='2'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
       <td rowspan='2'>August 31, 2024</td>
@@ -59,6 +62,7 @@ Sauce Labs supports the following test configurations for Playwright:
   <tbody>
     <tr>
       <td rowspan='2'>1.36.2</td>
+      <td rowspan='2'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
       <td rowspan='2'>August 1, 2024</td>
@@ -70,6 +74,7 @@ Sauce Labs supports the following test configurations for Playwright:
   <tbody>
     <tr>
       <td rowspan='2'>1.35.1</td>
+      <td rowspan='2'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
       <td rowspan='2'>June 16, 2024</td>
@@ -81,6 +86,7 @@ Sauce Labs supports the following test configurations for Playwright:
   <tbody>
     <tr>
       <td rowspan='2'>1.33.0</td>
+      <td rowspan='2'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
       <td rowspan='2'>May 11, 2024</td>
@@ -92,6 +98,7 @@ Sauce Labs supports the following test configurations for Playwright:
   <tbody>
     <tr>
       <td rowspan='2'>1.31.1</td>
+      <td rowspan='2'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
       <td rowspan='2'>Mar 01, 2024</td>
@@ -103,6 +110,7 @@ Sauce Labs supports the following test configurations for Playwright:
   <tbody>
     <tr>
       <td rowspan='2'>1.29.2</td>
+      <td rowspan='2'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
       <td rowspan='2'>Jan 15, 2024</td>
@@ -114,6 +122,7 @@ Sauce Labs supports the following test configurations for Playwright:
   <tbody>
     <tr>
       <td rowspan='2'>1.28.1</td>
+      <td rowspan='2'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
       <td rowspan='2'>Nov 30, 2023</td>
@@ -125,6 +134,7 @@ Sauce Labs supports the following test configurations for Playwright:
   <tbody>
     <tr>
       <td rowspan='2'>1.27.1</td>
+      <td rowspan='2'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chromium, Firefox, Webkit</td>
       <td rowspan='2'>Oct 20, 2023</td>

--- a/docs/web-apps/automated-testing/testcafe.md
+++ b/docs/web-apps/automated-testing/testcafe.md
@@ -29,6 +29,7 @@ Sauce Labs supports the following test configurations for TestCafe:
 <table id="table-fw">
   <tr>
     <th>TestCafe Version</th>
+    <th>Node.js Version</th>
     <th>Supported Platforms</th>
     <th>Supported Browsers</th>
     <th>End of Life</th>
@@ -36,6 +37,7 @@ Sauce Labs supports the following test configurations for TestCafe:
   <tbody>
     <tr>
       <td rowspan='3'>3.3.0</td>
+      <td rowspan='3'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td>Safari, Chrome, Firefox, Microsoft Edge</td>
       <td rowspan='3'>September 28, 2024</td>
@@ -52,6 +54,7 @@ Sauce Labs supports the following test configurations for TestCafe:
   <tbody>
     <tr>
       <td rowspan='3'>3.2.0</td>
+      <td rowspan='3'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td>Safari, Chrome, Firefox, Microsoft Edge</td>
       <td rowspan='3'>August 31, 2024</td>
@@ -68,6 +71,7 @@ Sauce Labs supports the following test configurations for TestCafe:
   <tbody>
     <tr>
       <td rowspan='3'>3.0.1</td>
+      <td rowspan='3'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td>Safari, Chrome, Firefox, Microsoft Edge</td>
       <td rowspan='3'>August 1, 2024</td>
@@ -84,6 +88,7 @@ Sauce Labs supports the following test configurations for TestCafe:
   <tbody>
     <tr>
       <td rowspan='3'>2.6.2</td>
+      <td rowspan='3'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td>Safari, Chrome, Firefox, Microsoft Edge</td>
       <td rowspan='3'>June 16, 2024</td>
@@ -100,6 +105,7 @@ Sauce Labs supports the following test configurations for TestCafe:
   <tbody>
     <tr>
       <td rowspan='3'>2.5.0</td>
+      <td rowspan='3'>18</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td>Safari, Chrome, Firefox, Microsoft Edge</td>
       <td rowspan='3'>May 11, 2024</td>
@@ -116,6 +122,7 @@ Sauce Labs supports the following test configurations for TestCafe:
   <tbody>
     <tr>
       <td rowspan='3'>2.3.1</td>
+      <td rowspan='3'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td>Safari, Chrome, Firefox, Microsoft Edge</td>
       <td rowspan='3'>Mar 01, 2024</td>
@@ -132,6 +139,7 @@ Sauce Labs supports the following test configurations for TestCafe:
   <tbody>
     <tr>
       <td rowspan='3'>2.2.0</td>
+      <td rowspan='3'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td>Safari, Chrome, Firefox, Microsoft Edge</td>
       <td rowspan='3'>Jan 15, 2024</td>
@@ -148,6 +156,7 @@ Sauce Labs supports the following test configurations for TestCafe:
   <tbody>
     <tr>
       <td rowspan='3'>2.1.0</td>
+      <td rowspan='3'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td>Safari, Chrome, Firefox, Microsoft Edge</td>
       <td rowspan='3'>Nov 30, 2023</td>
@@ -164,6 +173,7 @@ Sauce Labs supports the following test configurations for TestCafe:
   <tbody>
     <tr>
       <td rowspan='3'>2.0.1</td>
+      <td rowspan='3'>16</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td>Safari, Chrome, Firefox, Microsoft Edge</td>
       <td rowspan='3'>Oct 20, 2023</td>


### PR DESCRIPTION
Highlight the included node version for reach runner release, as this is highly relevant for the user's project compatibility.