### PR TITLE
docs: Remove outdated proxy setting notes for Playwright

### DIFF
--- a/docs/dev/cli/saucectl/usage/use-cases.md
+++ b/docs/dev/cli/saucectl/usage/use-cases.md
@@ -109,10 +109,6 @@ If you need to go through a proxy server, you can set it through the following v
 - `HTTP_PROXY`: Proxy to use to access HTTP websites
 - `HTTPS_PROXY`: Proxy to use to access HTTPS websites
 
-:::note
-At this time, these proxy settings are not supported for Playwright.
-:::
-
 ### Saucectl
 
 `saucectl` supports going through a proxy to access Sauce Labs API.


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Remove outdated proxy setting notes for Playwright. That was the limitation back to folio. Playwright runner does support HTTP Proxy setting now.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
