### PR TITLE
Change documentation for latest image since it was rolled back

### DIFF
--- a/docs/mobile-apps/automated-testing/appium/appium-versions.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-versions.md
@@ -213,23 +213,23 @@ The following list of custom Appium plugins are supported:
         This is a collection of drivers that were released in this version <br />
        <ul>
           <li>
-            <a href="https://github.com/appium/appium/releases/tag/appium%402.18.0" target="_blank">
-              <code>appium</code>: 2.18.0
+            <a href="https://github.com/appium/appium/releases/tag/appium%402.13.1" target="_blank">
+              <code>appium</code>: 2.13.1
             </a>
           </li>
           <li>
-            <a href="https://github.com/appium/appium-flutter-driver/releases/tag/v2.15.1" target="_blank">
-              <code>appium-flutter-driver</code>: 2.15.1
+            <a href="https://github.com/appium/appium-flutter-driver/releases/tag/v2.11.0" target="_blank">
+              <code>appium-flutter-driver</code>: 2.11.0
             </a>
           </li>
           <li>
-            <a href="https://github.com/appium/appium-uiautomator2-driver/releases/tag/v4.2.3" target="_blank">
-              <code>appium-uiautomator2-driver</code>: 4.2.3
+            <a href="https://github.com/appium/appium-uiautomator2-driver/releases/tag/v3.9.6" target="_blank">
+              <code>appium-uiautomator2-driver</code>: 3.9.6
             </a>
           </li>
           <li>
-            <a href="https://github.com/appium/appium-xcuitest-driver/releases/tag/v9.2.3" target="_blank">
-              <code>appium-xcuitest-driver</code>: 9.2.3
+            <a href="https://github.com/appium/appium-xcuitest-driver/releases/tag/v7.35.0" target="_blank">
+              <code>appium-xcuitest-driver</code>: 7.35.0
             </a>
           </li>
           <li>


### PR DESCRIPTION
### Description
The latest image needed to roll back, since it contained too many breaking changes and also some bugs when it comes to handling web views in iOS.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
