### PR TITLE
docs: remove experimental note

### DIFF
--- a/docs/web-apps/automated-testing/_partials/_advanced.md
+++ b/docs/web-apps/automated-testing/_partials/_advanced.md
@@ -158,10 +158,6 @@ npm:
     - "package.json"
 ```
 
-:::caution
-This feature is highly experimental.
-:::
-
 ## Attaching Test Assets
 
 By default, any test assets created by your tests at runtime (such as logs, screenshots or reports) you wish to retain along with your test results must be placed in the `__assets__` directory of your project root folder. On Sauce Labs VMs, this path is relative to the current working directory.

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -583,10 +583,6 @@ npm:
 To use this feature, make sure that `node_modules` is not ignored via `.sauceignore`.
 
 :::caution
-This feature is highly experimental.
-:::
-
-:::caution
 Do not use `dependencies` and `packages` at the same time.
 :::
 

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -562,10 +562,6 @@ npm:
 To use this feature, make sure that `node_modules` is not ignored via `.sauceignore`.
 
 :::caution
-This feature is highly experimental.
-:::
-
-:::caution
 Do not use `dependencies` and `packages` at the same time.
 :::
 

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -566,10 +566,6 @@ npm:
 To use this feature, make sure that `node_modules` is not ignored via `.sauceignore`.
 
 :::caution
-This feature is highly experimental.
-:::
-
-:::caution
 Do not use `dependencies` and `packages` at the same time.
 :::
 


### PR DESCRIPTION
### Description

`npm.dependencies` has been out for a while, with almost half of the userbase using this feature. Not so experimental anymore.