### PR TITLE
Updating Test Capabilities to be in Correct Section and Updated Typos

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -880,8 +880,7 @@ Using Appium 2? Prevent `appium:`-prefix repetitiveness and start using [`appium
 
 Defines the custom time zone override for the application under test.
 You can use `UTC`, `PST`, `EST`, as well as place-based timezone names such as `America/Los_Angeles`.
-See [the list of available time zone identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) f
-or more details. The same behavior could be achieved by providing a custom
+See [the list of available time zone identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for more details. The same behavior could be achieved by providing a custom
 value to the `TZ` environment variable via the `appium:processArguments` capability.
 
 :::note

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -2006,38 +2006,6 @@ Appium tests for the Real Device Cloud using the W3C protocol MUST use `tunnelNa
 
 ---
 
-### `recordVideo`
-
-<p><small>| OPTIONAL | BOOLEAN |</small></p>
-
-Use this to disable video recording. By default, Sauce Labs records a video of every test you run. Disabling video recording can be useful for debugging failing tests as well as having a visual confirmation that a certain feature works (or still works). However, there is an added wait time for screen recording during a test run.
-
-```java
-MutableCapabilities capabilities = new MutableCapabilities();
-//...
-MutableCapabilities sauceOptions = new MutableCapabilities();
-sauceOptions.setCapability("recordVideo", false);
-capabilities.setCapability("sauce:options", sauceOptions);
-```
-
----
-
-### `videoUploadOnPass`
-
-<p><small>| OPTIONAL | BOOLEAN |</small></p>
-
-Disables video upload for passing tests. `videoUploadOnPass` is an alternative to `recordVideo`; it lets you discard videos for tests you've marked as passing. It disables video post-processing and uploading that may otherwise consume some extra time after your test is complete.
-
-```java
-MutableCapabilities capabilities = new MutableCapabilities();
-//...
-MutableCapabilities sauceOptions = new MutableCapabilities();
-sauceOptions.setCapability("videoUploadOnPass", false);
-capabilities.setCapability("sauce:options", sauceOptions);
-```
-
----
-
 ### `recordScreenshots`
 
 <p><small>| OPTIONAL | BOOLEAN |</small></p>
@@ -2139,6 +2107,22 @@ capabilities.setCapability("sauce:options", sauceOptions);
 
 ---
 
+### `recordVideo`
+
+<p><small>| OPTIONAL | BOOLEAN |</small></p>
+
+Use this to disable video recording. By default, Sauce Labs records a video of every test you run. Disabling video recording can be useful for debugging failing tests as well as having a visual confirmation that a certain feature works (or still works). However, there is an added wait time for screen recording during a test run.
+
+```java
+MutableCapabilities capabilities = new MutableCapabilities();
+//...
+MutableCapabilities sauceOptions = new MutableCapabilities();
+sauceOptions.setCapability("recordVideo", false);
+capabilities.setCapability("sauce:options", sauceOptions);
+```
+
+---
+
 ### `timeZone`
 
 <p><small>| OPTIONAL | STRING | <span className="sauceGreen">Desktop and Virtual Devices Only</span> |</small></p>
@@ -2183,6 +2167,22 @@ The time zone identifier must be a valid name from the list of
 The time zone is changed on the *per-application* basis and is only valid for the application under test.
 The same behavior could be achieved by providing a custom value to the
 [TZ](https://developer.apple.com/forums/thread/86951#263395) environment variable via the `appium:processArguments` capability.
+
+---
+
+### `videoUploadOnPass`
+
+<p><small>| OPTIONAL | BOOLEAN |</small></p>
+
+Disables video upload for passing tests. `videoUploadOnPass` is an alternative to `recordVideo`; it lets you discard videos for tests you've marked as passing. It disables video post-processing and uploading that may otherwise consume some extra time after your test is complete.
+
+```java
+MutableCapabilities capabilities = new MutableCapabilities();
+//...
+MutableCapabilities sauceOptions = new MutableCapabilities();
+sauceOptions.setCapability("videoUploadOnPass", false);
+capabilities.setCapability("sauce:options", sauceOptions);
+```
 
 ---
 

--- a/docs/mobile-apps/automated-testing/appium/real-devices.md
+++ b/docs/mobile-apps/automated-testing/appium/real-devices.md
@@ -278,7 +278,7 @@ To optimize device availability, consistency, and efficiency for multiple tests,
 To skip the uninstallation and reinstallation of your app from the device, you can set `noReset` to `true` in conjunction with using a `cacheId`. This setting adds efficiency, but may not be suitable for test setups that require the app's state to be reset between tests.
 
 ```js
-"appium: noReset" : "true",
+"appium:noReset" : "true",
 "sauce:options" : {
   "cacheId" : "jnc0x1256",
 }


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

**Change 1** | Updated sentence to remove line break:

**BEFORE**
See [the list of available time zone identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) **f
or** more details. The same behavior could be achieved by providing a custom

**AFTER**
See [the list of available time zone identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for more details. The same behavior could be achieved by providing a custom


**Change 2** | Updated code block in appium real device doc to remove space:
**BEFORE**
"**appium: noReset**" : "true",

**AFTER**
"appium:noReset" : "true",

**Change 3** | Moved two capabilities as they are not supported on RDC:
- recordVideo
- videoUploadOnPass

Moved **FROM**: `Desktop and Mobile Capabilities: Sauce-Specific – Optional`
**TO**: `Desktop and Virtual Device Capabilities: Sauce-Specific – Optional`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To improve readability of docs and to ensure features are properly categorized so users know how to use them

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
