### PR TITLE
docs: update npm packages example

### DIFF
--- a/docs/web-apps/automated-testing/_partials/_advanced.md
+++ b/docs/web-apps/automated-testing/_partials/_advanced.md
@@ -134,11 +134,10 @@ You can avoid installing or uninstalling dependencies prior to each bundling ope
 
 ```jsx title= "config.yml npm example"
 npm:
-  registry: https://registry.npmjs.org
+  registries:
+    - url: https://registry.npmjs.org
   packages:
-    lodash: "4.17.20"
-    "@babel/preset-typescript": "7.12"
-    "@playwright/react": "^5.0.1"
+    "lodash": "4.17.20"
 ```
 
 Alternatively, you can let `saucectl` selectively include already installed dependencies from the `node_modules` folder.


### PR DESCRIPTION
### Description

1. `registry` is a deprecated setting that we don't want our users to use anymore.
2. `@playwright/react` doesn't even exist in the official npmjs registry 🤷  Also, it's a very playwright specific example and this snippet is used as an example for all our frameworks. So I reduced it to a bare minimum that would apply to Cypress/Playwright/TestCafe.