### PR TITLE
Reapply "chore: add Playwright 1.60.0 and Cypress 15.14.2 to supporte…

### DIFF
--- a/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
+++ b/docs/web-apps/automated-testing/cucumberjs-playwright/yaml.md
@@ -864,7 +864,7 @@ The parent property containing the details specific to the Playwright project.
 
 ```yaml
 playwright:
-  version: 1.58.2
+  version: 1.60.0
 ```
 
 ---
@@ -877,7 +877,7 @@ The version of Playwright that is compatible with the tests defined in this file
 
 ```yaml
 playwright:
-  version: 1.58.2
+  version: 1.60.0
 ```
 
 :::tip

--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -37,6 +37,19 @@ Sauce Labs supports the following test configurations for Cypress:
   </tr>
   <tbody>
      <tr>
+      <td rowspan='2'>15.14.2</td>
+      <td rowspan='2'>22</td>
+      <td rowspan='2'>✅</td>
+      <td><b>macOS:</b> 11.00, 12, 13</td>
+      <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
+      <td rowspan='2'>June 15th, 2027</td>
+    </tr>
+    <tr>
+      <td><b>Windows:</b> 10, 11</td>
+    </tr>
+  </tbody>
+  <tbody>
+     <tr>
       <td rowspan='2'>15.12.0</td>
       <td rowspan='2'>22</td>
       <td rowspan='2'>✅</td>

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -888,7 +888,7 @@ The parent property containing the details specific to the Cypress project.
 
 ```yaml
 cypress:
-  version: 15.12.0
+  version: 15.14.2
   configFile: "cypress.config.js"
 ```
 
@@ -902,7 +902,7 @@ The version of Cypress that is compatible with the tests defined in this file. S
 
 ```yaml
 cypress:
-  version: 15.12.0
+  version: 15.14.2
 ```
 
 :::tip

--- a/docs/web-apps/automated-testing/playwright.md
+++ b/docs/web-apps/automated-testing/playwright.md
@@ -38,6 +38,19 @@ Sauce Labs supports the following test configurations for Playwright:
   </tr>
     <tbody>
       <tr>
+        <td rowspan='2'>1.60.0</td>
+        <td rowspan='2'>22</td>
+        <td rowspan='2'>✅</td>
+        <td><b>macOS:</b> 14*, 15*</td>
+        <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>
+        <td rowspan='2'>June 15th, 2027</td>
+      </tr>
+      <tr>
+        <td><b>Windows:</b> 10, 11</td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr>
         <td rowspan='2'>1.58.2</td>
         <td rowspan='2'>22</td>
         <td rowspan='2'>✅</td>

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -864,7 +864,7 @@ The parent property containing the details specific to the Playwright project.
 
 ```yaml
 playwright:
-  version: 1.58.2
+  version: 1.60.0
   configFile: config.ts
 ```
 
@@ -878,7 +878,7 @@ The version of Playwright that is compatible with the tests defined in this file
 
 ```yaml
 playwright:
-  version: 1.58.2
+  version: 1.60.0
 ```
 
 :::tip


### PR DESCRIPTION
Description
Reapplies PR #3542 (add Playwright 1.60.0 and Cypress 15.14.2 to the supported testing platforms), which was temporarily reverted in #3551. This re-introduces the changes to the docs:

Playwright supported-versions table top entry back to 1.60.0
Cypress supported-versions table top entry back to 15.14.2
config.yml examples in playwright/yaml.md, cucumberjs-playwright/yaml.md, and cypress/yaml/v1.md updated accordingly
(5 files changed, 32 insertions, 6 deletions.)

Motivation and Context
The versions were temporarily reverted because they were published to the docs ahead of being available on the platform. They are now ready, so this PR restores the supported-versions tables and config examples to reflect what's actually supported.

Types of Changes
 [ ] Bug fix (non-breaking change which fixes an issue)
 [ ] New feature (non-breaking change which adds functionality)
 [ ] Breaking change (fix or feature that would cause existing functionality to change)
 [x] Documentation fix (typos, incorrect content, missing content, etc.)