### PR TITLE
Add information about screenshots limit | TO-981

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -1913,6 +1913,10 @@ capabilities.setCapability("sauce:options", sauceOptions);
 
 Disables step-by-step screenshots. In addition to capturing video, Sauce Labs captures step-by-step screenshots of every test you run. Most users find it very useful to get a quick overview of what happened without having to watch the complete video. However, this feature may add some extra time to your tests.
 
+:::caution Limitations
+The maximum number of screenshots is **150**. Once the limit is reached, further screenshots will no longer be taken.
+:::
+
 ```java
 MutableCapabilities capabilities = new MutableCapabilities();
 //...


### PR DESCRIPTION
### Description
There is a limit to how many screenshots can be taken during a single test session. It's important to include that information in the official docs.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
