### PR TITLE
Improve AccessAPI docs for launchWebDriverAgent to clarify usage

### DIFF
--- a/static/oas/real-device-access-api-spec.yaml
+++ b/static/oas/real-device-access-api-spec.yaml
@@ -585,8 +585,9 @@ paths:
       summary: Launch WDA installed on the device
       description: |
         Launches WebDriverAgent (WDA) on an iOS device. WDA enables Appium-based automation by providing
-        a WebDriver-compatible interface to the device. Optionally provide a custom bundleId if you've deployed
-        your own WDA fork. Use getWebDriverAgentStatus to check if WDA is already running before launching.
+        a WebDriver-compatible interface to the device. Please use the installApp endpoint to provide your own
+        WDA binary and use getWebDriverAgentStatus to check if WDA is running. After launching, you can interact with 
+        the newly installed WDA using the the HTTP Proxy​ endpoinds provided by this API.
       tags:
         - "Device Interactions"
       parameters:


### PR DESCRIPTION
### Description
Improves the openAPI definition of the launchWebDriverAgent endpoint

### Motivation and Context
Current description doesn't propetly clarify the flow required to launch a custom WDA. Adding the installation step, and hints on how to interact with it after launched.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
