### PR TITLE
SC-5215: Add information about deprecation of selenium-relay

### DIFF
--- a/docs/secure-connections/sauce-connect-5/migrating.md
+++ b/docs/secure-connections/sauce-connect-5/migrating.md
@@ -177,6 +177,12 @@ Tracking process state through a PID file is error-prone and no longer recommend
 
 SC5 leaves log management to third party tools such as journald. It can log to stdout or a single file.
 
+### Selenium Relay
+
+Selenium Relay was introduced as a reverse proxy for development environments. Over time, enterprise customers adopted it for production scenarios where more robust communication channels with the Sauce Labs WebDriver endpoint were needed.
+
+With established alternatives like Envoy, Nginx, and HAProxy offering better security, performance, and support, we have deprecated Selenium Relay. We recommend adopting one of these solutions for a more robust and maintainable setup.
+
 ## Proxy Updates
 
 Sauce Connect 5 no longer uses the `HTTP(S)_PROXY` and `NO_PROXY` environment variables.


### PR DESCRIPTION
### Description
This PR explains why support for Selenium Relay has been dropped in favor of more robust alternatives like Envoy, Nginx, and HAProxy.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
