### PR TITLE
Remove deviceId parameter from the GET /devices

### DIFF
--- a/static/oas/real-device-access-api-spec.yaml
+++ b/static/oas/real-device-access-api-spec.yaml
@@ -44,14 +44,6 @@ paths:
       description: "List our catalog of devices available to you. Use this endpoint to retrieve 'device descriptors'. Note: for public devices there can be multiple physical devices that share one 'device descriptor'"
       tags:
         - "Device Catalog"
-      parameters:
-        - name: deviceId
-          in: query
-          description: "Filter by device identifier (supports regex). Matches the descriptor ID or device name."
-          required: false
-          schema:
-            type: string
-            example: "iPhone.*"
       responses:
         "200":
           description: Ok


### PR DESCRIPTION
### Description
Remove non existing `deviceId` query parameter from the GET /devices

### Motivation and Context
The endpoint doesn't accept this query parameter

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation fix (typos, incorrect content, missing content, etc.)
