### PR TITLE
docs: add testcafe firefox profile example reference

### DIFF
--- a/docs/web-apps/automated-testing/_partials/_advanced-testcafe.md
+++ b/docs/web-apps/automated-testing/_partials/_advanced-testcafe.md
@@ -1,0 +1,9 @@
+## Setting a Custom Firefox Profile
+
+If you ever have the need to mock video streams, such as a webcam, the browser
+needs to be configured accordingly. Firefox does not provide a browser arg to
+enable all flags necessary—they have to be set via the profile settings.
+
+[This example](https://github.com/saucelabs/saucectl-testcafe-example/tree/main/examples/browser_profile)
+illustrates how you can configure saucectl to make use of an existing
+preconfigured browser profile.

--- a/docs/web-apps/automated-testing/testcafe/advanced.md
+++ b/docs/web-apps/automated-testing/testcafe/advanced.md
@@ -8,11 +8,13 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Advanced, {toc as AdvancedTOC} from '../\_partials/\_advanced.md';
+import AdvancedTestCafe, {toc as AdvancedTestCafeTOC} from '../\_partials/\_advanced-testcafe.md';
 import AdvancedNodejs, {toc as AdvancedNodejsTOC} from '../\_partials/\_advanced-nodejs.md';
 
 <AdvancedNodejs />
 <Advanced />
+<AdvancedTestCafe />
 
 <!-- Using partials breaks table of contents. Using this workaround to get it working again. -->
 
-export const toc = [...AdvancedNodejsTOC, ...AdvancedTOC];
+export const toc = [...AdvancedNodejsTOC, ...AdvancedTOC, ...AdvancedTestCafeTOC];


### PR DESCRIPTION
### Description

Add a reference to the newly added example of https://github.com/saucelabs/saucectl-testcafe-example/pull/55.
