### PR TITLE
docs: Update information regarding fileImporter SwiftUI API

### DIFF
--- a/docs/mobile-apps/automated-testing/ipa-files.md
+++ b/docs/mobile-apps/automated-testing/ipa-files.md
@@ -149,3 +149,11 @@ We recommend that you try the following workaround:
 2. If the above solution does not work, try using a different network without the proxy.
 
 We do not have control over Apple's signature verification process. It is recommended to work with your network administrator to ensure that Apple's signature check is not blocked by the proxy.
+
+### Unable to access Downloads folder using 'fileImporter' SwiftUI API
+Apple prevents access to private sandbox data via fileImporter (and likely other APIs) after re-signing an app. 
+
+For instrumentation, Sauce Labs must re-sign the app using our certificates and provisioning profiles, and change the bundle identifier to Sauce Labs wildcard identifier. 
+
+This is an inherent limitation of the Apple system.
+The solution for the client is to not use instrumentation when accessing data using `fileImporter `. 


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
Update description regarding `fileImporter` API.

### Motivation and Context
The customer enabled instrumentation and faced issues with accessing the Downloads folder using `fileImporter` SwiftUI API.
We should document that this is not supported due to a limitation in the Apple security system.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
