### PR TITLE
DRAFT: Add Documentation for Sites(Account) in MAD REST API page.

### DIFF
--- a/docs/testfairy/api-reference/rest-api.md
+++ b/docs/testfairy/api-reference/rest-api.md
@@ -1211,3 +1211,131 @@ Deletes a single webhook.
 ```
 
 </details>
+
+## Sites
+
+### List All Sites
+
+<details>
+<summary><span className="api get">GET</span><code>/api/1/site/</code></summary>
+<p></p>
+
+List all sites in this account.
+
+#### Responses
+
+<table id="table-api">
+	<tbody>
+		<tr>
+			<td><code>200</code></td>
+			<td colSpan='2'>Success.</td>
+		</tr>
+	</tbody>
+</table>
+
+```json title="Sample Response"
+{
+  "status": "ok",
+  "site": {
+    "accounts": [
+      {
+        "id": "1",
+        "name": "Site 1",
+        "buildsCount": 0,
+        "users": [
+          {
+            "email": "[site-subaccount-682ae46476f9f]",
+            "role": "Account Owner"
+          },
+          {
+            "email": "sitemanager@saucelabs.com",
+            "role": "Account Manager"
+          }
+        ]
+      }
+    ],
+    "managers": [
+      {
+        "email": "accountmanager@saucelabs.com"
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+---
+
+### Create a New Site
+
+<details>
+<summary><span className="api post">POST</span><code>/api/1/site/</code></summary>
+<p></p>
+
+Add a new site to the organization.
+
+#### Parameters
+
+<table id="table-api">
+	<tbody>
+		<tr>
+			<td><code>name</code></td>
+			<td><p><small>| REQUIRED | STRING |</small></p><p>The name of the account. The string accepts numbers, letters, <code>-</code>, and <code>_</code>. The length has to be more than 3 characters.</p></td>
+		</tr>
+	</tbody>
+	<tbody>
+		<tr>
+			<td><code>loginMethod</code></td>
+			<td><p><small>| OPTIONAL | STRING |</small></p><p>Specify how users can log in to account. Pass <code>0</code> for SSO or <code>1</code> for credentials</p></td>
+		</tr>
+	</tbody>
+</table>
+
+#### Responses
+
+<table id="table-api">
+	<tbody>
+		<tr>
+			<td><code>200</code></td>
+			<td colSpan='2'>Success.</td>
+		</tr>
+	</tbody>
+</table>
+
+```json title="Sample Response"
+{
+    "status": "ok"
+}
+```
+
+</details>
+
+---
+
+### Delete a Site
+
+<details>
+<summary><span className="api delete">DELETE</span><code>/api/1/site/&#123;site-id&#125;/</code></summary>
+<p></p>
+
+Deletes an account .
+
+#### Responses
+
+<table id="table-api">
+	<tbody>
+		<tr>
+			<td><code>200</code></td>
+			<td colSpan='2'>Success.</td>
+		</tr>
+	</tbody>
+</table>
+
+```json title="Sample Response"
+{
+    "status": "ok"
+}
+```
+
+</details>


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
I have added the documentation for 3 endpoints:
List all Sites, Create New Site, and Delete new Site. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The documentation does not have the endpoint for Sites(Account) at all. The enduser do not have a way to know how to work with them. Adding the documentation allows the enduser to see what is possible to do through the API with Site(Accounts). 
### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
