### PR TITLE
Backtrace: Upload automatically source maps to Backtrace

### DIFF
--- a/docs/error-reporting/language-integrations/react-native.md
+++ b/docs/error-reporting/language-integrations/react-native.md
@@ -453,7 +453,7 @@ To integrate an application source maps in react-native with Backtrace you need:
 
 #### Modifying `metro.config.js` 
 
-Backtrace is compatible with metro build system. To enable source map support, set a `customSerializer` method in the `metro.config.js` file to the `processSourceMap` function available in `@backtrace/react-native/scripts/processSourceMap`.
+Backtrace is compatible with the metro build system. To enable source map support, set a `customSerializer` method in the `metro.config.js` file to the `processSourceMap` function available in `@backtrace/react-native/scripts/processSourceMap`.
 
 ```
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');

--- a/docs/error-reporting/language-integrations/react-native.md
+++ b/docs/error-reporting/language-integrations/react-native.md
@@ -443,7 +443,7 @@ const client = BacktraceClient.initialize({
 
 ### Automatically upload source maps
 
-@Backtrace/react allows for easy integration and automatic sending of generated source maps. Thanks to them, generated functions or unreadable reference to a line or column in the code will point to the correct place.
+@Backtrace/react provides CI tooling to easily post source maps to Backtrace. Posting source maps enables Backtrace to symbolicate minified code, allowing error reports to be displayed with the original source code highlighting the correct faulting line.
 
 To integrate an application source maps in react-native with Backtrace you need:
 - create a `.backtracejsrc` file in the main application folder,


### PR DESCRIPTION
Backtrace: Upload automatically source maps to Backtrace

### Description
This pull request adds instructions that allow user to upload automatically source maps to Backtrace via their build systems in react-native.

### Motivation and Context
Integrating source maps with any react-native application is a challenge. To have human-readable function names and correct line/column numbers, our users need to upload source maps to Backtrace. 

This pull request shows instructions how to make this process easy with Backtrace.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)

ref: BT-5175