### PR TITLE
Added Note to the logFilters Capability about Supported Appium Versions

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -1710,6 +1710,10 @@ Set custom filters for Appium server logs. This will allow you to mask sensitive
 
 For more information, please refer to the official Appium documentation on [Filtering the Appium Log](https://appium.io/docs/en/2.18/guides/log-filters/).
 
+:::note
+The `logFilters` capability is supported in Appium version 2.5.2 and later. To use this feature, ensure your test script specifies a compatible Appium version using the Sauce-specific [`appiumVersion`](/dev/test-configuration-options/#appiumversion) capability. You can view the list of [available Appium versions](/docs/mobile-apps/automated-testing/appium/appium-versions.md) here.
+:::
+
 ```java
 MutableCapabilities capabilities = new MutableCapabilities();
 //...


### PR DESCRIPTION
Added a note to the logFilters capability description

- /dev/test-configuration-options/#logfilters

Informing the user that the capability is only supported on a specific Appium version and they would need to specify it in the desired capabilities.

<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
:::note
The `logFilters` capability is supported in Appium version 2.5.2 and later. To use this feature, ensure your test script specifies a compatible Appium version using the Sauce-specific [`appiumVersion`](/dev/test-configuration-options/#appiumversion) capability. You can view the list of [available Appium versions](/docs/mobile-apps/automated-testing/appium/appium-versions.md) here.
:::
    - Added hyperlink to appiumVersion capability
    - Added hyperlink to list of available Appium versions

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To ensure that customers leveraging this feature use the correct appium version

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
