### PR TITLE
Updates endpoints for testfairy upload, and fixed name for Access Key

### DIFF
--- a/docs/testfairy/api-reference/upload-api.md
+++ b/docs/testfairy/api-reference/upload-api.md
@@ -39,7 +39,7 @@ Streamline your build process and upload APKs or IPAs directly to TestFairy.
 ### Upload API
 
 <details>
-<summary><span className="api post">POST</span><code>https://upload.testfairy.com/api/upload/</code></summary>
+<summary><span className="api post">POST</span><code>https://app.testfairy.com/api/upload/</code></summary>
 <p></p>
 
 #### Parameters
@@ -130,7 +130,7 @@ values={[
 <TabItem value="required">
 
 ```bash title="Sample Request with Required Params"
-curl https://upload.testfairy.com/api/upload -F api_key='your_api_key' -F file=@sample.apk
+curl https://app.testfairy.com/api/upload -F api_key='your_api_key' -F file=@sample.apk
 ```
 
 </TabItem>
@@ -138,7 +138,7 @@ curl https://upload.testfairy.com/api/upload -F api_key='your_api_key' -F file=@
 <TabItem value="optional">
 
 ```bash title="Sample Request with Optional Params"
-curl https://upload.testfairy.com/api/upload \
+curl https://app.testfairy.com/api/upload \
  -F api_key='your_api_key' \
  -F file=@sample.apk \
  -F symbols_file=@sample_mapping.txt \
@@ -212,11 +212,11 @@ In the case of an error, TestFairy returns a JSON with `status` => `fail` and `c
 
 ### Where Can I Find My API Key?
 
-To get your API KEY, open your account preferences at https://app.testfairy.com/settings/ and click on **Upload API Key**.
+To get your API KEY, open your account preferences at https://app.testfairy.com/settings/ and click on **TestFairy Access Key**.
 
 ### How Can I Create a New API Key?
 
-To create a new API KEY, click on **Regenerate API Key** on your account preferences page.
+To create a new API KEY, click on **Regenerate** on your account preferences page.
 
 ### Why Is My API Key Empty?
 
@@ -227,7 +227,7 @@ In cases TestFairy identifies that by mistake, you initialize the SDK by using y
 Yes. Any POST parameter prefixed with "metadata." in the name is considered custom data and stored along with the upload. For example, consider this command:
 
 ```bash
-curl https://upload.testfairy.com/api/upload \
+curl https://app.testfairy.com/api/upload \
  -F api_key='your_api_key' \
  -F file=@sample.apk \
  -F metadata.branch=master \

--- a/docs/testfairy/app-distribution/release-notes.md
+++ b/docs/testfairy/app-distribution/release-notes.md
@@ -37,7 +37,7 @@ To add release notes, use the `comment` field.
 For example:
 
 ```bash
-curl https://upload.testfairy.com/api/upload \
+curl https://app.testfairy.com/api/upload \
     -F api_key='your_api_key' \
     -F file=@sample.apk \
     -F symbols_file=@sample_mapping.txt \

--- a/docs/testfairy/app-distribution/symbols-file.md
+++ b/docs/testfairy/app-distribution/symbols-file.md
@@ -27,7 +27,7 @@ You can upload the mapping file by using the API provided by Sauce Labs. Here's 
 Android:
 
 ```bash
-curl https://upload.testfairy.com/api/upload \
+curl https://app.testfairy.com/api/upload \
  -F api_key='your_api_key' \
  -F file=@sample.apk \
  -F symbols_file=@mappings.txt
@@ -36,7 +36,7 @@ curl https://upload.testfairy.com/api/upload \
 IOS:
 
 ```bash
-curl https://upload.testfairy.com/api/upload \
+curl https://app.testfairy.com/api/upload \
  -F api_key='your_api_key' \
  -F file=@sample.ipa \
  -F symbols_file=@sample.dSYM.zip

--- a/docs/testfairy/ci-tools/fastlane.md
+++ b/docs/testfairy/ci-tools/fastlane.md
@@ -8,7 +8,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Upload a new build to TestFairy using Fastlane. You can find your API Key in the [TestFairy Settings](https://free.testfairy.com/settings/) page.
+Upload a new build to TestFairy using Fastlane. You can find your API Key in the [TestFairy Settings](https://app.testfairy.com/settings/) page.
 
 ```
 testfairy(
@@ -34,7 +34,7 @@ testfairy(
 | ipa            | 	Path to your IPA file for iOS	                                           |                              |
 | apk            | 	Path to your APK file for Android	                                       |                              |
 | symbols_file   | 	Symbols mapping file	                                                    |                              |
-| upload_url     | 	Upload API URL for TestFairy	                                            | https://upload.testfairy.com |
+| upload_url     | 	Upload API URL for TestFairy	                                            | https://app.testfairy.com |
 | testers_groups | 	Array of tester groups to be notified	                                   | []                           |
 | comment        | 	Additional release notes for this upload. Will be added to sent emails 	 | No comment                   |
 | notify         | 	Send email to testers	                                                   | off                          |

--- a/docs/testfairy/ci-tools/gitlab.md
+++ b/docs/testfairy/ci-tools/gitlab.md
@@ -8,14 +8,14 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-To automatically deply your Android or iOS Apps to [TestFairy](https://www.testfairy.com/) by using GitLab, follow the steps below:
+To automatically deply your Android or iOS Apps to [TestFairy](https://app.testfairy.com/) by using GitLab, follow the steps below:
 
-1. On the TestFairy dashboard, navigate to **Preferences** > **[Upload API Key](https://app.testfairy.com/settings/api-key)**.
+1. On the TestFairy dashboard, navigate to **Preferences** > **[TestFairy Access Key](https://app.testfairy.com/settings/access-key)**.
 
    <img src={useBaseUrl('/img/testfairy/ci-tools/testfairy_upload_key.png')} alt="testfairy upload key"/>
 
 2. Copy your API key and go to your application's project **Settings** > **CI/CD** > **Variables** in GitLab.
-3. Add a variable called `TESTFAIRY_API_KEY` to the list with the value of your **Upload API key**.
+3. Add a variable called `TESTFAIRY_API_KEY` to the list with the value of your **TestFairy Access Key**.
 
    <img src={useBaseUrl('/img/testfairy/ci-tools/gitlab_secret_keys.png')} alt="gitlab secret keys"/>
 
@@ -36,7 +36,7 @@ To automatically deply your Android or iOS Apps to [TestFairy](https://www.testf
            -F api_key="${TESTFAIRY_API_KEY}" \
            -F comment="GitLab Pipeline build ${CI_COMMIT_SHA}" \
            -F file=@android.apk \
-           https://upload.testfairy.com/api/upload/
+           https://app.testfairy.com/api/upload/
      ```
 
 :::note

--- a/docs/testfairy/ci-tools/ms-app-ctr.md
+++ b/docs/testfairy/ci-tools/ms-app-ctr.md
@@ -20,13 +20,13 @@ Create a new file, call it `appcenter-post-build.sh`, and add it next to the pro
 TESTFAIRY_UPLOAD_API_KEY=1234356
 
 if [[ "$APPCENTER_XCODE_PROJECT" ]]; then
- curl https://upload.testfairy.com/api/upload \
+ curl https://app.testfairy.com/api/upload \
  -F "api_key=$TESTFAIRY_UPLOAD_API_KEY" \
  -F "file=@$APPCENTER_OUTPUT_DIRECTORY/example.ipa"
 fi
 
 if [[ -z "$APPCENTER_XCODE_PROJECT" ]]; then
- curl https://upload.testfairy.com/api/upload \
+ curl https://app.testfairy.com/api/upload \
  -F "api_key=$TESTFAIRY_UPLOAD_API_KEY" \
  -F "file=@$APPCENTER_OUTPUT_DIRECTORY/example.apk"
 fi

--- a/docs/testfairy/ci-tools/team-city.md
+++ b/docs/testfairy/ci-tools/team-city.md
@@ -37,7 +37,7 @@ To automatically deply your Android or iOS Apps to [TestFairy](https://www.testf
    Copy the following command into the **Custom script** text field:
 
    ```bash
-   curl https://upload.testfairy.com/api/upload -F api_key=${env.TESTFAIRY_API_KEY} -F comment="TeamCity build" -F file=@android.apk
+   curl https://app.testfairy.com/api/upload -F api_key=${env.TESTFAIRY_API_KEY} -F comment="TeamCity build" -F file=@android.apk
    ```
 
    :::note

--- a/docs/testfairy/ci-tools/vs-team.md
+++ b/docs/testfairy/ci-tools/vs-team.md
@@ -21,7 +21,7 @@ This guide provides instructions for Visual Studio Team Services (VSTS) users to
 3. Configure the task and add the following line to arguments:
 
    ```bash
-   https://upload.testfairy.com/api/upload -F api_key=abcdabcdgfdsgfds56 -F file=@sample.apk
+   https://app.testfairy.com/api/upload -F api_key=abcdabcdgfdsgfds56 -F file=@sample.apk
    ```
 
    :::note

--- a/docs/testfairy/platforms/lumberyard.md
+++ b/docs/testfairy/platforms/lumberyard.md
@@ -99,7 +99,7 @@ Once your APK is built, you can choose your favourite upload method to finalize 
 To upload with **curl**, run the following command in **lumberyard_version\dev\BinAndroidCPU_ARCHClang** folder. Make sure your APK filename is set correctly.
 
 ```bash
-curl https://upload.testfairy.com/api/upload -F api_key='your_api_key' -F file=@ProjectName.apk
+curl https://app.testfairy.com/api/upload -F api_key='your_api_key' -F file=@ProjectName.apk
 ```
 
 Optionally, you can download and use [TestFairy command line uploader](https://github.com/testfairy/command-line-uploader) if you don't have **curl** installed.


### PR DESCRIPTION
### Description
Fixed some references to upload.testfairy.com and replaced them with app.testfairy.com. 
Also changed "API Key" to "TestFairy Access Key" as reflected in the UI.

### Motivation and Context
Better documentation.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
