### PR TITLE
Updated Broken Link for Apple Developer Enterprise Site

### DIFF
--- a/docs/testfairy/testers/managing-testers.md
+++ b/docs/testfairy/testers/managing-testers.md
@@ -30,7 +30,7 @@ You can also select a Group for the testers in the list or leave it blank (see *
 You can add testers manually or [import lists of testers](https://app.testfairy.com/testers/import/) in CSV format.
 
 :::note Only for iOS
-If you are **not** using an [iOS Enterprise certificate](https://developer.apple.com/programs/ios/enterprise/), you will need to obtain the UDIDs (Unique Device Identifiers) of your testers' devices before sending them the app. The registration link in the email sent to testers will enable them to provide their UDIDs. These details will be added to your [testers page](https://app.testfairy.com/testers).
+If you are **not** using an [iOS Enterprise certificate](https://developer.apple.com/programs/enterprise/), you will need to obtain the UDIDs (Unique Device Identifiers) of your testers' devices before sending them the app. The registration link in the email sent to testers will enable them to provide their UDIDs. These details will be added to your [testers page](https://app.testfairy.com/testers).
 For more information on how to add UDIDs to provisioning profiles, see [Adding UDIDs to iOS Development Profile](/testfairy/sdk/ios/adding-udids/).
 
 :::


### PR DESCRIPTION
The link in the note under Inviting Testers by Email is broken: https://developer.apple.com/programs/ios/enterprise/

<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Under this section: https://docs.saucelabs.com/testfairy/testers/managing-testers/#inviting-testers-by-email there is a footnote:
**Only for iOS**
`If you are not using an [iOS Enterprise certificate](https://developer.apple.com/programs/ios/enterprise/), you will need to obtain the UDIDs (Unique Device Identifiers) of your testers' devices before sending them the app.`
- Updated URL to correct site: https://developer.apple.com/programs/enterprise/

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Navigates the user to the correct Apple Developer site

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
