### PR TITLE
Document macOS 14 support for cypress

### DIFF
--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -40,7 +40,7 @@ Sauce Labs supports the following test configurations for Cypress:
       <td rowspan='2'>15.14.2</td>
       <td rowspan='2'>22</td>
       <td rowspan='2'>✅</td>
-      <td><b>macOS:</b> 11.00, 12, 13</td>
+      <td><b>macOS:</b> 11.00, 12, 13, 14*</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>June 15th, 2027</td>
     </tr>
@@ -179,6 +179,8 @@ Sauce Labs supports the following test configurations for Cypress:
     </tr>
   </tbody>
 </table>
+
+*macOS 14+ requires a Premium subscription. For additional details see [macOS Browser Tests on Apple Silicon](/web-apps/macos-apple-silicon).
 
 ## How to Get Started
 


### PR DESCRIPTION
What this does

This adds macOS 14 to the supported platforms row for the latest cypress version and adds a footnote that macOS 14 and above needs a premium subscription. The footnote links to the macOS Apple Silicon page.

Why

This is part of INT-246. Customers need the docs to show that cypress runs on macOS 14.

Do not merge yet

Do not publish this until cypress on macOS 14 is live so the docs match the product. Keep this as a draft until the feature is deployed.
