### PR TITLE
docs: add requirements for the usePackageLock feature

### DIFF
--- a/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
+++ b/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
@@ -423,7 +423,7 @@ npm:
       auth: base64SecretToken
       username: myUsername
       password: myPassword
-      email: myEmail 
+      email: myEmail
 ```
 
 ---
@@ -580,7 +580,7 @@ Do not use `dependencies` and `packages` at the same time.
 
 ### `usePackageLock`
 
-<p><small>| OPTIONAL | BOOLEAN |</small></p>
+<p><small>| OPTIONAL | BOOLEAN | <span className="sauceGreen">Playwright 1.48.2+</span> | <span className="sauceGreen">saucectl 0.187.0+</span> |</small></p>
 
 Specifies whether to use the project's package-lock.json when installing npm
 dependencies. If true, package-lock.json will be used during package
@@ -743,7 +743,7 @@ artifacts:
 <p><small>| OPTIONAL | OBJECT |</small></p>
 
 Define directories to archive and retain as a test asset at the end of a test run. Archived test assets can
-be downloaded automatically using the `download` configuration, via the 
+be downloaded automatically using the `download` configuration, via the
 [REST API](/dev/api/jobs/#get-a-job-asset-file), or through the test details page.
 
 ```yaml

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -565,7 +565,7 @@ Do not use `dependencies` and `packages` at the same time.
 
 ### `usePackageLock`
 
-<p><small>| OPTIONAL | BOOLEAN |</small></p>
+<p><small>| OPTIONAL | BOOLEAN | <span className="sauceGreen">Cypress 13.15.1+</span> | <span className="sauceGreen">saucectl 0.187.0+</span> |</small></p>
 
 Specifies whether to use the project's package-lock.json when installing npm
 dependencies. If true, package-lock.json will be used during package

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -414,7 +414,7 @@ npm:
       auth: base64SecretToken
       username: myUsername
       password: myPassword
-      email: myEmail 
+      email: myEmail
 ```
 
 ---
@@ -544,7 +544,7 @@ Do not use `dependencies` and `packages` at the same time.
 
 ### `usePackageLock`
 
-<p><small>| OPTIONAL | BOOLEAN |</small></p>
+<p><small>| OPTIONAL | BOOLEAN | <span className="sauceGreen">Playwright 1.48.2+</span> | <span className="sauceGreen">saucectl 0.187.0+</span> |</small></p>
 
 Specifies whether to use the project's package-lock.json when installing npm
 dependencies. If true, package-lock.json will be used during package
@@ -747,7 +747,7 @@ artifacts:
 <p><small>| OPTIONAL | OBJECT |</small></p>
 
 Define directories to archive and retain as a test asset at the end of a test run. Archived test assets can
-be downloaded automatically using the `download` configuration, via the 
+be downloaded automatically using the `download` configuration, via the
 [REST API](/dev/api/jobs/#get-a-job-asset-file), or through the test details page.
 
 ```yaml

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -416,7 +416,7 @@ npm:
       auth: base64SecretToken
       username: myUsername
       password: myPassword
-      email: myEmail 
+      email: myEmail
 ```
 
 ---
@@ -548,7 +548,7 @@ Do not use `dependencies` and `packages` at the same time.
 
 ### `usePackageLock`
 
-<p><small>| OPTIONAL | BOOLEAN |</small></p>
+<p><small>| OPTIONAL | BOOLEAN | <span className="sauceGreen">TestCafe 3.6.2+</span> | <span className="sauceGreen">saucectl 0.187.0+</span> |</small></p>
 
 Specifies whether to use the project's package-lock.json when installing npm
 dependencies. If true, package-lock.json will be used during package
@@ -751,7 +751,7 @@ artifacts:
 <p><small>| OPTIONAL | OBJECT |</small></p>
 
 Define directories to archive and retain as a test asset at the end of a test run. Archived test assets can
-be downloaded automatically using the `download` configuration, via the 
+be downloaded automatically using the `download` configuration, via the
 [REST API](/dev/api/jobs/#get-a-job-asset-file), or through the test details page.
 
 ```yaml


### PR DESCRIPTION
### Description

Document the minimum requirements (framework + saucectl) to use `usePackageLock`.