### PR TITLE
Remove unused capability from docs

### DIFF
--- a/docs/mobile-apps/automated-testing/espresso-xcuitest/xcuitest.md
+++ b/docs/mobile-apps/automated-testing/espresso-xcuitest/xcuitest.md
@@ -804,7 +804,6 @@ Application settings for real device tests.
 suites:
   - name: My Saucy Test
     appSettings:
-      audioCapture: true
       instrumentation:
         networkCapture: true
 ```


### PR DESCRIPTION
### Description
We have incorrect capability examples in xcuitests for audio capture. Removing it.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation fix (typos, incorrect content, missing content, etc.)
