### PR TITLE
docs: add caution around supported tunnel ports and protocols

### DIFF
--- a/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
+++ b/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
@@ -202,6 +202,10 @@ sauce:
     owner: tunnel_owner_username
 ```
 
+:::caution
+[Only certain HTTP(S) ports](/secure-connections/sauce-connect/advanced/specifications/#supported-browsers-and-ports) are proxied by the tunnel.
+:::
+
 ---
 
 #### `name`

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -208,6 +208,10 @@ sauce:
     owner: tunnel_owner_username
 ```
 
+:::caution
+[Only certain HTTP(S) ports](/secure-connections/sauce-connect/advanced/specifications/#supported-browsers-and-ports) are proxied by the tunnel.
+:::
+
 ---
 
 #### `name`

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -196,6 +196,10 @@ sauce:
     owner: tunnel_owner_username
 ```
 
+:::caution
+[Only certain HTTP(S) ports](/secure-connections/sauce-connect/advanced/specifications/#supported-browsers-and-ports) are proxied by the tunnel.
+:::
+
 ---
 
 #### `name`

--- a/docs/web-apps/automated-testing/replay/yaml.md
+++ b/docs/web-apps/automated-testing/replay/yaml.md
@@ -201,6 +201,10 @@ sauce:
     owner: tunnel_owner_username
 ```
 
+:::caution
+[Only certain HTTP(S) ports](/secure-connections/sauce-connect/advanced/specifications/#supported-browsers-and-ports) are proxied by the tunnel.
+:::
+
 ---
 
 #### `name`

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -196,6 +196,10 @@ sauce:
     owner: tunnel_owner_username
 ```
 
+:::caution
+[Only certain HTTP(S) ports](/secure-connections/sauce-connect/advanced/specifications/#supported-browsers-and-ports) are proxied by the tunnel.
+:::
+
 ---
 
 #### `name`


### PR DESCRIPTION
### Description

Caution the user when it comes to port and protocol support when using a tunnel.