### PR TITLE
Remove type: object siblings next to $ref in OpenAPI spec

### DIFF
--- a/static/oas/real-device-access-api-spec.yaml
+++ b/static/oas/real-device-access-api-spec.yaml
@@ -130,7 +130,6 @@ paths:
                   type: object
                   properties:
                     tunnel:
-                      type: object
                       $ref: "#/components/schemas/TunnelConfiguration"
                     sessionDuration:
                       type: string
@@ -356,7 +355,6 @@ paths:
           content:
             application/json:
               schema:
-                type: object
                 $ref: "#/components/schemas/AppInstallationStatus"
         "400":
           $ref: "#/components/responses/BadRequest"
@@ -544,7 +542,6 @@ paths:
         content:
           application/json:
             schema:
-              type: object
               $ref: "#/components/schemas/LaunchWDARequest"
       responses:
         "200":
@@ -552,7 +549,6 @@ paths:
           content:
             application/json:
               schema:
-                type: object
                 $ref: "#/components/schemas/RunningWDA"
         "400":
           $ref: "#/components/responses/BadRequest"
@@ -585,7 +581,6 @@ paths:
           content:
             application/json:
               schema:
-                type: object
                 $ref: "#/components/schemas/RunningWDA"
         "400":
           $ref: "#/components/responses/BadRequest"
@@ -796,7 +791,6 @@ paths:
           content:
             application/json:
               schema:
-                type: object
                 $ref: "#/components/schemas/AppiumSession"
         "400":
           $ref: "#/components/responses/BadRequest"
@@ -821,7 +815,6 @@ paths:
           content:
             application/json:
               schema:
-                type: object
                 $ref: "#/components/schemas/AppiumSession"
         "404":
           $ref: "#/components/responses/DeviceSessionNotFound"


### PR DESCRIPTION
## Summary
Removes 7 instances of `type: object` that appear as siblings next to `$ref` in the RDC Access API spec.

## Problem
In OpenAPI 3.0, when `$ref` is present, all sibling keywords are silently ignored. Each of these 7 locations had:

```yaml
schema:
  type: object           # <-- silently ignored
  $ref: "#/components/schemas/SomeSchema"
```

The `type: object` is redundant since each referenced schema already declares its own type. However:
- Strict validators reject the spec
- Some code generators produce incorrect untyped objects instead of the referenced schema

## Affected locations
1. `POST /sessions` → tunnel config property
2. `POST .../installApp` → 200 response
3. `POST .../launchWebDriverAgent` → request body
4. `POST .../launchWebDriverAgent` → 200 response
5. `POST .../checkWebDriverAgentStatus` → 200 response
6. `POST .../appiumserver` → 200 response
7. `GET .../appiumserver` → 200 response

## Fix
Removed the redundant `type: object` line in each case. No semantic change — the `$ref` resolves to schemas that already have `type: object`.