### PR TITLE
Existing Doc Updates - Android 17 emulator support

### DIFF
--- a/docs/mobile-apps/android-emulators.md
+++ b/docs/mobile-apps/android-emulators.md
@@ -19,7 +19,7 @@ Android 12 virtual devices on Sauce Labs are built with API level 32 (also known
 
 We offer emulators for Android 15, 16, and 17 which include critical support for the 16KB page size memory architecture. The Google Play Store requires that all new apps and app [updates submitted after November 1, 2025](https://developer.android.com/guide/practices/page-sizes), are compatible with 16KB pages. Testing on these emulator configurations is essential to ensure your application meets this requirement and functions correctly for all users. Look for Pixel devices with the `ps16k` label in their name to get started with these new emulators.
 
-Android 17 is available on the **Pixel 9a 16kb page size** and **Generic Medium Phone 16kb page size** emulators, which require [Appium 2.11.0](./automated-testing/appium/appium-versions.md#android-emulators).
+Android 17 is available on the **Pixel 9a ps16kb Emulator** and **Medium Phone ps16kb Emulator** devices, which require [Appium 2.11.0](./automated-testing/appium/appium-versions.md#android-emulators).
 
 ### Legacy Device Mapping for Automated Testing
 
@@ -34,9 +34,9 @@ Below is the current mapping of the default Chrome browser version installed on 
 
 | Android OS Version | Google Chrome Version |
 | :----------------- | :-------------------- |
-| Android 17         | 140                   |
-| Android 16         | 140                   |
-| Android 15         | 140                   |
+| Android 17         | 145                   |
+| Android 16         | 145                   |
+| Android 15         | 141                   |
 | Android 14         | 140                   |
 | Android 13         | 140                   |
 | Android 12         | 140                   |

--- a/docs/mobile-apps/android-emulators.md
+++ b/docs/mobile-apps/android-emulators.md
@@ -15,9 +15,11 @@ Our selection of Android Emulators corresponds to the most popular AVDs publishe
 
 Android 12 virtual devices on Sauce Labs are built with API level 32 (also known as Android 12L)
 
-### Android 15/16 with 16KB Page Size Support
+### Android 15, 16, and 17 with 16KB Page Size Support
 
-We offer emulators for Android 15 and 16 which include critical support for the 16KB page size memory architecture. The Google Play Store requires that all new apps and app [updates submitted after November 1, 2025](https://developer.android.com/guide/practices/page-sizes), are compatible with 16KB pages. Testing on these emulator configurations is essential to ensure your application meets this requirement and functions correctly for all users. Look for Pixel devices with the `ps16k` label in their name to get started with these new emulators.
+We offer emulators for Android 15, 16, and 17 which include critical support for the 16KB page size memory architecture. The Google Play Store requires that all new apps and app [updates submitted after November 1, 2025](https://developer.android.com/guide/practices/page-sizes), are compatible with 16KB pages. Testing on these emulator configurations is essential to ensure your application meets this requirement and functions correctly for all users. Look for Pixel devices with the `ps16k` label in their name to get started with these new emulators.
+
+Android 17 is available on the **Pixel 9a 16kb page size** and **Generic Medium Phone 16kb page size** emulators, which require [Appium 2.11.0](./automated-testing/appium/appium-versions.md#android-emulators).
 
 ### Legacy Device Mapping for Automated Testing
 
@@ -32,6 +34,7 @@ Below is the current mapping of the default Chrome browser version installed on 
 
 | Android OS Version | Google Chrome Version |
 | :----------------- | :-------------------- |
+| Android 17         | 140                   |
 | Android 16         | 140                   |
 | Android 15         | 140                   |
 | Android 14         | 140                   |

--- a/docs/mobile-apps/android-emulators.md
+++ b/docs/mobile-apps/android-emulators.md
@@ -19,7 +19,7 @@ Android 12 virtual devices on Sauce Labs are built with API level 32 (also known
 
 We offer emulators for Android 15, 16, and 17 which include critical support for the 16KB page size memory architecture. The Google Play Store requires that all new apps and app [updates submitted after November 1, 2025](https://developer.android.com/guide/practices/page-sizes), are compatible with 16KB pages. Testing on these emulator configurations is essential to ensure your application meets this requirement and functions correctly for all users. Look for Pixel devices with the `ps16k` label in their name to get started with these new emulators.
 
-Android 17 is available on the **Pixel 9a ps16kb Emulator** and **Medium Phone ps16kb Emulator** devices, which require [Appium 2.11.0](./automated-testing/appium/appium-versions.md#android-emulators).
+Android 17 is available on the **Pixel 9a ps16k Emulator** and **Medium Phone ps16k Emulator** devices, which require [Appium 2.11.0](./automated-testing/appium/appium-versions.md#android-emulators).
 
 ### Legacy Device Mapping for Automated Testing
 

--- a/docs/mobile-apps/automated-testing/appium/appium-versions.md
+++ b/docs/mobile-apps/automated-testing/appium/appium-versions.md
@@ -610,6 +610,28 @@ Starting with `appium3-2026-01`, iOS automated test sessions on Sauce Labs Real 
   </thead>
   <tbody>
     <tr>
+      <td>Android 17.0</td>
+      <td>
+        <ul>
+          <li>
+            <a href="#appium-2-versions">
+              <code>2.11.0</code>
+            </a>
+          </li>
+        </ul>
+      </td>
+      <td>
+        <a href="#appium-2-versions">
+          <code>2.11.0</code>
+        </a>
+      </td>
+      <td>
+        <a href="#appium-2-versions">
+          <code>2.11.0</code>
+        </a>
+      </td>
+    </tr>
+    <tr>
       <td>Android 16.0</td>
       <td>
         <ul>


### PR DESCRIPTION
## Summary

Documents support for **Android 17** on Sauce Labs Android Emulators, available on
the **Pixel 9a ps16k Emulator** and **Medium Phone ps16k Emulator** devices with **Appium 2.11.0**.

## Changes

**docs/mobile-apps/android-emulators.md**
- Expanded the 16KB Page Size Support section to cover Android 15, 16, and 17, and named the two new Android 17 devices.
- Updated the Google Chrome version table: added Android 17 (145) and corrected Android 16 (145) and Android 15 (141).

**docs/mobile-apps/automated-testing/appium/appium-versions.md**
- Added an Android 17.0 row to the Android Emulators table (supported / default / recommended Appium 2.11.0).
