### PR TITLE
Fix linter:  $ref must not be placed next to any other properties

### DIFF
--- a/static/oas/real-device-access-api-spec.yaml
+++ b/static/oas/real-device-access-api-spec.yaml
@@ -1500,7 +1500,6 @@ components:
                 $ref: "#/components/schemas/SessionId"
               state:
                 $ref: "#/components/schemas/SessionState"
-                example: CLOSING
     DeviceIsNotReady:
       description: Device not ready
       content:


### PR DESCRIPTION
### Description
Fix OpenAPI v3 linting issue: $ref must not be placed next to any other properties

### Motivation and Context
Make linter test pass

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
