### PR TITLE
ci: bucket based previews

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -46,7 +46,7 @@ jobs:
           credentials_json: '${{ secrets.RUN_SA_KEY_DEV }}'
 
       - name: Setup Google Cloud SDK
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.RUN_PROJECT_DEV }}
         env:
@@ -65,13 +65,14 @@ jobs:
         run: |
           npm run build
 
-      - name: Deploy to Bucket
+      - name: Deploy
+        if: github.event.action != 'closed' # Skip if the PR was closed
         working-directory: build
         run: |-
           gsutil -m rsync -R -d . ${{ secrets.GCS_DEV_BUCKET }}/${{ env.PREVIEW_PATH }}
 
       - name: Deploy Message
-        if: success()
+        if: github.event.action != 'closed' # Skip if the PR was closed
         uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,3 +80,8 @@ jobs:
           msg: |
             Deploy preview ready for ${{ github.event.number }}!
             https://docs.dev.saucelabs.net/${{ env.PREVIEW_PATH }}
+
+      - name: Cleanup
+        if: github.event.action == 'closed' # Cleanup action only on PR closure
+        run: |-
+          gsutil rm -r ${{ secrets.GCS_DEV_BUCKET }}/${{ env.PREVIEW_PATH }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -35,8 +35,20 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
+      - name: Google Cloud Login
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.RUN_SA_KEY_DEV }}'
+
+      - name: Setup Google Cloud SDK
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          project_id: ${{ secrets.RUN_PROJECT_DEV }}
+        env:
+          CLOUDSDK_PYTHON: ${{ env.pythonLocation }}/python
+
       - name: Set Preview Path
-        run: echo "PREVIEW_PATH=sauce-docs/pr-preview/pr-${{ github.event.number }}" >> "$GITHUB_ENV"
+        run: echo "PREVIEW_PATH=pr-preview/pr-${{ github.event.number }}" >> "$GITHUB_ENV"
 
       - name: Install Dependencies
         if: github.event.action != 'closed' # Skip if the PR was closed
@@ -48,7 +60,17 @@ jobs:
         run: |
           npm run build
 
-      - name: Deploy PR
-        uses: rossjrw/pr-preview-action@v1
+      - name: Deploy to Bucket
+        working-directory: build
+        run: |-
+          gsutil -m rsync -R -d . ${{ secrets.GCS_DEV_BUCKET }}/${{ env.PREVIEW_PATH }}
+
+      - name: Deploy Message
+        if: success()
+        uses: unsplash/comment-on-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          source-dir: ./build/
+          msg: |
+            Deploy preview ready for ${{ github.event.number }}!
+            https://docs.dev.saucelabs.net/${{ env.PREVIEW_PATH }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -35,6 +35,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Google Cloud Login
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
## Description

### Problem

Committing each full build (245MB at the time of writing) via GitHub pages to allow simultaneous PR previews has the downside that git retains the commit history in the `gh-pages` branch and therefore keeps growing infinitely, which in turn slows down git pulls.

### Solution

Use bucket based PR previews.

