### PR TITLE
Update JSON schema URL for IntelliJ usage

### DIFF
--- a/docs/dev/cli/saucectl/usage/ide/intellij.md
+++ b/docs/dev/cli/saucectl/usage/ide/intellij.md
@@ -16,7 +16,7 @@ IntelliJ can help you edit the `saucectl` configuration files by providing helpf
 
 ## JSON Schema Validation
 
-Our JSON schema is published to the [JSON Schema Store](https://www.schemastore.org/json/), which is made available to IntelliJ. To proceed, open your `saucectl` config yaml in IntelliJ and select the `SauceCTL Configuration` schema [per the IDEA instructions](https://www.jetbrains.com/help/idea/json.html#ws_json_using_schemas).
+Our JSON schema is published to the [JSON Schema Store](https://raw.githubusercontent.com/saucelabs/saucectl/main/api/saucectl.schema.json), which is made available to IntelliJ. To proceed, open your `saucectl` config yaml in IntelliJ and select the `SauceCTL Configuration` schema [per the IDEA instructions](https://www.jetbrains.com/help/idea/json.html#ws_json_using_schemas).
 
 <img src={useBaseUrl('img/stt/intellij-saucectl-schema-dropdown.png')} alt="IntelliJ Schema Dropdown" />
 


### PR DESCRIPTION

Description
This PR updates an incorrect or outdated link on the Sauce Labs documentation page for IntelliJ IDE usage. Specifically, it corrects the reference to https://docs.saucelabs.com/dev/cli/saucectl/usage/ide/intellij/.

Motivation and Context
The previous link was pointing to an incorrect location or required an update to ensure users can navigate the documentation successfully. This change ensures that the "IntelliJ IDE" section of the saucectl usage guide remains accurate and functional.

Types of Changes
[ ] Bug fix (non-breaking change which fixes an issue)

[ ] New feature (non-breaking change which adds functionality)

[ ] Breaking change (fix or feature that would cause existing functionality to change)

[x] Documentation fix (typos, incorrect content, missing content, etc.)