### PR TITLE
Moved Two Capabilities Under New Section To Properly Align with what They Support

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -1970,38 +1970,6 @@ Appium tests for the Real Device Cloud using the W3C protocol MUST use `tunnelNa
 
 ---
 
-### `recordVideo`
-
-<p><small>| OPTIONAL | BOOLEAN |</small></p>
-
-Use this to disable video recording. By default, Sauce Labs records a video of every test you run. Disabling video recording can be useful for debugging failing tests as well as having a visual confirmation that a certain feature works (or still works). However, there is an added wait time for screen recording during a test run.
-
-```java
-MutableCapabilities capabilities = new MutableCapabilities();
-//...
-MutableCapabilities sauceOptions = new MutableCapabilities();
-sauceOptions.setCapability("recordVideo", false);
-capabilities.setCapability("sauce:options", sauceOptions);
-```
-
----
-
-### `videoUploadOnPass`
-
-<p><small>| OPTIONAL | BOOLEAN |</small></p>
-
-Disables video upload for passing tests. `videoUploadOnPass` is an alternative to `recordVideo`; it lets you discard videos for tests you've marked as passing. It disables video post-processing and uploading that may otherwise consume some extra time after your test is complete.
-
-```java
-MutableCapabilities capabilities = new MutableCapabilities();
-//...
-MutableCapabilities sauceOptions = new MutableCapabilities();
-sauceOptions.setCapability("videoUploadOnPass", false);
-capabilities.setCapability("sauce:options", sauceOptions);
-```
-
----
-
 ### `recordScreenshots`
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
@@ -2103,6 +2071,22 @@ capabilities.setCapability("sauce:options", sauceOptions);
 
 ---
 
+### `recordVideo`
+
+<p><small>| OPTIONAL | BOOLEAN |</small></p>
+
+Use this to disable video recording. By default, Sauce Labs records a video of every test you run. Disabling video recording can be useful for debugging failing tests as well as having a visual confirmation that a certain feature works (or still works). However, there is an added wait time for screen recording during a test run.
+
+```java
+MutableCapabilities capabilities = new MutableCapabilities();
+//...
+MutableCapabilities sauceOptions = new MutableCapabilities();
+sauceOptions.setCapability("recordVideo", false);
+capabilities.setCapability("sauce:options", sauceOptions);
+```
+
+---
+
 ### `timeZone`
 
 <p><small>| OPTIONAL | STRING | <span className="sauceGreen">Desktop and Virtual Devices Only</span> |</small></p>
@@ -2147,6 +2131,22 @@ The time zone identifier must be a valid name from the list of
 The time zone is changed on the *per-application* basis and is only valid for the application under test.
 The same behavior could be achieved by providing a custom value to the
 [TZ](https://developer.apple.com/forums/thread/86951#263395) environment variable via the `appium:processArguments` capability.
+
+---
+
+### `videoUploadOnPass`
+
+<p><small>| OPTIONAL | BOOLEAN |</small></p>
+
+Disables video upload for passing tests. `videoUploadOnPass` is an alternative to `recordVideo`; it lets you discard videos for tests you've marked as passing. It disables video post-processing and uploading that may otherwise consume some extra time after your test is complete.
+
+```java
+MutableCapabilities capabilities = new MutableCapabilities();
+//...
+MutableCapabilities sauceOptions = new MutableCapabilities();
+sauceOptions.setCapability("videoUploadOnPass", false);
+capabilities.setCapability("sauce:options", sauceOptions);
+```
 
 ---
 


### PR DESCRIPTION
Moved the following 2 capabilities:
recordVideo
videoUploadOnPass
FROM section: Desktop and Mobile Capabilities: Sauce-Specific – Optional TO section: Desktop and Virtual Device Capabilities: Sauce-Specific – Optional As they are not supported on Real Devices.

<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Moved the following 2 capabilities:
[**recordVideo**](https://docs.saucelabs.com/dev/test-configuration-options/#recordvideo)
[**videoUploadOnPass**](https://docs.saucelabs.com/dev/test-configuration-options/#videouploadonpass)
**FROM** section: `Desktop and Mobile Capabilities: Sauce-Specific – Optional `
**TO** section: `Desktop and Virtual Device Capabilities: Sauce-Specific – Optional `
As they are not supported on Real Devices. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These features are listed under the Desktop and Mobile Capabilities section, suggesting they are supported on mobile devices. However, after thoroughly testing RDC, we found that they are not supported. Updating this classification will help reduce customer confusion and accurately reflect the capabilities' applicability.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
