### PR TITLE
Fix phantom required field in launchApp endpoint

### DIFF
--- a/static/oas/real-device-access-api-spec.yaml
+++ b/static/oas/real-device-access-api-spec.yaml
@@ -500,8 +500,7 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - id
+              description: "Requires either a 'bundleId' for iOS or a 'packageName' for Android, but not both."
               properties:
                 bundleId:
                   type: string


### PR DESCRIPTION
## Summary
Removes invalid `required: ["id"]` from the `launchApp` request body schema and adds a description clarifying the actual requirement.

## Problem
The request body schema declared:
```yaml
required:
  - id
properties:
  bundleId: ...
  packageName: ...
  activityName: ...
```

There is no property called `id`. Schema validation always fails because the required field can never be provided. Code generators create models requiring a non-existent field.

## Fix
Removed `required: ["id"]` and added a description: *"Requires either a 'bundleId' for iOS or a 'packageName' for Android, but not both."*

OpenAPI 3.0 doesn't support conditional required (oneOf for required fields), so the requirement is documented in the description instead.