### PR TITLE
Access-API: deviceName regex does not matches descriptor Id

### DIFF
--- a/docs/mobile-apps/real-device-access-api/integration-guide.md
+++ b/docs/mobile-apps/real-device-access-api/integration-guide.md
@@ -42,7 +42,7 @@ Understanding how devices are labeled helps you target exactly what you need:
 - `descriptor`: Device identifier, you can look up device IDs on device selection pages (for example, `iPhone_13_real`).
 - `deviceName`: The human-readable name you see in the UI (for example, `iPhone 12 Pro Max`).
 
-The `deviceName` parameter accepts an exact value or regular expression and matches against both `descriptor` and `deviceName`. This holds true for every endpoint that accepts the `deviceName` parameter.
+Provide a `descriptor` (Device ID) to target a specific device, or use a regular expression matched against the `deviceName` (Display Name) to broaden the pool of matches. This holds true for every endpoint that accepts the `deviceName` parameter.
 
 > Need the full schema for these fields? See `Device` and `Session` definitions in the [Real Device Access API Reference](/real-device-access-api).
 
@@ -62,7 +62,7 @@ The `/devices/status` endpoint supports the following query parameters:
 
 - `state`: Filter by device state (`AVAILABLE`, `IN_USE`, `CLEANING`, `REBOOTING`, `MAINTENANCE`, `OFFLINE`).
 - `privateOnly`: Set to `true` to show only your account's private devices.
-- `deviceName`: Filter by descriptor or friendly name. Accepts regular expressions (for example, `iPhone.*`).
+- `deviceName`: Provide a `descriptor` (Device ID, for example `iPhone_13_real`) to target a specific device, or a regular expression matched against the Display Name (for example, `iPhone.*`) to broaden the pool of matches.
 
 #### Examples:
 ```shell
@@ -76,7 +76,7 @@ curl -u $AUTH "$BASE_URL/devices/status?state=AVAILABLE"
 curl -X GET -u $AUTH \
   "$BASE_URL/devices/status?privateOnly=true"
 
-# Filter by device identifier (supports regular expression patterns)
+# Filter by descriptor (target one device) or by regex against the Display Name (broaden the pool)
 curl -X GET -u $AUTH \
   "$BASE_URL/devices/status?deviceName=iPhone.*"
 
@@ -142,7 +142,7 @@ Filter sessions by `state` and `deviceName`.
 The `/sessions` endpoint supports:
 
 - `state`: Session lifecycle state (`PENDING`, `CREATING`, `ACTIVE`, `CLOSING`, `CLOSED`, `ERRORED`).
-- `deviceName`: Specific descriptor or regular expression (for example, `iPhone_16_real` or `Samsung.*`).
+- `deviceName`: Provide a `descriptor` (Device ID, for example `iPhone_16_real`) to target a specific device, or a regular expression matched against the Display Name (for example, `Samsung.*`) to broaden the pool of matches.
 
 ##### Examples
 ```shell

--- a/static/oas/real-device-access-api-spec.yaml
+++ b/static/oas/real-device-access-api-spec.yaml
@@ -47,7 +47,7 @@ paths:
       parameters:
         - name: deviceName
           in: query
-          description: "Filter by device identifier (supports regex). Matches the descriptor ID or device name."
+          description: "Provide a descriptor (Device ID) to target a specific device, or use a regular expression matched against the deviceName (Display Name) to broaden the pool of matches."
           required: false
           schema:
             type: string
@@ -108,7 +108,7 @@ paths:
             type: boolean
         - name: deviceName
           in: query
-          description: "Filter by device identifier (supports regex). Matches both descriptor and deviceName fields."
+          description: "Provide a descriptor (Device ID) to target a specific device, or use a regular expression matched against the deviceName (Display Name) to broaden the pool of matches."
           schema:
             type: string
             example: "iPhone.*"
@@ -145,7 +145,7 @@ paths:
                   properties:
                     deviceName:
                       type: string
-                      description: "Device identifier (supports regex). If omitted, any device will be selected. Matches both descriptor and deviceName fields."
+                      description: "Provide a descriptor (Device ID) to target a specific device, or use a regular expression matched against the deviceName (Display Name) to broaden the pool of matches. If omitted, any device will be selected."
                       example: "iPhone_16_real"
                     os:
                       description: Filter by operating system (Android or iOS). The enum is case insensitive.
@@ -187,7 +187,7 @@ paths:
         - name: deviceName
           in: query
           required: false
-          description: "Filter by device identifier (supports regex). Matches both descriptor and deviceName fields."
+          description: "Provide a descriptor (Device ID) to target a specific device, or use a regular expression matched against the deviceName (Display Name) to broaden the pool of matches."
           schema:
             type: string
       responses:


### PR DESCRIPTION
### Description
Updated the Real Device Access API docs to clarify that the deviceName parameter matches the descriptor as a whole value, while regex matching applies only to the Display Name.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
