### PR TITLE
Remove enterprise only warning for Sauce Visual

### DIFF
--- a/docs/visual-testing/_partials/_enterprise-note.md
+++ b/docs/visual-testing/_partials/_enterprise-note.md
@@ -1,3 +1,0 @@
-:::note Important
-Access to this feature is currently limited to Enterprise customers as part of our commitment to providing tailored solutions. We are excited to announce that self-service access is under development and will be released shortly. Stay tuned!
-:::

--- a/docs/visual-testing/integrations/csharp.md
+++ b/docs/visual-testing/integrations/csharp.md
@@ -4,13 +4,10 @@ sidebar_label: C#/.Net
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import EnterpriseNote from '../_partials/_enterprise-note.md';
 import EnvironmentVariables from '../_partials/_environment-variables.md';
 import FullPageLimit from '../_partials/_fullpage-limit.md';
 
 # C#/.Net WebDriver Integration
-
-<EnterpriseNote />
 
 ## Introduction
 

--- a/docs/visual-testing/integrations/cypress.md
+++ b/docs/visual-testing/integrations/cypress.md
@@ -5,12 +5,9 @@ sidebar_label: Cypress
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ClippingDescription from '../_partials/_clipping-description.md';
-import EnterpriseNote from '../_partials/_enterprise-note.md';
 import EnvironmentVariables from '../_partials/_environment-variables.md';
 
 # Cypress Integration
-
-<EnterpriseNote />
 
 ## Introduction
 

--- a/docs/visual-testing/integrations/java.md
+++ b/docs/visual-testing/integrations/java.md
@@ -6,12 +6,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ClippingDescription from '../_partials/_clipping-description.md';
 import FullPageLimit from '../_partials/_fullpage-limit.md';
-import EnterpriseNote from '../_partials/_enterprise-note.md';
 import EnvironmentVariables from '../_partials/_environment-variables.md';
 
 # Java WebDriver Integration
-
-<EnterpriseNote />
 
 ## Introduction
 

--- a/docs/visual-testing/integrations/nightwatch.md
+++ b/docs/visual-testing/integrations/nightwatch.md
@@ -6,12 +6,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import FullPageJS from '../_partials/_fullpage-js.md'
 import ClippingWDIO from '../_partials/_clipping-webdriver.md';
-import EnterpriseNote from '../_partials/_enterprise-note.md';
 import EnvironmentVariables from '../_partials/_environment-variables.md';
 
 # Nightwatch Integration
-
-<EnterpriseNote />
 
 ## Introduction
 

--- a/docs/visual-testing/integrations/python-robot-framework.md
+++ b/docs/visual-testing/integrations/python-robot-framework.md
@@ -2,14 +2,11 @@
 sidebar_label: Python (Robot Framework)
 ---
 
-import EnterpriseNote from '../_partials/_enterprise-note.md';
 import EnvironmentVariables from '../_partials/_environment-variables.md';
 import PythonIntro from '../_partials/_python-shared-intro.md';
 import FullPageLimit from '../_partials/_fullpage-limit.md';
 
 # Python (Robot Framework) Integration
-
-<EnterpriseNote />
 
 ## Introduction
 

--- a/docs/visual-testing/integrations/python.md
+++ b/docs/visual-testing/integrations/python.md
@@ -2,13 +2,10 @@
 sidebar_label: Python
 ---
 
-import EnterpriseNote from '../_partials/_enterprise-note.md';
 import EnvironmentVariables from '../_partials/_environment-variables.md';
 import PythonIntro from '../_partials/_python-shared-intro.md';
 
 # Python Integration
-
-<EnterpriseNote />
 
 ## Introduction
 

--- a/docs/visual-testing/integrations/storybook.md
+++ b/docs/visual-testing/integrations/storybook.md
@@ -3,12 +3,9 @@ sidebar_label: Storybook
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import EnterpriseNote from '../_partials/_enterprise-note.md';
 import EnvironmentVariables from '../_partials/_environment-variables.md';
 
 # Storybook Integration
-
-<EnterpriseNote />
 
 An extension for [Storybook's test-runner](https://github.com/storybookjs/test-runner) powered by [Jest](https://jestjs.io/) and [Playwright](https://playwright.dev/) to integrate effortless visual testing with Sauce Visual.
 

--- a/docs/visual-testing/integrations/webdriverio.md
+++ b/docs/visual-testing/integrations/webdriverio.md
@@ -4,12 +4,9 @@ sidebar_label: WebdriverIO
 
 import FullPageJS from '../_partials/_fullpage-js.md';
 import ClippingWDIO from '../_partials/_clipping-webdriver.md';
-import EnterpriseNote from '../_partials/_enterprise-note.md';
 import EnvironmentVariables from '../_partials/_environment-variables.md';
 
 # WebdriverIO Integration
-
-<EnterpriseNote />
 
 ## Introduction
 


### PR DESCRIPTION
Removes the 'Enterprise Only' warning in Sauce Visual since that is no longer the case.

### Types of Changes
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
