### PR TITLE
api/connect: update us-east-1 examples to us-east-4

### DIFF
--- a/docs/dev/api/connect.md
+++ b/docs/dev/api/connect.md
@@ -75,7 +75,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-east-1.saucelabs.com/rest/v1/jim.smith/tunnels' \
+--request GET 'https://api.us-east-4.saucelabs.com/rest/v1/jim.smith/tunnels' \
 --header 'Content-Type: application/json' | json_pp
 ```
 
@@ -204,7 +204,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-east-1.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8' \
+--request GET 'https://api.us-east-4.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8' \
 --header 'Content-Type: application/json' | json_pp
 ```
 
@@ -314,7 +314,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-east-1.saucelabs.com/rest/v1/public/tunnels/info/versions' | json_pp
+--request GET 'https://api.us-east-4.saucelabs.com/rest/v1/public/tunnels/info/versions' | json_pp
 ```
 
 </TabItem>
@@ -631,7 +631,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request GET 'https://api.us-east-1.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8/num_jobs' \
+--request GET 'https://api.us-east-4.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8/num_jobs' \
 --header 'Content-Type: application/json' | json_pp
 ```
 
@@ -721,7 +721,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ```jsx title="Sample Request"
 curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
---request DELETE 'https://api.us-east-1.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8' \
+--request DELETE 'https://api.us-east-4.saucelabs.com/rest/v1/jim.smith/tunnels/28e7c8133ede4588a891666dd35af1f8' \
 --header 'Content-Type: application/json' | json_pp
 ```
 


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

US-East-1 region was deprecated. While US-East-4 is not supported by Sauce Connect yet, it will be fairly soon so updating examples in the API doc seems like a good idea.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
