### PR TITLE
add iOS 17.0 to appium-versions page

### DIFF
--- a/docs/mobile-apps/automated-testing/appium/appium-versions.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-versions.md
@@ -1911,6 +1911,28 @@ The following list of custom Appium plugins are supported:
   </thead>
   <tbody>
     <tr>
+      <td>iOS 17.0</td>
+      <td>
+        <ul>
+          <li>
+            <a href="#appium-2-versions">
+              <code>2.1.3</code>
+            </a>
+          </li>
+        </ul>
+      </td>
+      <td>
+        <a href="#appium-2-versions">
+          <code>2.1.3</code>
+        </a>
+      </td>
+      <td>
+        <a href="#appium-2-versions">
+          <code>2.1.3</code>
+        </a>
+      </td>
+    </tr>
+    <tr>
       <td>iOS 16.2</td>
       <td>
         <ul>


### PR DESCRIPTION
### Description
Add iOS 17.0 supported appium versions

### Motivation and Context
This has been out for a while and people are confused.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
