### PR TITLE
Update virtual-apple-silicon.md

### DIFF
--- a/docs/mobile-apps/virtual-apple-silicon.md
+++ b/docs/mobile-apps/virtual-apple-silicon.md
@@ -27,7 +27,7 @@ iOS 17.5 and iOS 18 Simulators on Apple Silicon are only available to Enterprise
 
 ### Building Your iOS/iPadOS App
 
-Xcode can builds apps for Simulators that support both `arm64` and `x86_64` architectures.
+Xcode can build apps for Simulators that support both `arm64` and `x86_64` architectures.
 
 To build specifically for **Apple Silicon (arm64)** Simulators:
 
@@ -170,7 +170,7 @@ Check [Appium Version Details](./automated-testing/appium/appium-versions.md#app
 
 Changes to Appium XCUITest Driver v7+ have modified how System alerts are interacted with, potentially requiring modifications to tests run on iOS 18 Simulators.
 
-**Solution**: set `respectSystemsAlerts` setting to `true` as in this example:
+**Solution**: Use the `respectSystemsAlerts` setting ([Settings](https://appium.github.io/appium-xcuitest-driver/latest/reference/settings/), not [Capabilities](https://appium.github.io/appium-xcuitest-driver/latest/reference/capabilities/) to `true` as in this Java example:
 ```java
 options.setSetting("respectSystemAlerts", true);
 ```

--- a/docs/mobile-apps/virtual-apple-silicon.md
+++ b/docs/mobile-apps/virtual-apple-silicon.md
@@ -27,7 +27,7 @@ iOS 17.5 and iOS 18 Simulators on Apple Silicon are only available to Enterprise
 
 ### Building Your iOS/iPadOS App
 
-By default, Xcode builds apps for Simulators that support both `arm64` and `x86_64` architectures.
+Xcode can builds apps for Simulators that support both `arm64` and `x86_64` architectures.
 
 To build specifically for **Apple Silicon (arm64)** Simulators:
 
@@ -174,7 +174,7 @@ Changes to Appium XCUITest Driver v7+ have modified how System alerts are intera
 ```java
 options.setSetting("respectSystemAlerts", true);
 ```
-For more details and alernative options see the [Appium documentation](https://appium.github.io/appium-xcuitest-driver/latest/guides/troubleshooting/#interact-with-dialogs-managed-by-comapplespringboard).
+For more details and alternative options see the [Appium documentation](https://appium.github.io/appium-xcuitest-driver/latest/guides/troubleshooting/#interact-with-dialogs-managed-by-comapplespringboard).
 
 ### Changes to Gestures
 

--- a/docs/mobile-apps/virtual-apple-silicon.md
+++ b/docs/mobile-apps/virtual-apple-silicon.md
@@ -170,7 +170,11 @@ Check [Appium Version Details](./automated-testing/appium/appium-versions.md#app
 
 Changes to Appium XCUITest Driver v7+ have modified how System alerts are interacted with, potentially requiring modifications to tests run on iOS 18 Simulators.
 
-**Solution**: set `respectSystemsAlerts` setting to `true` — for more details and alernative options see the [Appium documentation](https://appium.github.io/appium-xcuitest-driver/latest/guides/troubleshooting/#interact-with-dialogs-managed-by-comapplespringboard).
+**Solution**: set `respectSystemsAlerts` setting to `true` as in this example:
+```java
+options.setSetting("respectSystemAlerts", true);
+```
+For more details and alernative options see the [Appium documentation](https://appium.github.io/appium-xcuitest-driver/latest/guides/troubleshooting/#interact-with-dialogs-managed-by-comapplespringboard).
 
 ### Changes to Gestures
 

--- a/docs/mobile-apps/virtual-apple-silicon.md
+++ b/docs/mobile-apps/virtual-apple-silicon.md
@@ -170,7 +170,7 @@ Check [Appium Version Details](./automated-testing/appium/appium-versions.md#app
 
 Changes to Appium XCUITest Driver v7+ have modified how System alerts are interacted with, potentially requiring modifications to tests run on iOS 18 Simulators.
 
-**Solution**: Use the `respectSystemsAlerts` setting ([Settings](https://appium.github.io/appium-xcuitest-driver/latest/reference/settings/), not [Capabilities](https://appium.github.io/appium-xcuitest-driver/latest/reference/capabilities/) to `true` as in this Java example:
+**Solution**: Use the `respectSystemsAlerts` setting ([Settings](https://appium.github.io/appium-xcuitest-driver/latest/reference/settings/), not [Capabilities](https://appium.github.io/appium-xcuitest-driver/latest/reference/capabilities/)) to `true` as in this Java example:
 ```java
 options.setSetting("respectSystemAlerts", true);
 ```


### PR DESCRIPTION
Small tweak to Apple Silicon VDC Doc for iOS 18 

### Description

Added a code snippet to the respectSystemAlerts solution.

### Motivation and Context

Previous version was ambigous where to add the appium setting. 

### Types of Changes
- [ x] Documentation fix (typos, incorrect content, missing content, etc.)
