### PR TITLE
docs/basic: US-East-4 datacenter supports real mobile device testing only

### DIFF
--- a/docs/basics/data-center-endpoints.md
+++ b/docs/basics/data-center-endpoints.md
@@ -27,9 +27,13 @@ Your data center is determined based on your license type and your company's nee
 
 To see your data center, check the upper-right corner of the Sauce Labs user interface. Options include:
 
-- US West
-- US East
-- EU Central
+- US West 1
+- US East 4
+- EU Central 1
+
+:::note
+Virtual Device Testing is not available in US East 4.
+:::
 
 ## Data Center Endpoints
 
@@ -45,7 +49,7 @@ Sauce Connect Proxy makes its initial connection to saucelabs.com. After that, i
 
 | Description                  | Endpoint                                        |
 | ---------------------------- | ----------------------------------------------- |
-| OnDemand Endpoint            | https://ondemand.us-west-1.saucelabs.com/wd/hub |
+| Remote WebDriver Endpoint    | https://ondemand.us-west-1.saucelabs.com/wd/hub |
 | REST API                     | api.us-west-1.saucelabs.com                     |
 | Sauce Connect Tunnel Servers | maki\*.miso.saucelabs.com:443                   |
 
@@ -53,7 +57,7 @@ Sauce Connect Proxy makes its initial connection to saucelabs.com. After that, i
 
 | Description                  | Endpoint                                        |
 | ---------------------------- | ----------------------------------------------- |
-| OnDemand Endpoint            | https://ondemand.us-east-4.saucelabs.com/wd/hub |
+| Remote WebDriver Endpoint    | https://ondemand.us-east-4.saucelabs.com/wd/hub |
 | REST API                     | api.us-east-4.saucelabs.com                     |
 | Sauce Connect Tunnel Servers | \*.tunnels.us-east-4.saucelabs.com:443          |
 
@@ -65,7 +69,7 @@ Depending on the framework or driver you use, you might need to make additional 
 
 | Description                  | Endpoint                                           |
 | ---------------------------- | -------------------------------------------------- |
-| OnDemand Endpoint            | https://ondemand.eu-central-1.saucelabs.com/wd/hub |
+| Remote WebDriver Endpoint    | https://ondemand.eu-central-1.saucelabs.com/wd/hub |
 | REST API                     | api.eu-central-1.saucelabs.com                     |
 | Sauce Connect Tunnel Servers | maki\*.eu-central-1.miso.saucelabs.com:443         |
 

--- a/docs/test-results/sharing-test-results.md
+++ b/docs/test-results/sharing-test-results.md
@@ -244,7 +244,7 @@ https://app.saucelabs.com/video-embed/YOUR_JOB_ID.js?auth=AUTH_TOKEN
 To embed the page for EU DC test, you need to use the `app.eu-central-1.saucelabs.com` domain.
 
 ```js
-https://app.[eu-central-1|us-east-1].saucelabs.com/video-embed/YOUR_JOB_ID.js?auth=AUTH_TOKEN
+https://app.eu-central-1.saucelabs.com/video-embed/YOUR_JOB_ID.js?auth=AUTH_TOKEN
 ```
 
 ### Embedding Full Test Pages

--- a/static/oas/sauce.json
+++ b/static/oas/sauce.json
@@ -26,7 +26,7 @@
           "description":"region of datacenter",
           "enum":[
             "us-west-1",
-            "us-east-1",
+            "us-east-4",
             "eu-central-1",
             "staging"
           ]


### PR DESCRIPTION
### Description

- Removing defunct us-east-1 from a couple of places
- Adding a note about us-east-4 limitations
- Other minor changes
  - For instance, it is not descriptive to call `ondemand.sl.com` "ondemand endpoint" as if "ondemand" had a special meaning explaining the endpoint

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
