### PR TITLE
Android doc custom logger

### DIFF
--- a/docs/error-reporting/platform-integrations/android/configuration.md
+++ b/docs/error-reporting/platform-integrations/android/configuration.md
@@ -383,6 +383,12 @@ To enable displaying logs from inside the library, set the level from which info
 BacktraceLogger.setLevel(LogLevel.DEBUG);
 ```
 
+You can replace internal BacktraceLogger with your custom implementation using code below.
+```java
+BacktraceLogger.setLogger(customLoggerInstance);
+```
+Your custom logger implementation has to implement [Logger](https://github.com/backtrace-labs/backtrace-android/blob/master/backtrace-library/src/main/java/backtraceio/library/logger/Logger.java) interface.
+
 ## Monitoring Custom Threads
 
 The backtrace-android library provides structures and methods to monitor the blocking of your own threads.

--- a/docs/error-reporting/platform-integrations/android/configuration.md
+++ b/docs/error-reporting/platform-integrations/android/configuration.md
@@ -384,9 +384,11 @@ BacktraceLogger.setLevel(LogLevel.DEBUG);
 ```
 
 You can replace internal BacktraceLogger with your custom implementation using code below.
+
 ```java
 BacktraceLogger.setLogger(customLoggerInstance);
 ```
+
 Your custom logger implementation has to implement [Logger](https://github.com/backtrace-labs/backtrace-android/blob/master/backtrace-library/src/main/java/backtraceio/library/logger/Logger.java) interface.
 
 ## Monitoring Custom Threads


### PR DESCRIPTION
### Description
Added example how to replace default BacktraceLogger used for logging internal SDK information by custom implementation.

### Motivation and Context
It's adding example how to use this feature for clients. Should be merged after merging PR which introducing this feature https://github.com/backtrace-labs/backtrace-android/pull/147.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x]  Documentation fix (typos, incorrect content, missing content, etc.)