### PR TITLE
chore: update Node.js version to 24 for Playwright 1.60.0

### DIFF
--- a/docs/web-apps/automated-testing/playwright.md
+++ b/docs/web-apps/automated-testing/playwright.md
@@ -39,7 +39,7 @@ Sauce Labs supports the following test configurations for Playwright:
     <tbody>
       <tr>
         <td rowspan='2'>1.60.0</td>
-        <td rowspan='2'>22</td>
+        <td rowspan='2'>24</td>
         <td rowspan='2'>✅</td>
         <td><b>macOS:</b> 14*, 15*</td>
         <td rowspan='2'>Chromium, Chrome, Firefox, Webkit</td>


### PR DESCRIPTION


### Description
Updates the Node.js version for Playwright 1.60.0 from 22 to 24 in the supported testing platforms table. Only the 1.60.0 row is affected; all other versions remain on Node.js 22.

### Motivation and Context
Playwright 1.60.0 on Sauce Labs now runs on Node.js 24. The docs previously listed Node.js 22 for this version, so the supported-versions table was out of sync with the actual runner. This corrects it so users configure the right Node.js version.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Documentation fix (typos, incorrect content, missing content, etc.)
