### PR TITLE
fix: vale linter configuration

### DIFF
--- a/styles/sauce/MeaningfulLinkWords.yml
+++ b/styles/sauce/MeaningfulLinkWords.yml
@@ -2,7 +2,7 @@
 extends: existence
 message: "Improve SEO and accessibility by rewriting '%s' in the link text."
 level: warning
-scope: link
+scope: raw
 ignorecase: true
 tokens:
   - here


### PR DESCRIPTION
### Description

`link` is no longer a valid scope, which prevented the vale linter from running.