### PR TITLE
docs: add example for cypress component testing

### DIFF
--- a/docs/web-apps/automated-testing/_partials/_advanced-cypress.md
+++ b/docs/web-apps/automated-testing/_partials/_advanced-cypress.md
@@ -37,4 +37,5 @@ saucectl run --env CYPRESS_TAGS="(@smoke or @ui) and (not @slow)"
 
 ## Component Testing
 
-`saucectl` doesn't currently support Component Testing.
+[This example](https://github.com/saucelabs/saucectl-cypress-example/tree/main/v1/examples/component-testing-react-cra5)
+showcases how use Cypress' Compontent Testing with saucectl.

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -1091,10 +1091,27 @@ suites:
     browser: "firefox"
     platformName: "Windows 10"
     config:
+      testingType: e2e
       env:
         hello: world
       specPattern: [ "cypress/e2e/**/*.cy.js" ]
       excludeSpecPattern: [ "cypress/e2e/**/not_this_one.cy.js" ]
+```
+
+---
+
+#### `testingType`
+
+<p><small>| OPTIONAL | STRING |</small></p>
+
+Toggle between the different testing types that Cypress supports:
+'e2e' (default) or 'component'.
+
+```yaml {5}
+suites:
+  - name: "Hello"
+    config:
+      testingType: e2e
 ```
 
 ---


### PR DESCRIPTION
### Description

[Cypress Component Testing](https://docs.cypress.io/guides/component-testing/overview) is indeed supported with a [new example added to illustrate the setup](https://github.com/saucelabs/saucectl-cypress-example/pull/119), following an investigation after https://github.com/saucelabs/sauce-docs/pull/2971.

Thanks @JessicaSachs for bringing this to our attention 🏅 