### PR TITLE
Documented generation POST&GET endpoints

### DIFF
--- a/docs/dev/api/authoring.md
+++ b/docs/dev/api/authoring.md
@@ -588,9 +588,7 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 <details>
 <summary><span className="api post">POST</span> <code>/v1/ai-authoring/testcases/generate</code></summary>
 
-Starts an asynchronous test case generation task from a natural-language prompt. Returns a `taskId` that you poll via [Get Generation Status](#get-generation-status). The `Location` response header points at the polling URL.
-
-For an overview of the feature and a UI walkthrough, see the [AI Test Authoring guide](/sauce-ai/ai-authoring). For tips on writing effective `intent` prompts, see the [prompting guide](/sauce-ai/ai-authoring-prompting-guide).
+Starts an asynchronous test case generation task from a natural-language prompt. Returns a `taskId` to poll via [Get Generation Status](#get-generation-status); the `Location` response header points at the polling URL.
 
 #### Parameters
 
@@ -614,7 +612,7 @@ For an overview of the feature and a UI walkthrough, see the [AI Test Authoring 
        <p><small>| BODY | REQUIRED | OBJECT |</small></p>
        <p>Run configuration applied to the generated test case. The available attributes are:</p>
        <ul>
-         <li><code>target.capabilities</code> - <small>REQUIRED | OBJECT</small> - W3C WebDriver capabilities (e.g. <code>browserName</code>, <code>platformName</code>, <code>browserVersion</code>, <code>sauce:options</code>).</li>
+         <li><code>target.capabilities</code> - <small>REQUIRED | OBJECT</small> - W3C WebDriver capabilities (for example, <code>browserName</code>, <code>platformName</code>, <code>browserVersion</code>, <code>sauce:options</code>).</li>
          <li><code>testUrl</code> - <small>OPTIONAL | STRING</small> - Fully qualified URL the generated test will navigate to (max 2048 chars).</li>
          <li><code>scTunnelName</code> - <small>OPTIONAL | STRING</small> - The name of the Sauce Connect tunnel to use for the run (max 1000 chars).</li>
        </ul>
@@ -705,8 +703,6 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 #### Responses
 
-A successful response sets the `Location` header to <code>/v1/ai-authoring/testcases/generate/&#123;taskId&#125;</code> so you can poll for status.
-
 <table id="table-api">
 <tbody>
   <tr>
@@ -745,7 +741,7 @@ A successful response sets the `Location` header to <code>/v1/ai-authoring/testc
 <details>
 <summary><span className="api get">GET</span> <code>/v1/ai-authoring/testcases/generate/&#123;taskId&#125;</code></summary>
 
-Returns the current status of a generation task previously started by [Generate a Test Case](#generate-a-test-case). Clients should poll this endpoint until `status` is `COMPLETED` or `FAILED`. While the task is running, `status` is one of `QUEUED` or `IN_PROGRESS`. On `COMPLETED`, the response includes the generated `testCaseId`. On `FAILED`, the response includes an `error` object describing the failure.
+Returns the current status of a generation task started by [Generate a Test Case](#generate-a-test-case). Poll until `status` is `COMPLETED` (response includes `testCaseId`) or `FAILED` (response includes `error`); otherwise `status` is `QUEUED` or `IN_PROGRESS`.
 
 #### Parameters
 

--- a/docs/dev/api/authoring.md
+++ b/docs/dev/api/authoring.md
@@ -583,6 +583,250 @@ curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
 
 ---
 
+### Generate a Test Case
+
+<details>
+<summary><span className="api post">POST</span> <code>/v1/ai-authoring/testcases/generate</code></summary>
+
+Starts an asynchronous test case generation task from a natural-language prompt. Returns a `taskId` that you poll via [Get Generation Status](#get-generation-status). The `Location` response header points at the polling URL.
+
+For an overview of the feature and a UI walkthrough, see the [AI Test Authoring guide](/sauce-ai/ai-authoring). For tips on writing effective `intent` prompts, see the [prompting guide](/sauce-ai/ai-authoring-prompting-guide).
+
+#### Parameters
+
+<table id="table-api">
+  <tbody>
+    <tr>
+     <td><code>name</code></td>
+     <td><p><small>| BODY | REQUIRED | STRING |</small></p><p>The name for the generated test case (1–255 characters).</p></td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
+     <td><code>testSuiteId</code></td>
+     <td><p><small>| BODY | OPTIONAL | STRING |</small></p><p>UUID of an existing test suite to attach the generated test case to.</p></td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
+     <td><code>runSettings</code></td>
+     <td>
+       <p><small>| BODY | REQUIRED | OBJECT |</small></p>
+       <p>Run configuration applied to the generated test case. The available attributes are:</p>
+       <ul>
+         <li><code>target.capabilities</code> - <small>REQUIRED | OBJECT</small> - W3C WebDriver capabilities (e.g. <code>browserName</code>, <code>platformName</code>, <code>browserVersion</code>, <code>sauce:options</code>).</li>
+         <li><code>testUrl</code> - <small>OPTIONAL | STRING</small> - Fully qualified URL the generated test will navigate to (max 2048 chars).</li>
+         <li><code>scTunnelName</code> - <small>OPTIONAL | STRING</small> - The name of the Sauce Connect tunnel to use for the run (max 1000 chars).</li>
+       </ul>
+     </td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
+     <td><code>promptSettings</code></td>
+     <td>
+       <p><small>| BODY | REQUIRED | OBJECT |</small></p>
+       <p>Prompt configuration that drives generation. The available attributes are:</p>
+       <ul>
+         <li><code>intent</code> - <small>REQUIRED | STRING</small> - Natural-language description of what the test should do (max 20,000 chars).</li>
+         <li><code>maxSteps</code> - <small>OPTIONAL | INTEGER</small> - Cap on the number of generation steps.</li>
+       </ul>
+     </td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
+     <td><code>timeout</code></td>
+     <td><p><small>| BODY | OPTIONAL | INTEGER |</small></p><p>Generation timeout in milliseconds (1–3,600,000).</p></td>
+    </tr>
+  </tbody>
+</table>
+
+<Tabs
+groupId="dc-url"
+defaultValue="us"
+values={[
+{label: 'United States', value: 'us'},
+{label: 'Europe', value: 'eu'},
+]}>
+
+<TabItem value="us">
+
+```jsx title="Sample Request"
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
+--request POST 'https://api.us-west-1.saucelabs.com/v1/ai-authoring/testcases/generate' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "name": "Saucedemo login flow",
+  "runSettings": {
+    "target": {
+      "capabilities": {
+        "browserName": "chrome",
+        "platformName": "Windows 11",
+        "browserVersion": "latest"
+      }
+    },
+    "testUrl": "https://www.saucedemo.com/"
+  },
+  "promptSettings": {
+    "intent": "Log in with standard_user / secret_sauce and assert the inventory page is visible."
+  }
+}' | json_pp
+```
+
+</TabItem>
+
+<TabItem value="eu">
+
+```jsx title="Sample Request"
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
+--request POST 'https://api.eu-central-1.saucelabs.com/v1/ai-authoring/testcases/generate' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "name": "Saucedemo login flow",
+  "runSettings": {
+    "target": {
+      "capabilities": {
+        "browserName": "chrome",
+        "platformName": "Windows 11",
+        "browserVersion": "latest"
+      }
+    },
+    "testUrl": "https://www.saucedemo.com/"
+  },
+  "promptSettings": {
+    "intent": "Log in with standard_user / secret_sauce and assert the inventory page is visible."
+  }
+}' | json_pp
+```
+
+</TabItem>
+</Tabs>
+
+#### Responses
+
+A successful response sets the `Location` header to <code>/v1/ai-authoring/testcases/generate/&#123;taskId&#125;</code> so you can poll for status.
+
+<table id="table-api">
+<tbody>
+  <tr>
+    <td><code>202</code></td>
+    <td colSpan='2'>Generation task accepted</td>
+  </tr>
+</tbody>
+<tbody>
+  <tr>
+    <td><code>400</code></td>
+    <td colSpan='2'>Invalid request body</td>
+  </tr>
+</tbody>
+<tbody>
+  <tr>
+    <td><code>401</code></td>
+    <td colSpan='2'>Missing or invalid authentication header</td>
+  </tr>
+</tbody>
+</table>
+
+```jsx title="Sample Response"
+{
+  "data": {
+    "taskId": "f9c2e1a4-7b3d-4e2a-9c11-2b8e0d5f4c33"
+  }
+}
+```
+
+</details>
+
+---
+
+### Get Generation Status
+
+<details>
+<summary><span className="api get">GET</span> <code>/v1/ai-authoring/testcases/generate/&#123;taskId&#125;</code></summary>
+
+Returns the current status of a generation task previously started by [Generate a Test Case](#generate-a-test-case). Clients should poll this endpoint until `status` is `COMPLETED` or `FAILED`. While the task is running, `status` is one of `QUEUED` or `IN_PROGRESS`. On `COMPLETED`, the response includes the generated `testCaseId`. On `FAILED`, the response includes an `error` object describing the failure.
+
+#### Parameters
+
+<table id="table-api">
+  <tbody>
+    <tr>
+     <td><code>taskId</code></td>
+     <td><p><small>| PATH | REQUIRED | STRING |</small></p><p>UUID returned by <code>POST /v1/ai-authoring/testcases/generate</code>.</p></td>
+    </tr>
+  </tbody>
+</table>
+
+<Tabs
+groupId="dc-url"
+defaultValue="us"
+values={[
+{label: 'United States', value: 'us'},
+{label: 'Europe', value: 'eu'},
+]}>
+
+<TabItem value="us">
+
+```jsx title="Sample Request"
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
+--request GET "https://api.us-west-1.saucelabs.com/v1/ai-authoring/testcases/generate/<taskId>" | json_pp
+```
+
+</TabItem>
+
+<TabItem value="eu">
+
+```jsx title="Sample Request"
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
+--request GET "https://api.eu-central-1.saucelabs.com/v1/ai-authoring/testcases/generate/<taskId>" | json_pp
+```
+
+</TabItem>
+</Tabs>
+
+#### Responses
+
+<table id="table-api">
+<tbody>
+  <tr>
+    <td><code>200</code></td>
+    <td colSpan='2'>Current generation task status</td>
+  </tr>
+</tbody>
+<tbody>
+  <tr>
+    <td><code>400</code></td>
+    <td colSpan='2'>Invalid path parameters</td>
+  </tr>
+</tbody>
+<tbody>
+  <tr>
+    <td><code>401</code></td>
+    <td colSpan='2'>Missing or invalid authentication header</td>
+  </tr>
+</tbody>
+<tbody>
+  <tr>
+    <td><code>404</code></td>
+    <td colSpan='2'>Generation task not found</td>
+  </tr>
+</tbody>
+</table>
+
+```jsx title="Sample Response"
+{
+  "data": {
+    "status": "COMPLETED",
+    "testCaseId": "69c164bcd27d5bfc3e3ef8a7"
+  }
+}
+```
+
+</details>
+
+---
+
 ## Test Suites
 
 ### List Test Suites


### PR DESCRIPTION
### Description
  Documents the asynchronous test case generation endpoints on the **AI Test Authoring API** reference page (`docs/dev/api/authoring.md`). Two new collapsible sections are added inside the existing **Test Cases** block, after
  _Rename a Test Case_:

  - **Generate a Test Case** — `POST /v1/ai-authoring/testcases/generate`
    - Full request schema (`name`, `testSuiteId`, `runSettings.target.capabilities`, `runSettings.testUrl`, `runSettings.scTunnelName`, `promptSettings.intent`, `promptSettings.maxSteps`, `timeout`)
    - US/EU curl tabs with a runnable Saucedemo example
    - Response codes (`202` / `400` / `401`), sample JSON, and a note that the `Location` header points at the polling URL
  - **Get Generation Status** — `GET /v1/ai-authoring/testcases/generate/{taskId}`
    - `taskId` path param
    - US/EU curl tabs
    - Response codes (`200` / `400` / `401` / `404`) plus an explanation of the four `status` values (`QUEUED`, `IN_PROGRESS`, `COMPLETED`, `FAILED`) and what each response body shape looks like

  Cross-links are added to the existing `/sauce-ai/ai-authoring` user guide and `/sauce-ai/ai-authoring-prompting-guide` so readers can find the UI walkthrough and prompting tips. No sidebar changes were needed — the page is
  already listed under **API Reference**.

  ### Motivation and Context
  The `POST /testcases/generate` and `GET /testcases/generate/{taskId}` endpoints have been shipped in the `ai-authoring` service for some time and are present in the internal OpenAPI registry, but they were never surfaced on
  `docs.saucelabs.com`. Every other test-case operation (List, Get, Delete, Run, Rename) is documented.

  ### Types of Changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation fix (typos, incorrect content, missing content, etc.)