### PR TITLE
Clarify macOS support and make armRequired param optional for saucectl runners

### DIFF
--- a/docs/web-apps/automated-testing/playwright.md
+++ b/docs/web-apps/automated-testing/playwright.md
@@ -41,7 +41,7 @@ Sauce Labs supports the following test configurations for Playwright:
         <td rowspan='2'>1.58.2</td>
         <td rowspan='2'>22</td>
         <td rowspan='2'>✅</td>
-        <td><b>macOS:</b> 14, 15</td>
+        <td><b>macOS:</b> 14*, 15*</td>
         <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
         <td rowspan='2'>March 25th, 2027</td>
       </tr>
@@ -54,7 +54,7 @@ Sauce Labs supports the following test configurations for Playwright:
         <td rowspan='2'>1.58.1</td>
         <td rowspan='2'>22</td>
         <td rowspan='2'>✅</td>
-        <td><b>macOS:</b> 14, 15</td>
+        <td><b>macOS:</b> 14*, 15*</td>
         <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
         <td rowspan='2'>February 25th, 2027</td>
       </tr>
@@ -154,6 +154,8 @@ Sauce Labs supports the following test configurations for Playwright:
     </tr>
   </tbody>
 </table>
+
+*macOS 14+ requires a Premium subscription. For additional details see [macOS Browser Tests on Apple Silicon](/web-apps/macos-apple-silicon)
 
 ## How to Get Started
 

--- a/docs/web-apps/automated-testing/playwright.md
+++ b/docs/web-apps/automated-testing/playwright.md
@@ -20,7 +20,7 @@ Cucumber.js is not directly supported by Playwright. However, Playwright can be 
 Supported OS:
 
 - Windows 10 / Windows 11
-- macOS 10.15+
+- macOS 12+
 - Linux
 
 ## Supported Testing Platforms
@@ -154,8 +154,6 @@ Sauce Labs supports the following test configurations for Playwright:
     </tr>
   </tbody>
 </table>
-
-Playwright 1.58.1 runs on ARM architecture (macOS 14 and 15) and requires a Premium subscription and `armRequired:"true"` as an additional configuration parameter in your [YAML file](/web-apps/automated-testing/playwright/yaml#armrequired).
 
 ## How to Get Started
 

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -1342,7 +1342,7 @@ suite:
 When set to `true`, this option adds capability requirement for ARM architecture on the machine running the test.
 
 :::note
-ARM is available for macOS 14 and macOS 15 with Playwright >=1.58.1. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue.
+ARM is available for macOS 14 and macOS 15 with Playwright >=1.58.1. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required for tests to execute on macOS 14+.
 :::
 
 ```yaml

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -1342,7 +1342,7 @@ suite:
 When set to `true`, this option adds capability requirement for ARM architecture on the machine running the test.
 
 :::note
-ARM is available for macOS 14 and macOS 15 with Playwright >=1.58.1. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required for tests to execute on macOS 14+.
+ARM is available for macOS 14 and macOS 15 with Playwright >=1.58.1. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required in order for tests to execute on macOS 14+ and can be omitted from your configuration.
 :::
 
 ```yaml

--- a/docs/web-apps/automated-testing/testcafe.md
+++ b/docs/web-apps/automated-testing/testcafe.md
@@ -110,7 +110,7 @@ Sauce Labs supports the following test configurations for TestCafe:
   </tbody>
 </table>
 
-*macOS 14+ requires a Premium subscription and `armRequired:"true"` as an additional configuration parameter in your [YAML file](/web-apps/automated-testing/testcafe/yaml#armrequired)
+*macOS 14+ requires a Premium subscription. For additional details see [macOS Browser Tests on Apple Silicon](/web-apps/macos-apple-silicon)
 
 ## How to Get Started
 

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -1740,7 +1740,7 @@ suite:
 When set to `true`, this option adds capability requirement for ARM architecture on the machine running the test.
 
 :::note
-ARM is available for macOS 14 and macOS 15 with TestCafe >=3.7.2. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue.
+ARM is available for macOS 14 and macOS 15 with TestCafe >=3.7.2. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required in order for tests to execute on macOS 14+ and can be omitted from your configuration.
 :::
 
 ```yaml


### PR DESCRIPTION
Updated macOS support version on Playwright page and removed outdated information about ARM versions needing `armRequired` parameter for Playwright and Testcafe pages.




### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation fix (typos, incorrect content, missing content, etc.)
