### PR TITLE
Fix disableNetworkCapture endpoint indentation in OpenAPI spec

### DIFF
--- a/static/oas/real-device-access-api-spec.yaml
+++ b/static/oas/real-device-access-api-spec.yaml
@@ -637,26 +637,26 @@ paths:
         "404":
           $ref: "#/components/responses/DeviceSessionNotFound"
 
-    /sessions/{sessionId}/device/disableNetworkCapture:
-      post:
-        summary: Stop network traffic capture
-        description: Stops the ongoing system-wide network traffic capture for the device session. Returns HTTP 204.
-        tags:
-          - "Device Interactions"
-        parameters:
-          - name: sessionId
-            in: path
-            required: true
-            description: The id of the device session
-            schema:
-              type: string
-        responses:
-          "204":
-            description: Network capture stopped successfully
-          "400":
-            $ref: "#/components/responses/BadRequest"
-          "404":
-            $ref: "#/components/responses/DeviceSessionNotFound"
+  /sessions/{sessionId}/device/disableNetworkCapture:
+    post:
+      summary: Stop network traffic capture
+      description: Stops the ongoing system-wide network traffic capture for the device session. Returns HTTP 204.
+      tags:
+        - "Device Interactions"
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          description: The id of the device session
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Network capture stopped successfully
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/DeviceSessionNotFound"
 
   /sessions/{sessionId}/network/profiles:
     get:


### PR DESCRIPTION
## Summary
Fixes incorrect YAML indentation that caused the `disableNetworkCapture` endpoint to be nested inside `enableNetworkCapture` instead of being a sibling path.

## Problem
The `disableNetworkCapture` path was indented 4 extra spaces, making YAML parsers treat it as a child of `enableNetworkCapture`. The spec silently exposed 26 paths instead of 27 — consumers (MCP servers, code generators) could start network capture but had no endpoint to stop it.

## Fix
Dedented the entire `disableNetworkCapture` block by 2 spaces to align with other top-level paths.