### PR TITLE
Document changes in W3C vs JWP protocol selection

### DIFF
--- a/docs/mobile-apps/automated-testing/appium/real-devices.md
+++ b/docs/mobile-apps/automated-testing/appium/real-devices.md
@@ -54,13 +54,7 @@ The W3C WebDriver Protocol test capability syntax differs from that of JWP, so i
 
 ### How Sauce Labs Determines Your Protocol
 
-When Sauce Labs executes your test configuration, it looks for the presence of certain indicators in the session creation request to determine whether it should apply the JWP or W3C protocol. The following table outlines how Sauce Labs evaluates your creation request.
-
-| Indicator                                                                 | Determination |
-| :------------------------------------------------------------------------ | :------------ |
-| `sauce:options` node is present within the capabilities node.             | W3C           |
-| `desiredCapabilities` node is absent.                                     | W3C           |
-| `desiredCapabilities` node is present AND `sauce:options` node is absent. | JWP           |
+Sauce Labs always prioritizes W3C as the standard appium protocol. Most modern appium clients support sending both W3C and JWP in the session creation request. In this case, the W3C will be considered and the JWP ignored. The only scenario where JWP is used is when it is the only protocol available in the session creation request.
 
 ### Examples of JWP and W3C Configurations
 


### PR DESCRIPTION
### Description
We changed the way we select wether to use the W3C vs JWP protocol portion of the appium creation request, now always priotizing W3C.

### Motivation and Context
JWP is EoL and W3C should always be used when available. This will also pave the way to set a modern appium version as the default (now it is 1.22.1).

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
