### PR TITLE
Fix invalid oneOf at response level for 5 file-management endpoints

### DIFF
--- a/static/oas/real-device-access-api-spec.yaml
+++ b/static/oas/real-device-access-api-spec.yaml
@@ -879,9 +879,7 @@ paths:
                   type: string
                   example: "/sdcard/Download/file.txt"
         "400":
-          oneOf:
-            - $ref: "#/components/responses/BadRequest"
-            - $ref: "#/components/responses/BundleIdMissing"
+          $ref: "#/components/responses/FileOperationBadRequest"
         "404":
           $ref: "#/components/responses/DeviceSessionNotFound"
         "422":
@@ -913,9 +911,7 @@ paths:
         "204":
           description: File removed successfully
         "400":
-          oneOf:
-            - $ref: "#/components/responses/BadRequest"
-            - $ref: "#/components/responses/BundleIdMissing"
+          $ref: "#/components/responses/FileOperationBadRequest"
         "404":
           $ref: "#/components/responses/DeviceSessionNotFound"
         "422":
@@ -951,9 +947,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FileInfo"
         "400":
-          oneOf:
-            - $ref: "#/components/responses/BadRequest"
-            - $ref: "#/components/responses/BundleIdMissing"
+          $ref: "#/components/responses/FileOperationBadRequest"
         "404":
           $ref: "#/components/responses/DeviceSessionNotFound"
         "422":
@@ -1000,9 +994,7 @@ paths:
         "204":
           description: File uploaded successfully
         "400":
-          oneOf:
-            - $ref: "#/components/responses/BadRequest"
-            - $ref: "#/components/responses/BundleIdMissing"
+          $ref: "#/components/responses/FileOperationBadRequest"
         "404":
           $ref: "#/components/responses/DeviceSessionNotFound"
         "422":
@@ -1045,9 +1037,7 @@ paths:
                 type: string
                 example: 'attachment; filename="report.txt"'
         "400":
-          oneOf:
-            - $ref: "#/components/responses/BadRequest"
-            - $ref: "#/components/responses/BundleIdMissing"
+          $ref: "#/components/responses/FileOperationBadRequest"
         "404":
           $ref: "#/components/responses/DeviceSessionNotFound"
         "422":
@@ -1525,6 +1515,42 @@ components:
               status:
                 type: integer
                 example: 500
+    FileOperationBadRequest:
+      description: |
+        Bad request for a file operation. Two common causes:
+
+        1. **Malformed request** — the payload was invalid or referenced a non-existent device, path, or app.
+        2. **Missing `bundleId` on iOS** — file operations on iOS devices require the `bundleId` of the target app because each iOS app runs inside its own sandboxed file system. Unlike Android, where shared storage paths like `/sdcard/` are accessible, iOS requires the bundle identifier (e.g., `com.example.app`) of the app whose files you want to access.
+
+        See [Apple's File System documentation](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html) for background on iOS app sandboxing.
+      content:
+        application/problem+json:
+          schema:
+            oneOf:
+              - type: object
+                title: Bad Request
+                properties:
+                  type:
+                    type: string
+                    example: "about:blank"
+                  title:
+                    type: string
+                    example: "Device does not exist."
+                  detail:
+                    type: string
+                    example: 'The deviceId "Samsung XR" does not exist. Please ensure you provide an existing device Id.'
+              - type: object
+                title: Bundle ID Missing
+                properties:
+                  type:
+                    type: string
+                    example: "about:blank"
+                  title:
+                    type: string
+                    example: "Bundle ID required"
+                  detail:
+                    type: string
+                    example: "The `bundleId` parameter is required for file operations on iOS devices. Each iOS app has its own sandboxed file system — provide the bundle identifier of the app whose files you want to access."
   schemas:
     DeviceDescriptor:
       type: object


### PR DESCRIPTION
## Summary

Five file-management operations under `/sessions/{sessionId}/device/` (`listFiles`, `pullFile`, `pushFile`, `removeFile`, `statFile`) currently declare their `400` response as a `oneOf` of two `$ref`s:

```yaml
"400":
  oneOf:
    - $ref: "#/components/responses/BadRequest"
    - $ref: "#/components/responses/BundleIdMissing"
```

This is **invalid OpenAPI 3.x** — the [Response Object slot](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#responses-object) must contain either an inline Response (with a `description`) or a single `$ref`. `oneOf` is only legal inside a Schema Object, not at the response level. Strict parsers reject the whole spec on encounter.

This was introduced in #3445 (2026-03-10) when iOS file-management endpoints were added. Since then, any consumer using a strict OpenAPI validator (e.g. `openapi-pydantic`, used by FastMCP, `prance`, several Go/Rust generators) crashes loading the spec.

## Fix

Introduce a single shared response component `FileOperationBadRequest` whose schema uses `oneOf` *inside* `content.application/problem+json.schema` (where it's valid), and replace the 5 broken blocks with a `$ref` to it. Same dual-variant intent (generic bad request OR missing `bundleId` on iOS), valid OpenAPI 3.0.

```yaml
# new component (excerpt)
FileOperationBadRequest:
  description: |
    Bad request for a file operation. Two common causes:
    1. Malformed request — invalid payload, non-existent device/path/app
    2. Missing `bundleId` on iOS — file ops require the target app's bundle ID
  content:
    application/problem+json:
      schema:
        oneOf:
          - type: object  # generic bad-request shape
            properties: { ... }
          - type: object  # bundle-id-missing shape
            properties: { ... }

# 5 endpoint blocks now collapse to:
"400":
  $ref: "#/components/responses/FileOperationBadRequest"
```

Net diff: +41 / -15 lines, single file.

## Validation

Parsed the modified spec end-to-end through `openapi-pydantic` (via FastMCP's `parse_openapi_to_http_routes`):

- **Before:** `ValueError: Invalid OpenAPI schema` — 10 pydantic validation errors, no tools generated, server cannot start.
- **After:** spec loads cleanly, all 26 paths parse, 35 tool definitions generated including the previously-broken file ops.

## Test plan

- [x] YAML parses (`yq` / `python -c "import yaml; yaml.safe_load(...)"`)
- [x] Spec validates with `openapi-pydantic` (Pydantic-based OAS 3.0 validator)
- [x] Spec validates with FastMCP's `FastMCPOpenAPI` (constructs server without raising)
- [ ] Render check on docs.saucelabs.com preview build (Redoc) — please run as part of CI
- [ ] No semantic regression in the 5 endpoints' documented `400` responses (intent preserved, just expressed differently)