### PR TITLE
Removed the space that was in this code block for appium:noReset

### DIFF
--- a/docs/mobile-apps/automated-testing/appium/real-devices.md
+++ b/docs/mobile-apps/automated-testing/appium/real-devices.md
@@ -278,7 +278,7 @@ To optimize device availability, consistency, and efficiency for multiple tests,
 To skip the uninstallation and reinstallation of your app from the device, you can set `noReset` to `true` in conjunction with using a `cacheId`. This setting adds efficiency, but may not be suitable for test setups that require the app's state to be reset between tests.
 
 ```js
-"appium: noReset" : "true",
+"appium:noReset" : "true",
 "sauce:options" : {
   "cacheId" : "jnc0x1256",
 }


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
There is a block of code showing an example for appium:noReset. The capability appium:noReset had a space in it:
`appium: noReset`

If used in a test, the capability would not be passed. Updated it and removed the space.
`appium:noReset`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a code block so customers can quickly copy/paste the code and it work properly

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
