### PR TITLE
Don't let beamer change favicon url

### DIFF
--- a/src/plugins/beamer/index.js
+++ b/src/plugins/beamer/index.js
@@ -34,6 +34,11 @@ module.exports = function (context) {
                             product_id : 'WyhkZHOU27797',
                             ${selector},
                             ${display},
+                            callback: function() {
+                                setTimeout(function() {
+                                    window.Beamer.enableFaviconNotification = false;
+                                }, 0);
+                            },
                         };`,
                     },
                     {


### PR DESCRIPTION
### Description
Disable Beamer modification of favicon

### Motivation and Context
Google indexes the wrong icon

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
