### PR TITLE
Update max session count until a reboot to 10

### DIFF
--- a/docs/mobile-apps/real-device-cleaning.md
+++ b/docs/mobile-apps/real-device-cleaning.md
@@ -23,7 +23,7 @@ A clean device:
 
 ## Public Devices
 
-Every 5th cleaning session includes a device reboot. This ensures that the system remains
+Every 10th cleaning session includes a device reboot. This ensures that the system remains
 performant and any stray processes are stopped.
 
 :::caution


### PR DESCRIPTION
### Motivation and Context
Now we only reboot devices after 10 sessions to ensure that the devices remain longer on the grid.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
