### PR TITLE
Unreal guide - Note support for asserts

### DIFF
--- a/docs/error-reporting/platform-integrations/unreal/setup.md
+++ b/docs/error-reporting/platform-integrations/unreal/setup.md
@@ -20,6 +20,7 @@ The Backtrace Unreal plugin reports on the following types of errors:
 - Crashes - An end to the game play experience, where the game crashes or restarts.
 - Hangs (mobile only) - Errors that occur when a game or an app is non-responsive.
 - Out of memory crashes (mobile only) - Terminations of your game or app due to low memory conditions.
+- Asserts - Used to detect and diagnose unexpected or invalid runtime conditions during development.
 
 ## Supported Platforms
 

--- a/docs/error-reporting/platform-integrations/unreal/troubleshooting.md
+++ b/docs/error-reporting/platform-integrations/unreal/troubleshooting.md
@@ -5,10 +5,6 @@ sidebar_label: Troubleshooting
 description: Troubleshooting reference for Unreal Engine crash reports.
 ---
 
-## Android Assert (Check/Ensure/Verify) crashes are not showing up in Backtrace for my debug builds
-
-Backtrace currently doesn't handle the Assert crashes typically associated with Debug builds on Android. This is not a problem in release builds, where these types of conditions tend to be compiled out. For more information on Asserts, see the [Unreal Engine Documentation](https://docs.unrealengine.com/4.27/en-US/ProgrammingAndScripting/ProgrammingWithCPP/Assertions/).
-
 ## How can I troubleshoot failures in crash reporting?
 
 Please refer to your crash reporting client logs.


### PR DESCRIPTION
### Description
Formally declaring BT support for alerts in Unreal.