### PR TITLE
docs: document scopeless registry restriction

### DIFF
--- a/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
+++ b/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
@@ -353,7 +353,7 @@ Specifies the location of the npm registry source. If the registry source is a p
 
 <p><small>| OPTIONAL | ARRAY |</small></p>
 
-Specifies the location of the npm registry, scope, and credentials. If the registry is inside a private network, you must establish a tunnel using [Sauce Connect](/dev/cli/saucectl/#run-tests-on-sauce-labs-with-sauce-connect).
+Specifies the location of the npm registry, scope, and credentials. Only one scopeless registry is allowed. If the registry is inside a private network, you must establish a tunnel using [Sauce Connect](/dev/cli/saucectl/#run-tests-on-sauce-labs-with-sauce-connect).
 
 ```yaml
   registries:

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -362,7 +362,7 @@ Specifies the location of the npm registry source. If the registry source is a p
 
 <p><small>| OPTIONAL | ARRAY |</small></p>
 
-Specifies the location of the npm registry, scope, and credentials. If the registry is inside a private network, you must establish a tunnel using [Sauce Connect](/dev/cli/saucectl/#run-tests-on-sauce-labs-with-sauce-connect).
+Specifies the location of the npm registry, scope, and credentials. Only one scopeless registry is allowed. If the registry is inside a private network, you must establish a tunnel using [Sauce Connect](/dev/cli/saucectl/#run-tests-on-sauce-labs-with-sauce-connect).
 
 ```yaml
   registries:

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -346,7 +346,7 @@ Specifies the location of the npm registry source. If the registry source is a p
 
 <p><small>| OPTIONAL | ARRAY |</small></p>
 
-Specifies the location of the npm registry, scope, and credentials. If the registry is inside a private network, you must establish a tunnel using [Sauce Connect](/dev/cli/saucectl/#run-tests-on-sauce-labs-with-sauce-connect).
+Specifies the location of the npm registry, scope, and credentials. Only one scopeless registry is allowed. If the registry is inside a private network, you must establish a tunnel using [Sauce Connect](/dev/cli/saucectl/#run-tests-on-sauce-labs-with-sauce-connect).
 
 ```yaml
   registries:

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -346,7 +346,7 @@ Specifies the location of the npm registry source. If the registry source is a p
 
 <p><small>| OPTIONAL | ARRAY |</small></p>
 
-Specifies the location of the npm registry, scope, and credentials. If the registry is inside a private network, you must establish a tunnel using [Sauce Connect](/dev/cli/saucectl/#run-tests-on-sauce-labs-with-sauce-connect).
+Specifies the location of the npm registry, scope, and credentials. Only one scopeless registry is allowed. If the registry is inside a private network, you must establish a tunnel using [Sauce Connect](/dev/cli/saucectl/#run-tests-on-sauce-labs-with-sauce-connect).
 
 ```yaml
   registries:


### PR DESCRIPTION
### Description

Mention restriction around how many scopeless registries are allowed.
