### PR TITLE
Remove Support Email from crashpad.md

### DIFF
--- a/docs/error-reporting/platform-integrations/crashpad.md
+++ b/docs/error-reporting/platform-integrations/crashpad.md
@@ -25,7 +25,7 @@ For new users, Backtrace has prepared an enhanced fork of Crashpad, allowing eas
 
 If you are a Windows and Visual Studio user, review the [Crashpad Integration Guide for Visual Studio](/error-reporting/platform-integrations/visual-studio/) to simplify the integration of Crashpad into your new or existing application.
 
-Advanced instructions are available at [the Crashpad home page](https://chromium.googlesource.com/crashpad/crashpad/+/HEAD/doc/developing.md) if you can't find what you're looking for or prefer to build Crashpad from the source. Backtrace's fork of Crashpad is available [on Github](https://github.com/backtrace-labs/crashpad/tree/backtrace), which contains easy [CMake](https://cmake.org/) build instructions and also hosts [binary builds for Android, Linux, Windows, Mac and more](https://github.com/backtrace-labs/crashpad/releases). If you would like additional assistance, don't hesitate to contact support@saucelabs.com.
+Advanced instructions are available at [the Crashpad home page](https://chromium.googlesource.com/crashpad/crashpad/+/HEAD/doc/developing.md) if you can't find what you're looking for or prefer to build Crashpad from the source. Backtrace's fork of Crashpad is available [on Github](https://github.com/backtrace-labs/crashpad/tree/backtrace), which contains easy [CMake](https://cmake.org/) build instructions and also hosts [binary builds for Android, Linux, Windows, Mac and more](https://github.com/backtrace-labs/crashpad/releases). If you would like additional assistance, don't hesitate to [contact Support](https://support.saucelabs.com/).
 
 ### Update Your Application
 
@@ -119,4 +119,4 @@ Windows Registry Editor Version 5.00
 
 Additional documentation is available at the [Crashpad Website](https://chromium.googlesource.com/crashpad/crashpad/). For more information on the `crashpad_handler`, see [crashpad_handler.md](https://chromium.googlesource.com/crashpad/crashpad/+/HEAD/handler/crashpad_handler.md).
 
-If you're still encountering issues, contact us at support@saucelabs.com.
+If you're still encountering issues, contact us via our [Support page](https://support.saucelabs.com/).


### PR DESCRIPTION
Removed mention of contacting support via email and added link to Support site.

<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Removed two sections that directed users to contact support by emailing support@saucelabs.com.

- First: https://docs.saucelabs.com/error-reporting/platform-integrations/crashpad/#initial-integration
- Second: https://docs.saucelabs.com/error-reporting/platform-integrations/crashpad/#additional-documentation

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want users to contact support using the recommended methods. Eventually, email-to-case will be deprecated, so this change would need to be made.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
