### PR TITLE
Adding ProGuard rule to de-obfuscate Java classes

### DIFF
--- a/docs/error-reporting/platform-integrations/android/proguard-deobfuscation.md
+++ b/docs/error-reporting/platform-integrations/android/proguard-deobfuscation.md
@@ -28,6 +28,9 @@ To do this, you need to upload the ProGuard mapping file corresponding to the bu
    ```
    -keep class com.google.gson.**.* { *; }
    -keep class backtraceio.library.**.* { *; }
+
+   # Add this line for Unity projects:
+   -keep class backtraceio.unity.* { *; }
    ```
 
 1. Enable ProGuard mode in the `BacktraceClient`.

--- a/docs/error-reporting/platform-integrations/unity/configuration.md
+++ b/docs/error-reporting/platform-integrations/unity/configuration.md
@@ -125,7 +125,10 @@ For more information about other data that is captured, see [Attributes](/error-
 | Symbols upload token                       | Required to automatically upload debug symbols to Backtrace. <br /> <br /> To generate a symbol upload token, in Backtrace go to Project Settings > Symbols > Access tokens > and select + to generate a new token.                                                                                                                                                                                                                    | String  |
 
 #### ProGuard Rules
-ProGuard obfuscation prevents the reflection used to get Java class names to setup a bridge between Unity and Java. The ProGuard symbolication id must be passed to BacktraceClient, and additional ProGuard rules must be added to allow Backtrace to identify Java classes.
+ProGuard obfuscation prevents the reflection used to invoke Java code from the Unity bridge. The ProGuard symbolication id must be passed to BacktraceClient, and additional ProGuard rules must be added to allow Backtrace to identify Java classes. 
+<br /> 
+Symbolication id is a UUID identifier created by the user. The same identifier value must be sent when uploading the source map and must be accessible in the game's runtime environment.
+
 <br/>
 Please follow [this guide](/error-reporting/platform-integrations/android/proguard-deobfuscation/) to enable ProGuard, and add the following:
 

--- a/docs/error-reporting/platform-integrations/unity/configuration.md
+++ b/docs/error-reporting/platform-integrations/unity/configuration.md
@@ -124,6 +124,15 @@ For more information about other data that is captured, see [Attributes](/error-
 | Enable client-side unwinding               | Enables callstack unwinding. If you're unable to upload all debug symbols for your app, you can use this setting to get debug information. Available only for supported versions of Android (NDK 19; Unity 2019+). <br /><br /> You can also enable this setting via the [`BacktraceConfiguration`](/error-reporting/platform-integrations/unity/configuration/#backtraceclient) object and the `.ClientSideUnwinding = true;` option. | Boolean | False   |
 | Symbols upload token                       | Required to automatically upload debug symbols to Backtrace. <br /> <br /> To generate a symbol upload token, in Backtrace go to Project Settings > Symbols > Access tokens > and select + to generate a new token.                                                                                                                                                                                                                    | String  |
 
+#### ProGuard Rules
+ProGuard obfuscation prevents the reflection used to get Java class names to setup a bridge between Unity and Java. Additional rules must be added to allow Backtrace to identify Java classes.
+
+- Please follow [this guide](/error-reporting/platform-integrations/android/proguard-deobfuscation/) to enable ProGuard, and add the following rule to proguard_rules.pro:
+    ```
+    -keep class backtraceio.unity.* { *; }
+    ```
+
+
 #### Uploading Debug Symbols
 
 You can configure the Backtrace client to automatically upload debug symbols in IL2CPP builds for Android apps.

--- a/docs/error-reporting/platform-integrations/unity/configuration.md
+++ b/docs/error-reporting/platform-integrations/unity/configuration.md
@@ -125,13 +125,21 @@ For more information about other data that is captured, see [Attributes](/error-
 | Symbols upload token                       | Required to automatically upload debug symbols to Backtrace. <br /> <br /> To generate a symbol upload token, in Backtrace go to Project Settings > Symbols > Access tokens > and select + to generate a new token.                                                                                                                                                                                                                    | String  |
 
 #### ProGuard Rules
-ProGuard obfuscation prevents the reflection used to get Java class names to setup a bridge between Unity and Java. Additional rules must be added to allow Backtrace to identify Java classes.
+ProGuard obfuscation prevents the reflection used to get Java class names to setup a bridge between Unity and Java. The ProGuard symbolication id must be passed to BacktraceClient, and additional ProGuard rules must be added to allow Backtrace to identify Java classes.
+<br/>
+Please follow [this guide](/error-reporting/platform-integrations/android/proguard-deobfuscation/) to enable ProGuard, and add the following:
 
-- Please follow [this guide](/error-reporting/platform-integrations/android/proguard-deobfuscation/) to enable ProGuard, and add the following rule to proguard_rules.pro:
+- Pass your ProGuard symbolication id to BacktraceClient:
+   ```java
+   var backtraceClient = GameObject.Find("manager name").GetComponent<BacktraceClient>();
+   final UUID proguardMappingUUID = UUID.fromString("f6c3e8d4-8626-4051-94ec-53e6daccce25");
+   backtraceClient.UseProguard(proguardMappingUUID.toString());
+   ```
+- Use these rules in proguard_rules.pro:
     ```
     -keep class backtraceio.unity.* { *; }
+    -keep class backtraceio.library.**.* { *; }
     ```
-
 
 #### Uploading Debug Symbols
 

--- a/docs/error-reporting/platform-integrations/unity/configuration.md
+++ b/docs/error-reporting/platform-integrations/unity/configuration.md
@@ -135,8 +135,8 @@ Please follow [this guide](/error-reporting/platform-integrations/android/progua
 - Pass your ProGuard symbolication id to BacktraceClient:
    ```java
    var backtraceClient = GameObject.Find("manager name").GetComponent<BacktraceClient>();
-   final UUID proguardMappingUUID = UUID.fromString("f6c3e8d4-8626-4051-94ec-53e6daccce25");
-   backtraceClient.UseProguard(proguardMappingUUID.toString());
+   var symbolicationId = "f6c3e8d4-8626-4051-94ec-53e6daccce25";
+   backtraceClient.UseProguard(symbolicationId);
    ```
 - Use these rules in proguard_rules.pro:
     ```


### PR DESCRIPTION
### Description
ProGuard obfuscation prevents the reflection used to get Java class names to setup a bridge between Unity and Java. Additional rules must be added to allow Backtrace to identify Java classes.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
