### PR TITLE
build/commands instead of /commands

### DIFF
--- a/docs/visual-testing/integrations/cypress.md
+++ b/docs/visual-testing/integrations/cypress.md
@@ -67,7 +67,7 @@ export default defineConfig({
 - Register Sauce Visual for Cypress commands. Add the following line in your `cypress/support/e2e.ts`:
 
 ```ts
-import '@saucelabs/cypress-visual-plugin/commands';
+import '@saucelabs/cypress-visual-plugin/build/commands';
 ```
 
 ### Step 3: Add visual tests in your project:


### PR DESCRIPTION
Changing the import statement from `
import '@saucelabs/cypress-visual-plugin/commands';` to `import '@saucelabs/cypress-visual-plugin/build/commands'` fixed a resolution problem.

I'll let you all decide if this is how you want users to import commands or if you want to change the library so they can import it via just `/commands`.

<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
