### PR TITLE
Update getting started requirements for Visual

### DIFF
--- a/docs/visual-testing.md
+++ b/docs/visual-testing.md
@@ -37,7 +37,7 @@ Sauce Visual Testing stands for:
 
 ## What You'll Need
 
-- A Sauce Labs account ([Log in](https://accounts.saucelabs.com/am/XUI/#login/) or sign up for a [free trial license](https://saucelabs.com/sign-up)) to access Visual Testing.
+- A Sauce Labs account ([Log in](https://accounts.saucelabs.com) or sign up for a [free trial license](https://saucelabs.com/sign-up)) to access Visual Testing.
 - Your Sauce Labs [Username and Access Key](https://app.saucelabs.com/user-settings).
 
 ## Workflows

--- a/docs/visual-testing.md
+++ b/docs/visual-testing.md
@@ -37,7 +37,7 @@ Sauce Visual Testing stands for:
 
 ## What You'll Need
 
-- A [Sauce Labs Enterprise account](https://saucelabs.com/pricing) with access to Visual Testing. To request access, contact your CSM or Sauce Labs Support.
+- A Sauce Labs account ([Log in](https://accounts.saucelabs.com/am/XUI/#login/) or sign up for a [free trial license](https://saucelabs.com/sign-up)) to access Visual Testing.
 - Your Sauce Labs [Username and Access Key](https://app.saucelabs.com/user-settings).
 
 ## Workflows


### PR DESCRIPTION
Update getting started requirements for Visual

### Description
An enterprise account is no longer required for Visual tests. Everyone can use Visual tests in Sauce labs.

### Motivation and Context
This change makes sure users know they can use Sauce Visual without enterprise license. 

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation fix (typos, incorrect content, missing content, etc.)
