### PR TITLE
docs: Specify that the region is mandatory when running saucectl run

### DIFF
--- a/docs/api-testing/integrations/yaml.md
+++ b/docs/api-testing/integrations/yaml.md
@@ -77,6 +77,10 @@ sauce:
 
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
+:::note
+`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+:::
+
 ```yaml
   region: eu-central-1
 ```

--- a/docs/api-testing/integrations/yaml.md
+++ b/docs/api-testing/integrations/yaml.md
@@ -78,7 +78,7 @@ sauce:
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
 :::note
-`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+If you do not specify a region in your config file, you must set it when running your command with the `--region` flag.
 :::
 
 ```yaml

--- a/docs/mobile-apps/automated-testing/espresso-xcuitest/espresso.md
+++ b/docs/mobile-apps/automated-testing/espresso-xcuitest/espresso.md
@@ -124,7 +124,7 @@ sauce:
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
 :::note
-`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+If you do not specify a region in your config file, you must set it when running your command with the `--region` flag.
 :::
 
 ```yaml

--- a/docs/mobile-apps/automated-testing/espresso-xcuitest/espresso.md
+++ b/docs/mobile-apps/automated-testing/espresso-xcuitest/espresso.md
@@ -123,6 +123,10 @@ sauce:
 
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
+:::note
+`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+:::
+
 ```yaml
   region: eu-central-1
 ```

--- a/docs/mobile-apps/automated-testing/espresso-xcuitest/xcuitest.md
+++ b/docs/mobile-apps/automated-testing/espresso-xcuitest/xcuitest.md
@@ -125,7 +125,7 @@ sauce:
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
 :::note
-`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+If you do not specify a region in your config file, you must set it when running your command with the `--region` flag.
 :::
 
 ```yaml

--- a/docs/mobile-apps/automated-testing/espresso-xcuitest/xcuitest.md
+++ b/docs/mobile-apps/automated-testing/espresso-xcuitest/xcuitest.md
@@ -124,6 +124,10 @@ sauce:
 
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
+:::note
+`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+:::
+
 ```yaml
 sauce:
   region: eu-central-1

--- a/docs/orchestrate/saucectl-configuration.md
+++ b/docs/orchestrate/saucectl-configuration.md
@@ -45,7 +45,7 @@ kind: imagerunner
 The parent property containing all settings related to how tests are run and identified in the Sauce Labs platform.
 
 :::note
-`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+If you do not specify a region in your config file, you must set it when running your command with the `--region` flag.
 :::
 
 ```yaml

--- a/docs/orchestrate/saucectl-configuration.md
+++ b/docs/orchestrate/saucectl-configuration.md
@@ -44,6 +44,10 @@ kind: imagerunner
 
 The parent property containing all settings related to how tests are run and identified in the Sauce Labs platform.
 
+:::note
+`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+:::
+
 ```yaml
 sauce:
   region: eu-central-1

--- a/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
+++ b/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
@@ -126,7 +126,7 @@ sauce:
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
 :::note
-`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+If you do not specify a region in your config file, you must set it when running your command with the `--region` flag.
 :::
 
 ```yaml

--- a/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
+++ b/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
@@ -125,6 +125,10 @@ sauce:
 
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
+:::note
+`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+:::
+
 ```yaml
   region: eu-central-1
 ```

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -132,7 +132,7 @@ sauce:
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
 :::note
-`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+If you do not specify a region in your config file, you must set it when running your command with the `--region` flag.
 :::
 
 ```yaml

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -131,6 +131,10 @@ sauce:
 
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
+:::note
+`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+:::
+
 ```yaml
   region: eu-central-1
 ```

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -120,7 +120,7 @@ sauce:
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
 :::note
-`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+If you do not specify a region in your config file, you must set it when running your command with the `--region` flag.
 :::
 
 ```yaml

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -119,6 +119,10 @@ sauce:
 
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
+:::note
+`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+:::
+
 ```yaml
   region: eu-central-1
 ```

--- a/docs/web-apps/automated-testing/replay/yaml.md
+++ b/docs/web-apps/automated-testing/replay/yaml.md
@@ -120,6 +120,10 @@ sauce:
 
 Specifies on which Sauce Labs data center jobs will run. Valid values are: `us-west-1` or `eu-central-1`.
 
+:::note
+`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+:::
+
 ```yaml
 sauce:
   region: eu-central-1

--- a/docs/web-apps/automated-testing/replay/yaml.md
+++ b/docs/web-apps/automated-testing/replay/yaml.md
@@ -121,7 +121,7 @@ sauce:
 Specifies on which Sauce Labs data center jobs will run. Valid values are: `us-west-1` or `eu-central-1`.
 
 :::note
-`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+If you do not specify a region in your config file, you must set it when running your command with the `--region` flag.
 :::
 
 ```yaml

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -120,7 +120,7 @@ sauce:
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
 :::note
-`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+If you do not specify a region in your config file, you must set it when running your command with the `--region` flag.
 :::
 
 ```yaml

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -119,6 +119,10 @@ sauce:
 
 Specifies through which Sauce Labs data center tests will run. Valid values are: `us-west-1` or `eu-central-1`.
 
+:::note
+`region` is mandatory and should be set either in the Sauce Config file or by using the `--region` flag.
+:::
+
 ```yaml
   region: eu-central-1
 ```


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

Add a note indicating that when triggering `saucectl run`, the `region` parameter is required.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
