### PR TITLE
Correct AccessAPI launchApp docs

### DIFF
--- a/static/oas/real-device-access-api-spec.yaml
+++ b/static/oas/real-device-access-api-spec.yaml
@@ -549,12 +549,8 @@ paths:
                   description: Main Activity Name of app to launch (Android)
                   example: "com.android.XXX.Activity"
       responses:
-        "200":
-          description: Command executed successfully
-          content:
-            application/json:
-              schema:
-                type: object
+        "204":
+          description: App launched successfully
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":


### PR DESCRIPTION
### Description
The OpenAPI definition for RDC AccessAPI's `launchApp` erroneously documented a response code of 200 for successful execution, while in reality the API returns a 204 in this scenario.

### Motivation and Context
Documentation mistake.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
