### PR TITLE
docs: Document Battery Saver reset in Android real device cleaning

### DIFF
--- a/docs/mobile-apps/real-device-cleaning.md
+++ b/docs/mobile-apps/real-device-cleaning.md
@@ -93,6 +93,7 @@ We use a proprietary process that wipes every real device clean at the end of th
 - EU devices: Lat 52.500, Lon 13.447, Alt 40m (Berlin, DE)
 - Media files (Photos, Videos, Files) on the device are removed.
 - PIN code/Password is removed.
+- On Android, Battery Saver (Low Power Mode) is disabled.
 
 ## Private Devices
 


### PR DESCRIPTION
### Description

Adds a bullet to the Real Device Cleaning Process page (`docs/mobile-apps/real-device-cleaning.md`), under "Cleaning Process Steps", noting that on Android, Battery Saver (Low Power Mode) is disabled during cleaning.

### Motivation and Context

When Battery Saver (Low Power Mode) is enabled during a session, it was not reverted during device cleaning and persisted into the next session, which can cause shortened screen timeouts, app background-sync issues, and test failures for the following user. The Android cleaning process now disables it, and this documents that behavior.

### Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)