### PR TITLE
Add instructions on how to get private devices

### DIFF
--- a/docs/mobile-apps/automated-testing/ipa-files.md
+++ b/docs/mobile-apps/automated-testing/ipa-files.md
@@ -113,7 +113,7 @@ Sauce Labs applies its own resigning to apps that are installed on our public iO
 
 ### Private Devices
 
-If your organization requires specific entitlements, Sauce Labs gives you the option to [disable resigning](/dev/test-configuration-options/#resigningenabled) for devices in your private pool. When resigning is disabled, you may sign your app using your own provisioning profile, which can include any entitlements in:
+If your organization requires specific entitlements, Sauce Labs gives you the option to [disable resigning](/dev/test-configuration-options/#resigningenabled) for devices in your private pool. To acquire private devices for your organization please get in contact with your Customer Success Manager. When resigning is disabled, you may sign your app using your own provisioning profile, which can include any entitlements in:
 
 - `com.apple.developer.associated-domains`
 - `com.apple.security.application-groups`


### PR DESCRIPTION
### Description
Extend the documentation on private devices to let people know how to get them.

### Motivation and Context
When customers read the documentation on private devices we should point them to a way to actually get them. 
We are still missing a dedicated page on private devices. There is no specific page in the sauce doc on the benefits that these bring and the features we support. Since private devices are a big part of our business we should make sure to add a section about them.

### Types of Changes
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
