### PR TITLE
Fix direct-domains example

### DIFF
--- a/docs/dev/cli/sauce-connect-5/run.md
+++ b/docs/dev/cli/sauce-connect-5/run.md
@@ -295,7 +295,7 @@ Setting this to `direct` sends requests to `localhost` directly without using th
 **Shorthand**: `-D`
 
 ```bash
---tls-passthrough-domains .*\.example\.com,.*google\.com,mycompany\.com
+--direct-domains .*\.example\.com,.*google\.com,mycompany\.com
 ```
 
 ---


### PR DESCRIPTION
Looks like a copy&paste error from `tls-passthrough-domains`.