### PR TITLE
Add OpenAPI spec linter to CI

### DIFF
--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,0 +1,20 @@
+name: OpenAPI Spec Linter
+
+on:
+  pull_request:
+    paths:
+      - "static/oas/**"
+      - ".spectral.yaml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint OpenAPI specs
+        uses: stoplightio/spectral-action@latest
+        with:
+          file_glob: "static/oas/*.yaml"
+          spectral_ruleset: ".spectral.yaml"

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,29 @@
+extends:
+  - spectral:oas
+
+rules:
+  # --- Standard OpenAPI rules (severity overrides) ---
+
+  # Every operation must have an operationId (standard best practice)
+  operation-operationId: error
+
+  # Every operation must have a description (not just summary)
+  operation-description: warn
+
+  # Operation IDs must be unique
+  operation-operationId-unique: error
+
+  # Every operation must define at least one response
+  oas3-valid-schema-example: warn
+
+  # Path parameters must be defined
+  path-params: error
+
+  # No duplicate parameters
+  no-eval-in-markdown: warn
+  no-script-tags-in-markdown: warn
+
+  # Schema best practices
+  oas3-schema: error
+  oas3-unused-component: warn
+  typed-enum: warn


### PR DESCRIPTION
## Summary
- Adds [Spectral](https://github.com/stoplightio/spectral) OpenAPI linter that runs automatically on PRs touching `static/oas/` files
- Uses the standard `spectral:oas` ruleset — no custom rules, all industry-standard checks
- Adds `.spectral.yaml` config with `operationId` and `description` checks elevated to error/warn

## Why
The RDC Access API OpenAPI spec currently has no CI validation. Spec bugs like invalid `oneOf` usage or missing `operationId` can break downstream consumers (including MCP servers) without being caught at review time. A linter prevents this.

## What it catches
Running against the current spec finds **44 errors and 18 warnings**, including:
- Missing `operationId` on all 35 endpoints
- `type` + `$ref` coexistence (7 instances) — `no-$ref-siblings` rule
- Schema-example type mismatches (e.g., `type: object` with example `"stable"`)
- Missing operation descriptions (13 endpoints)

## Test locally
```bash
npx @stoplight/spectral-cli lint static/oas/real-device-access-api-spec.yaml
```