### PR TITLE
Install js-cli locally, fix name of backtracejsrc file

### DIFF
--- a/docs/error-reporting/platform-integrations/source-map.md
+++ b/docs/error-reporting/platform-integrations/source-map.md
@@ -71,7 +71,7 @@ Install the `backtrace-js` command line tool and update your build scripts to ru
 1. Install `@backtrace-labs/javascript-cli` as a dev dependency:
 
    ```bash
-   npm install -g --save-dev @backtrace-labs/javascript-cli
+   npm install --save-dev @backtrace-labs/javascript-cli
    ```
 
 2. Add the following script to `package.json` to process and upload source maps:
@@ -95,7 +95,7 @@ Install the `backtrace-js` command line tool and update your build scripts to ru
 ---
 ### Step 3: Create a `.backtracejsrc` configuration file
 
-Create a `.backtracejs` configuration file in the root of your project with these settings to process source maps, add source and upload to Backtrace.
+Create a `.backtracejsrc` configuration file in the root of your project with these settings to process source maps, add source and upload to Backtrace.
 
 ```json
 {


### PR DESCRIPTION
### Description
- Fixing Typo in the .backtracejsrc file name
- Recommending to install @backtrace-labs/javascript-cli locally

### Motivation and Context
Fix integration instructions

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
