### PR TITLE
sc: remove links to the sauce connect client 4.8.X

### DIFF
--- a/docs/secure-connections/sauce-connect/lifecycle.md
+++ b/docs/secure-connections/sauce-connect/lifecycle.md
@@ -10,7 +10,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
   <tr>
    <td>Family</td>
    <td>Version</td>
-   <td>Download Link</td>
    <td>End of Life</td>
   </tr>
   <tr>
@@ -19,9 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
   <tr>
    <td rowspan="1" >4.9</td>
    <td>4.9.2</td>
-   <td>
-    <a href="https://saucelabs.com/downloads/sc-4.9.2-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.9.2-linux-arm64.tar.gz">Linux ARM64</a>, <a href="https://saucelabs.com/downloads/sc-4.9.2-win32.zip">Windows</a>
-   </td>
    <td rowspan="2" >Feb. 29, 2024</td>
   </tr>
   <tr>
@@ -32,22 +28,13 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
   <tr>
    <td rowspan="3">4.9</td>
    <td>4.9.2</td>
-   <td>
-    <a href="https://saucelabs.com/downloads/sc-4.9.2-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.9.2-linux-arm64.tar.gz">Linux ARM64</a>, <a href="https://saucelabs.com/downloads/sc-4.9.2-win32.zip">Windows</a>
-   </td>
    <td rowspan="3">Dec. 31, 2024</td>
   </tr>
    <tr>
    <td>4.9.1</td>
-   <td>
-    <a href="https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.9.1-linux-arm64.tar.gz">Linux ARM64</a>, <a href="https://saucelabs.com/downloads/sc-4.9.1-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.9.1-win32.zip">Windows</a>
-   </td>
   </tr>
    <tr>
    <td>4.9.0</td>
-   <td>
-    <a href="https://saucelabs.com/downloads/sc-4.9.0-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.9.0-linux-arm64.tar.gz">Linux ARM64</a>, <a href="https://saucelabs.com/downloads/sc-4.9.0-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.9.0-win32.zip">Windows</a>
-   </td>
   </tr>
 </table>
 

--- a/docs/secure-connections/sauce-connect/lifecycle.md
+++ b/docs/secure-connections/sauce-connect/lifecycle.md
@@ -42,45 +42,19 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
    <td>
     <a href="https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.9.1-linux-arm64.tar.gz">Linux ARM64</a>, <a href="https://saucelabs.com/downloads/sc-4.9.1-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.9.1-win32.zip">Windows</a>
    </td>
-
   </tr>
    <tr>
    <td>4.9.0</td>
    <td>
     <a href="https://saucelabs.com/downloads/sc-4.9.0-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.9.0-linux-arm64.tar.gz">Linux ARM64</a>, <a href="https://saucelabs.com/downloads/sc-4.9.0-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.9.0-win32.zip">Windows</a>
    </td>
-
-  </tr>
-  <tr>
-   <td rowspan="4" >4.8</td>
-   <td>4.8.3</td>
-   <td>
-    <a href="https://saucelabs.com/downloads/sc-4.8.3-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.8.3-linux-arm64.tar.gz">Linux ARM64</a>, <a href="https://saucelabs.com/downloads/sc-4.8.3-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.8.3-win32.zip">Windows</a>
-   </td>
-   <td rowspan="4" >May. 29, 2024</td>
-  </tr>
- <tr>
-  <td>4.8.2</td>
-  <td>
-    <a href="https://saucelabs.com/downloads/sc-4.8.2-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.8.2-linux-arm64.tar.gz">Linux ARM64</a>, <a href="https://saucelabs.com/downloads/sc-4.8.2-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.8.2-win32.zip">Windows</a>
-  </td>
- </tr>
- <tr>
-  <td>4.8.1</td>
-  <td>
-    <a href="https://saucelabs.com/downloads/sc-4.8.1-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.8.1-linux-arm64.tar.gz">Linux ARM64</a>, <a href="https://saucelabs.com/downloads/sc-4.8.1-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.8.1-win32.zip">Windows</a>
-  </td>
- </tr>
-  <tr>
-   <td>4.8.0</td>
-   <td>
-    <a href="https://saucelabs.com/downloads/sc-4.8.0-linux.tar.gz">Linux</a>, <a href="https://saucelabs.com/downloads/sc-4.8.0-linux-arm64.tar.gz">Linux ARM64</a>, <a href="https://saucelabs.com/downloads/sc-4.8.0-osx.zip">Mac</a>, <a href="https://saucelabs.com/downloads/sc-4.8.0-win32.zip">Windows</a>
-   </td>
-  </tr>
-  <tr>
   </tr>
 </table>
 
 :::note
 MacOS is not supported in version 4.9.2.
+:::
+
+:::note
+Versions 4.8 and below of the Sauce Connect client are no longer supported. Please ensure that you are using a supported version to maintain compatibility and receive the latest updates and support.
 :::

--- a/docs/secure-connections/sauce-connect/setup-configuration/docker.md
+++ b/docs/secure-connections/sauce-connect/setup-configuration/docker.md
@@ -29,10 +29,6 @@ Here are some benefits/use cases:
       - 4.9.2, 4.9.2-ubuntu-22.04, 4.9.2-alpine-glibc, latest<br/>
       - 4.9.1, 4.9.1-ubuntu-22.04, 4.9.1-alpine-glibc<br/>
       - 4.9.0, 4.9.0-ubuntu-22.04, 4.9.0-alpine-glibc<br/>
-      - 4.8.3, 4.8.3-ubuntu-22.04, 4.8.3-alpine-glibc<br/>
-      - 4.8.2, 4.8.2-ubuntu-22.04, 4.8.2-alpine-glibc<br/>
-      - 4.8.1, 4.8.1-ubuntu-22.04, 4.8.1-alpine-glibc<br/>
-      - 4.8.0, 4.8.0-alpine-glibc<br/>
     </details>
 2. To run the Sauce Connect Proxy Docker image, run the script below.
 


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
Sauce Connect Client 4.8.X is no longer supported since it's reached the EOL. This MR removes all the links to sc 4.8 binaries.