### PR TITLE
docs: update available devx frameworks

### DIFF
--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -180,6 +180,10 @@ Cypress does not currently work with Firefox 101 on Windows.
 Cypress does not currently work with Firefox 105.
 See https://github.com/cypress-io/cypress/issues/23897 for more information.
 
+### Microsoft Edge 120
+
+Cypress does not currently work with Microsoft Edge 120.
+
 ### Webkit
 
 - Cypress only supports launching Webkit with a fixed resolution of 1280x720.

--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -36,6 +36,18 @@ Sauce Labs supports the following test configurations for Cypress:
   </tr>
   <tbody>
     <tr>
+      <td rowspan='2'>13.6.3</td>
+      <td rowspan='2'>20</td>
+      <td><b>macOS:</b> 11.00, 12, 13</td>
+      <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
+      <td rowspan='2'>January 22, 2025</td>
+    </tr>
+    <tr>
+      <td><b>Windows:</b> 10, 11</td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
       <td rowspan='2'>13.6.0</td>
       <td rowspan='2'>20</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
@@ -125,18 +137,6 @@ Sauce Labs supports the following test configurations for Cypress:
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>Mar 01, 2024</td>
-    </tr>
-    <tr>
-      <td><b>Windows:</b> 10, 11</td>
-    </tr>
-  </tbody>
-  <tbody>
-    <tr>
-      <td rowspan='2'>12.3.0</td>
-      <td rowspan='2'>16</td>
-      <td><b>macOS:</b> 11.00, 12, 13</td>
-      <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
-      <td rowspan='2'>Jan 15, 2024</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10, 11</td>

--- a/docs/web-apps/automated-testing/playwright.md
+++ b/docs/web-apps/automated-testing/playwright.md
@@ -37,6 +37,18 @@ Sauce Labs supports the following test configurations for Playwright:
   </tr>
   <tbody>
     <tr>
+      <td rowspan='2'>1.41.0</td>
+      <td rowspan='2'>20</td>
+      <td><b>macOS:</b> 11.00, 12, 13</td>
+      <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
+      <td rowspan='2'>January 22, 2025</td>
+    </tr>
+    <tr>
+      <td><b>Windows:</b> 10, 11</td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
       <td rowspan='2'>1.40.1</td>
       <td rowspan='2'>20</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
@@ -126,18 +138,6 @@ Sauce Labs supports the following test configurations for Playwright:
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
       <td rowspan='2'>Mar 01, 2024</td>
-    </tr>
-    <tr>
-      <td><b>Windows:</b> 10, 11</td>
-    </tr>
-  </tbody>
-  <tbody>
-    <tr>
-      <td rowspan='2'>1.29.2</td>
-      <td rowspan='2'>16</td>
-      <td><b>macOS:</b> 11.00, 12, 13</td>
-      <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
-      <td rowspan='2'>Jan 15, 2024</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10, 11</td>

--- a/docs/web-apps/automated-testing/testcafe.md
+++ b/docs/web-apps/automated-testing/testcafe.md
@@ -36,6 +36,23 @@ Sauce Labs supports the following test configurations for TestCafe:
   </tr>
   <tbody>
     <tr>
+      <td rowspan='3'>3.5.0</td>
+      <td rowspan='3'>20</td>
+      <td><b>macOS:</b> 11.00, 12, 13</td>
+      <td>Safari, Chrome, Firefox, Microsoft Edge</td>
+      <td rowspan='3'>January 22, 2025</td>
+    </tr>
+    <tr>
+      <td><b>Windows:</b> 10, 11</td>
+      <td>Chrome, Firefox, Microsoft Edge</td>
+    </tr>
+    <tr>
+      <td><b>iOS:</b> 13.4, 14.5, 15.4, 16.0, 16.1, 16.2</td>
+      <td>Safari</td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
       <td rowspan='3'>3.4.0</td>
       <td rowspan='3'>20</td>
       <td><b>macOS:</b> 11.00, 12, 13</td>
@@ -143,23 +160,6 @@ Sauce Labs supports the following test configurations for TestCafe:
       <td><b>macOS:</b> 11.00, 12, 13</td>
       <td>Safari, Chrome, Firefox, Microsoft Edge</td>
       <td rowspan='3'>Mar 01, 2024</td>
-    </tr>
-    <tr>
-      <td><b>Windows:</b> 10, 11</td>
-      <td>Chrome, Firefox, Microsoft Edge</td>
-    </tr>
-    <tr>
-      <td><b>iOS:</b>13.4, 14.5, 15.4, 16.0, 16.1</td>
-      <td>Safari</td>
-    </tr>
-  </tbody>
-  <tbody>
-    <tr>
-      <td rowspan='3'>2.2.0</td>
-      <td rowspan='3'>16</td>
-      <td><b>macOS:</b> 11.00, 12, 13</td>
-      <td>Safari, Chrome, Firefox, Microsoft Edge</td>
-      <td rowspan='3'>Jan 15, 2024</td>
     </tr>
     <tr>
       <td><b>Windows:</b> 10, 11</td>


### PR DESCRIPTION
### Description

Update release pages of DevX frameworks.

Regarding Edge 120:
I tested the current version and everything in between Cypress 12 <-> 13 and nothing works with Edge 120. Nothing interesting in the Cypress community regarding that one. Might be a one-off.