### PR TITLE
Replace GitHub embedded codeblocks with maintained fork

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -149,7 +149,7 @@ const docusaurusConfig = {
             },
         ],
     ],
-    themes: ['@saucelabs/theme-github-codeblock'],
+    themes: ['docusaurus-theme-github-codeblock'],
     plugins: ['./src/plugins/beamer'],
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@svgr/webpack": "^6.5.1",
         "algoliasearch": "^4.23.2",
         "clsx": "1.1.1",
+        "docusaurus-theme-github-codeblock": "2.0.2",
         "file-loader": "^6.2.0",
         "prism-react-renderer": "^2.3.1",
         "prop-types": "^15.8.1",
@@ -40,6 +41,9 @@
         "husky": "^8.0.0",
         "lint-staged": "^13.1.0",
         "prettier": "2.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6523,6 +6527,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/docusaurus-theme-github-codeblock": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/docusaurus-theme-github-codeblock/-/docusaurus-theme-github-codeblock-2.0.2.tgz",
+      "integrity": "sha512-H2WoQPWOLjGZO6KS58Gsd+eUVjTFJemkReiSSu9chqokyLc/3Ih3+zPRYfuEZ/HsDvSMIarf7CNcp+Vt+/G+ig==",
+      "dependencies": {
+        "@docusaurus/types": "^3.0.0"
       }
     },
     "node_modules/dom-converter": {
@@ -23042,6 +23054,14 @@
       "devOptional": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "docusaurus-theme-github-codeblock": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/docusaurus-theme-github-codeblock/-/docusaurus-theme-github-codeblock-2.0.2.tgz",
+      "integrity": "sha512-H2WoQPWOLjGZO6KS58Gsd+eUVjTFJemkReiSSu9chqokyLc/3Ih3+zPRYfuEZ/HsDvSMIarf7CNcp+Vt+/G+ig==",
+      "requires": {
+        "@docusaurus/types": "^3.0.0"
       }
     },
     "dom-converter": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@svgr/webpack": "^6.5.1",
     "algoliasearch": "^4.23.2",
     "clsx": "1.1.1",
+    "docusaurus-theme-github-codeblock": "2.0.2",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^2.3.1",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
### Description
Our embedded GitHub code blocks broke after the upgrade to docusaurus v3. It seems our [plugin](https://github.com/saucelabs/docusaurus-theme-github-codeblock) has gotten a bit stale and a [fork from the WDIO folks](https://github.com/christian-bromann/docusaurus-theme-github-codeblock) seems to be a bit ahead. Swapping that out here.

### Motivation and Context
Fixes metastring parsing on mdx code blocks after the upgrade to load GitHub snippets properly.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
