### PR TITLE
BT-6260: Replace "organization" UI text with "universe"

### DIFF
--- a/docs/error-reporting/org-settings/saml-sso.md
+++ b/docs/error-reporting/org-settings/saml-sso.md
@@ -22,13 +22,13 @@ First, the identity provider configuration should be completed. The following se
 This functionality requires on premise deployments to install and run the **backtrace-saml** package and service.
 :::
 
-1. As an admin user, go to **Organization settings** > **Single sign-on**.
+1. As an admin user, go to **Universe settings** > **Single sign-on**.
 1. Enter the following configuration settings:
    - **Entity ID (issuer)**: ID for the service provider (Backtrace). By default, hosted Backtrace tenants will have a value of `https://saml.backtrace.io` for the Entity ID. This setting needs to be the same in your identity provider's configuration.
    - **SSO URL**: URL pointing to the identity provider.
    - **Callback URL**: URL for the identity provider to post the SAML payload to the service provider (Backtrace). The required format is: https:<span>//saml.backtrace.io/api/sso/saml/\{backtrace hostname} </span>. For example: https:<span>//saml.backtrace.io/api/sso/saml/organization.sp.backtrace.io </span>
    - **User provisioning (optional)**: User provisioning, if enabled, allows the SAML SSO service to create a Backtrace user on the return of a successful assertion from the identity provider.
-   - **Admin contact (optional)**: The email contact that will display upon SSO login failure, to direct users to appropriate SSO resources within the organization.
+   - **Admin contact (optional)**: The email contact that will display upon SSO login failure, to direct users to appropriate SSO resources within the universe.
    - **SAML request private key (optional)**: Identity provider's private key for signing SAML requests. Includes signature algorithm and private key.
    - **Certificate (optional)**: Identity provider's public signing certificate used to validate the signatures of SAML Responses. Includes public certificate and private key.
    - **Private key (optional)**: Private key that will be used to attempt to decrypt any encrypted assertions from the identity provider.
@@ -37,7 +37,7 @@ Once the configuration is saved, click **Test configuration** to verify the conf
 
 ### User Management and Authentication
 
-In **Organization settings** > **Users**, admin users can edit users' authentication method. If SSO is configured, existing users will be able to sign in via SSO and their specified authentication method, if it's different than saml. If a user's authentication method is set to SAML, then they will only be able to sign in via SSO.
+In **Universe settings** > **Users**, admin users can edit users' authentication method. If SSO is configured, existing users will be able to sign in via SSO and their specified authentication method, if it's different than saml. If a user's authentication method is set to SAML, then they will only be able to sign in via SSO.
 
 ## Troubleshooting
 

--- a/docs/error-reporting/org-settings/team-mgmnt.md
+++ b/docs/error-reporting/org-settings/team-mgmnt.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Teams are a way to group users together for the purposes of allowing access to certain projects. Organization Administrators can access Organization Settings - Teams to create and manage new teams.
+Teams are a way to group users together for the purposes of allowing access to certain projects. Universe Administrators can access Universe Settings - Teams to create and manage new teams.
 
 <img src={useBaseUrl('img/error-reporting/project-settings/teams.webp')} alt="" />
 
@@ -17,6 +17,6 @@ Teams can be added to Projects so that all members of the team have access to th
 
 A project by default has no project members, and all users in the tenant have access to it. In order for access control to be implemented, a project member mapping must exist. When a project member mapping exists: The user’s role with respect to a project is the highest project role across project member mappings. When no project member mapping exists: all users have access.
 
-Organization Admins (users with the admin role under Organization settings | Users) can also manage project membership through this interface. Organization Admins will be able to see projects even if the project has a team associated that the admin user is not part of.
+Universe Admins (users with the admin role under Universe settings | Users) can also manage project membership through this interface. Universe Admins will be able to see projects even if the project has a team associated that the admin user is not part of.
 
-Organization Admins will also retain their admin privileges if they are added to a team with member access to a project. On the other hand, a user with the member role will have admin privileges if they are added to a team with admin access to a project. The owner of a project (derived from the owner field of project) always has “admin” project member privileges for that project.
+Universe Admins will also retain their admin privileges if they are added to a team with member access to a project. On the other hand, a user with the member role will have admin privileges if they are added to a team with admin access to a project. The owner of a project (derived from the owner field of project) always has “admin” project member privileges for that project.

--- a/docs/error-reporting/org-settings/user-mgmnt.md
+++ b/docs/error-reporting/org-settings/user-mgmnt.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-To manage user accounts, go to the **Organization settings** menu and select **Users**.
+To manage user accounts, go to the **Universe settings** menu and select **Users**.
 
 On the Users page, the following sections are available:
 
@@ -17,7 +17,7 @@ On the Users page, the following sections are available:
 - **Manage invitations**: Allows you to send invitations to users and see pending invitations.
 - **Users**: Shows the list of users accounts in the system and their roles.
 
-<img src={useBaseUrl('img/error-reporting/project-settings/user-mgmt.webp')} alt="Shows the Users page in Organization settings." />
+<img src={useBaseUrl('img/error-reporting/project-settings/user-mgmt.webp')} alt="Shows the Users page in Universe settings." />
 
 ## Configure Self Sign Up
 

--- a/docs/error-reporting/project-setup/connections.md
+++ b/docs/error-reporting/project-setup/connections.md
@@ -9,11 +9,11 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Integrations such as Jira and Slack, which have an application installed or use another mechanism to connect with Backtrace to a third-party domain, will create a workflow connection. This process simplifies linking new Jira projects or Slack channels to receive Backtrace data. Backtrace elevates these connections to an organization level, allowing different Backtrace projects to use the configured Jira and Slack applications. These connections are established as part of the normal integration flow found in **Project settings** > **Integrations**.
+Integrations such as Jira and Slack, which have an application installed or use another mechanism to connect with Backtrace to a third-party domain, will create a workflow connection. This process simplifies linking new Jira projects or Slack channels to receive Backtrace data. Backtrace elevates these connections to a universe level, allowing different Backtrace projects to use the configured Jira and Slack applications. These connections are established as part of the normal integration flow found in **Project settings** > **Integrations**.
 
 ## Workflow Connections Page
 
-Admins have the ability to manage workflow connections in **Organization Settings** > **Workflow Connections**. They can easily view the various projects that are utilizing the connection at a glance.
+Admins have the ability to manage workflow connections in **Universe Settings** > **Workflow Connections**. They can easily view the various projects that are utilizing the connection at a glance.
 
 <img src={useBaseUrl('/img/error-reporting/project-settings/connection-page.png')} alt="connection page"/>
 

--- a/docs/error-reporting/project-setup/storage-management.md
+++ b/docs/error-reporting/project-setup/storage-management.md
@@ -11,7 +11,7 @@ Backtrace instances have limits on how many monthly error submissions they can a
 
 Admin users can control retention, compression, storage sampling, and submission rules. In addition, the delete-by-query capability allows users to take a manual action to remove objects from the system and free space.
 
-- To see how much storage was purchased and what percentage is consumed, admin users can go to the **Organization Settings** > **Subscriptions** page.
+- To see how much storage was purchased and what percentage is consumed, admin users can go to the **Universe Settings** > **Subscriptions** page.
 - To see how much storage is being consumed by project, go to the **Project settings** > **Overview** page > under **Storage usage** > see **attachments**.
 
 Our sales team can assist in the purchase of additional storage as needed, and our support team can disable storage enforcement in critical cases.

--- a/docs/error-reporting/troubleshooting.md
+++ b/docs/error-reporting/troubleshooting.md
@@ -187,7 +187,7 @@ On Windows, 64-bit applications store some unwinding information exclusively in 
 Direct login to Morgue using an SSO-only account is not supported. However, there is a workaround available:
 
 1. Start by logging into the Backtrace UI as you normally would.
-2. Next, navigate to the account page under Organization settings (https://youruniverse.sp.backtrace.io/settings/me)
+2. Next, navigate to the account page under Universe settings (https://youruniverse.sp.backtrace.io/settings/me)
 3. Copy the "Command line login" 
 
 Paste the provided command to login:

--- a/docs/error-reporting/whats-new.md
+++ b/docs/error-reporting/whats-new.md
@@ -13,7 +13,7 @@ This page is now deprecated and will be removed. To see what's new for Error Rep
 
 As an admin, you can now check when a user last logged in to their account.
 
-From the **Organization Settings**, click **Users**. In the list of users, under **Last login**, you'll see the date and time of the user's last login.
+From the **Universe Settings**, click **Users**. In the list of users, under **Last login**, you'll see the date and time of the user's last login.
 
 If a new user hasn't logged in to their account for the first time or hasn't logged in since August 1st 2022, the column will not be populated.
 
@@ -34,9 +34,9 @@ You can now generate a sample project to see errors and crashes for a Unity appl
 To generate a sample project, go to **Project settings > Integration guides (under Error Submission) > Unity**, then click **Generate sample project**.
 <img src="/img/error-reporting/whats-new/unity-sample-project.png" width="500"/>
 
-## Improved Navigation in Organization Settings (2022-11-01)
+## Improved Navigation in Universe Settings (2022-11-01)
 
-We've made it easier for you to navigate in the Organization settings menu. The improvements include a breadcrumb trail at the top of the screen, and a new side navigation menu.
+We've made it easier for you to navigate in the Universe settings menu. The improvements include a breadcrumb trail at the top of the screen, and a new side navigation menu.
 
 ## Improved Navigation in Project Settings (2022-10-17)
 
@@ -53,7 +53,7 @@ In addition to filtering attributes by name, you can now use the global filter b
 
 ## Sorting Users (2022-07-29)
 
-In the Organization settings, you can now sort the Users page by username, email, and role.
+In the Universe settings, you can now sort the Users page by username, email, and role.
 
 ## Releases Comparison View (2021-10-05)
 
@@ -114,7 +114,7 @@ The Debugger "Download" action now offers the ability to download a core file re
 
 ## Teams and Project Permissions (2020-06-10)
 
-A new Organization Setting object called Teams is available for Administrators to Manage. Teams consist of other Teams or users of the system. Teams be used as Project Members with defined Roles so that access can be restricted to both individual users or groups of users.
+A new Universe Setting object called Teams is available for Administrators to Manage. Teams consist of other Teams or users of the system. Teams be used as Project Members with defined Roles so that access can be restricted to both individual users or groups of users.
 
 ## Reopen Criteria (2020-04-28)
 
@@ -181,7 +181,7 @@ The new Web Console is now the default for all users. For more information, see 
 
 ## SAML Configuration (2019-03-15)
 
-Customers on the Enterprise plan can now configure their SAML configuration under Organization Settings.
+Customers on the Enterprise plan can now configure their SAML configuration under Universe Settings.
 
 ## Comments (2019-03-07)
 
@@ -189,7 +189,7 @@ When viewing the Details of a Fingerprint in the Triage view, a user can view li
 
 ## Per User Default Setting for New Web Console (2019-03-01)
 
-Users can choose to have the new Web Console be their default using the Set As Default button after they login. This setting is also available under Organization Settings > My Account > Early Access toggles.
+Users can choose to have the new Web Console be their default using the Set As Default button after they login. This setting is also available under Universe Settings > My Account > Early Access toggles.
 
 ## Manual Issue (Jira) Creation (2019-01)
 


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
Organization is used in Backtrace to mean universe in several places in the UX.  Hence replacing it in code as well as docs

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
