### PR TITLE
docs/sc5: document recommended open files limt

### DIFF
--- a/docs/secure-connections/sauce-connect-5/system-requirements.md
+++ b/docs/secure-connections/sauce-connect-5/system-requirements.md
@@ -58,3 +58,7 @@ Thus, a Sauce Connect running with 4 CPU cores achieves the maximum capacity:
   limits: GOMAXPROCS=4 GOMEMLIMIT=300MiB
   ```
   This line prints the effective configured values for GOMAXPROCS and GOMEMLIMIT.
+
+## Open Files Limit
+
+To fully unlock the potential of Sauce Connect, we recommend setting the open file limit to at least 16,000. 


### PR DESCRIPTION

<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Since SC5 tunnel with defualt streams setting is able to handle 4096 requests, thus 4096 open connections at one time, 16000 sounds like a reasonable limit.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
