### PR TITLE
Update the documentation that only admins can delete files and groups.

### DIFF
--- a/docs/dev/api/storage.md
+++ b/docs/dev/api/storage.md
@@ -1004,7 +1004,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 <summary><span className="api delete">DELETE</span> <code>/v1/storage/files/&#123;file_id&#125;</code></summary>
 <p/>
 
-Deletes the specified file from Sauce Storage. Only team or organization admins can delete files. 
+Deletes the specified file from Sauce Storage. Only team or organization administrators have permission to delete files. 
 
 #### Parameters
 
@@ -1103,7 +1103,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 <summary><span className="api delete">DELETE</span> <code>/v1/storage/groups/&#123;group_id&#125;</code></summary>
 <p/>
 
-Deletes the specified group of files from Sauce Storage. Only team or organization admins can delete group of files.
+Deletes the specified group of files from Sauce Storage. Only team or organization administrators have permission to delete a group of files.
 
 #### Parameters
 

--- a/docs/dev/api/storage.md
+++ b/docs/dev/api/storage.md
@@ -1103,7 +1103,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 <summary><span className="api delete">DELETE</span> <code>/v1/storage/groups/&#123;group_id&#125;</code></summary>
 <p/>
 
-Deletes the specified group of files from Sauce Storage. . Only team or organization admins can delete group of files.
+Deletes the specified group of files from Sauce Storage. Only team or organization admins can delete group of files.
 
 #### Parameters
 

--- a/docs/dev/api/storage.md
+++ b/docs/dev/api/storage.md
@@ -1004,7 +1004,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 <summary><span className="api delete">DELETE</span> <code>/v1/storage/files/&#123;file_id&#125;</code></summary>
 <p/>
 
-Deletes the specified file from Sauce Storage.
+Deletes the specified file from Sauce Storage. Only team or organization admins can delete files. 
 
 #### Parameters
 
@@ -1103,7 +1103,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 <summary><span className="api delete">DELETE</span> <code>/v1/storage/groups/&#123;group_id&#125;</code></summary>
 <p/>
 
-Deletes the specified group of files from Sauce Storage.
+Deletes the specified group of files from Sauce Storage. . Only team or organization admins can delete group of files.
 
 #### Parameters
 


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Update the delete endpoints of files and groups to show that only admins can perform this action. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users are confused as to why sometimes they cannot delete files or groups. They are not aware that members cannot perform this action. 

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
