### PR TITLE
add ellipsis before + after Cypress command plugin

### DIFF
--- a/docs/visual-testing/integrations/cypress.md
+++ b/docs/visual-testing/integrations/cypress.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Cypress Integration
 
 :::note Important
-Access to this feature is currentlylimited to Enterprise customers as part of our commitment to providing tailored solutions. We are excited to announce that self-service access is under development and will be released shortly. Stay tuned!
+Access to this feature is currently limited to Enterprise customers as part of our commitment to providing tailored solutions. We are excited to announce that self-service access is under development and will be released shortly. Stay tuned!
 :::
 
 ## Introduction

--- a/docs/visual-testing/integrations/cypress.md
+++ b/docs/visual-testing/integrations/cypress.md
@@ -56,7 +56,9 @@ export default defineConfig({
   e2e: {
     [...]
     setupNodeEvents(on, config) {
+      ...
       CypressSauceVisual.register(on, config);
+      ...
     },
   },
 })

--- a/docs/visual-testing/integrations/java.md
+++ b/docs/visual-testing/integrations/java.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Java WebDriver Integration
 
 :::note Important
-Access to this feature is currentlylimited to Enterprise customers as part of our commitment to providing tailored solutions. We are excited to announce that self-service access is under development and will be released shortly. Stay tuned!
+Access to this feature is currently limited to Enterprise customers as part of our commitment to providing tailored solutions. We are excited to announce that self-service access is under development and will be released shortly. Stay tuned!
 :::
 
 ## Introduction

--- a/docs/visual-testing/integrations/storybook.md
+++ b/docs/visual-testing/integrations/storybook.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Storybook Integration
 
 :::note Important
-Access to this feature is currentlylimited to Enterprise customers as part of our commitment to providing tailored solutions. We are excited to announce that self-service access is under development and will be released shortly. Stay tuned!
+Access to this feature is currently limited to Enterprise customers as part of our commitment to providing tailored solutions. We are excited to announce that self-service access is under development and will be released shortly. Stay tuned!
 :::
 
 An extension for [Storybook's test-runner](https://github.com/storybookjs/test-runner) powered by [Jest](https://jestjs.io/) and [Playwright](https://playwright.dev/) to integrate effortless visual testing with Sauce Visual.

--- a/docs/visual-testing/integrations/webdriverio.md
+++ b/docs/visual-testing/integrations/webdriverio.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # WebdriverIO Integration
 
 :::note Important
-Access to this feature is currentlylimited to Enterprise customers as part of our commitment to providing tailored solutions. We are excited to announce that self-service access is under development and will be released shortly. Stay tuned!
+Access to this feature is currently limited to Enterprise customers as part of our commitment to providing tailored solutions. We are excited to announce that self-service access is under development and will be released shortly. Stay tuned!
 :::
 
 ## Introduction


### PR DESCRIPTION
Show ellipsis before and after `CypressSauceVisual.register(on, config);` in case the user already has 

```
setupNodeEvents(on, config) {
    },
```

populated with content
