### PR TITLE
build: fail on broken anchors

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,6 +11,7 @@ const docusaurusConfig = {
     noIndex: process.env.NO_INDEX,
     trailingSlash: true,
     baseUrl: siteBaseUrl,
+    onBrokenAnchors: 'throw',
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'throw',
     organizationName: 'saucelabs',


### PR DESCRIPTION
### Description

Now that [all broken anchors have been fixed](https://github.com/saucelabs/sauce-docs/pull/2932), let's enable Docusaurus' broken anchor gating mechanism, which will fail the build if it detects any:

```
[ERROR] Error: Unable to build website for locale en.
    at tryToBuildLocale (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/commands/build.js:54:19)
    at async /Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/commands/build.js:65:9
    at async mapAsyncSequential (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/utils/lib/jsUtils.js:21:24)
    at async Command.build (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/commands/build.js:63:5) {
  [cause]: Error: Docusaurus found broken anchors!

  Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
  Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.

  Exhaustive list of all broken anchors found:
  - Broken anchor on source page path = /mobile-apps/automated-testing/:
     -> linking to /dev/test-configuration-options/#bla

      at throwError (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/logger/lib/index.js:79:11)
      at reportBrokenLinks (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/server/brokenLinks.js:254:49)
      at handleBrokenLinks (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/server/brokenLinks.js:282:5)
      at executeBrokenLinksCheck (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/commands/build.js:199:47)
      at /Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/commands/build.js:145:66
      at Object.async (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/utils.js:36:47)
      at buildLocale (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/commands/build.js:145:30)
      at async tryToBuildLocale (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/commands/build.js:47:13)
      at async /Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/commands/build.js:65:9
      at async mapAsyncSequential (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/utils/lib/jsUtils.js:21:24)
      at async Command.build (/Users/alexplischke/devel/sauce-docs/node_modules/@docusaurus/core/lib/commands/build.js:63:5)
```