### PR TITLE
Adding additional context and some formatting changes for source-map.md

### DIFF
--- a/docs/error-reporting/platform-integrations/source-map.md
+++ b/docs/error-reporting/platform-integrations/source-map.md
@@ -18,7 +18,7 @@ The Backtrace debugger can highlight specific lines in your source code associat
 
 ## Creating and Uploading Source Maps
 
-Follow these steps to create and upload source maps with every build of your application:
+Source maps are matched 1:1 to each unique build of your app. Follow these steps to create and upload source maps with every build of your application:
 1. [Enable source maps](#step-1-enable-source-maps-for-your-application)
 1. [Install the `backtrace-js` command line tool](#step-2-install-backtrace-js)
 1. [Create a configuration file for `backtrace-js`](#step-3-create-a-backtracejsrc-configuration-file)
@@ -190,7 +190,7 @@ values={[
 
 If you're using Webpack as your project bundler, you can use `@backtrace/webpack-plugin` to automate working with sourcemaps.
 
-**Step 1: Enable Source Maps for Your Application**
+### Step 1: Enable Source Maps for Your Application
 
 Set `devtool` to `source-map` in your `webpack.config.js`:
 
@@ -203,7 +203,7 @@ module.exports = {
 
 If you're using code transpiler plugins (such as Typescript), be sure to enable source maps there as well.
 
-**Step 2: Set up `@backtrace/webpack-plugin`**
+### Step 2: Set up `@backtrace/webpack-plugin`
 
 1. Install `@backtrace/webpack-plugin` as a developer dependency:
 
@@ -233,7 +233,7 @@ If you're using code transpiler plugins (such as Typescript), be sure to enable 
 
 If you're using Rollup as your project bundler, you can use `@backtrace/rollup-plugin` to automate working with sourcemaps.
 
-**Step 1: Enable Source Maps for Your Application**
+### Step 1: Enable Source Maps for Your Application
 
 Set `sourcemap` in `output` to `true` in your `rollup.config.js`:
 
@@ -247,7 +247,7 @@ module.exports = {
 
 If you're using code transpiler plugins (such as Typescript), be sure to enable source maps there as well.
 
-**Step 2: Set up `@backtrace/rollup-plugin`**
+### Step 2: Set up `@backtrace/rollup-plugin`
 
 1. Install `@backtrace/rollup-plugin` as a developer dependency:
 
@@ -277,7 +277,7 @@ If you're using code transpiler plugins (such as Typescript), be sure to enable 
 
 If you're using Vite as your project bundler, you can use `@backtrace/vite-plugin` to automate working with sourcemaps.
 
-**Step 1: Enable Source Maps for Your Application**
+### Step 1: Enable Source Maps for Your Application
 
 Set `sourcemap` in `output` to `true` in your `vite.config.js`:
 
@@ -291,7 +291,7 @@ module.exports = {
 
 If you're using code transpiler plugins (such as Typescript), be sure to enable source maps there as well.
 
-**Step 2: Set up `@backtrace/vite-plugin`**
+### Step 2: Set up `@backtrace/vite-plugin`
 
 1. Install `@backtrace/vite-plugin` as a developer dependency:
 


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
### Content Change

Internal discussion to add some more context to the following section: https://docs.saucelabs.com/error-reporting/platform-integrations/source-map/#creating-and-uploading-source-maps

- Replaced:
`Follow these steps to create and upload source maps with every build of your application:`

- With:
`Source maps are matched 1:1 to each unique build of your app. Follow these steps to create and upload source maps with every build of your application:`

### Formatting Change
Formatting issue under the following section: https://docs.saucelabs.com/error-reporting/platform-integrations/source-map/#project-bundlers
The initial step text was all in one line. Example:
`If you're using Webpack as your project bundler, you can use @backtrace/webpack-plugin to automate working with sourcemaps.Step 1: Enable Source Maps for Your ApplicationSet devtool to source-map in your webpack.config.js:`

Updated the formatting so that it displays correctly on the public doc site.
- From:
`**Step 2: Set up @backtrace/webpack-plugin**`

- To:
`### Step 2: Set up @backtrace/webpack-plugin`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To provide more clarity on creating source maps as well as making sure our documentation is formatted correctly.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
