### PR TITLE
Document macOS 15 support for cypress

### DIFF
--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -40,7 +40,7 @@ Sauce Labs supports the following test configurations for Cypress:
       <td rowspan='2'>15.14.2</td>
       <td rowspan='2'>22</td>
       <td rowspan='2'>✅</td>
-      <td><b>macOS:</b> 11.00, 12, 13, 14*</td>
+      <td><b>macOS:</b> 11.00, 12, 13, 14*, 15*†</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>June 15th, 2027</td>
     </tr>
@@ -181,6 +181,8 @@ Sauce Labs supports the following test configurations for Cypress:
 </table>
 
 *macOS 14+ requires a Premium subscription. For additional details see [macOS Browser Tests on Apple Silicon](/web-apps/macos-apple-silicon).
+
+† On macOS 15, Cypress supports Chrome, Microsoft Edge, and Webkit (Experimental). Firefox is not supported on macOS 15 due to a macOS firewall issue. Chrome, Firefox, Microsoft Edge, and Webkit (Experimental) all remain available on macOS 11.00, 12, 13, and 14.
 
 ## How to Get Started
 

--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -40,7 +40,7 @@ Sauce Labs supports the following test configurations for Cypress:
       <td rowspan='2'>15.14.2</td>
       <td rowspan='2'>22</td>
       <td rowspan='2'>✅</td>
-      <td><b>macOS:</b> 11.00, 12, 13</td>
+      <td><b>macOS:</b> 11.00, 12, 13, 14*</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>June 15th, 2027</td>
     </tr>
@@ -179,6 +179,8 @@ Sauce Labs supports the following test configurations for Cypress:
     </tr>
   </tbody>
 </table>
+
+*macOS 14+ requires a Premium subscription. For additional details see [macOS Browser Tests on Apple Silicon](/web-apps/macos-apple-silicon).
 
 ## How to Get Started
 

--- a/docs/web-apps/automated-testing/cypress/limitations.md
+++ b/docs/web-apps/automated-testing/cypress/limitations.md
@@ -58,7 +58,8 @@ module.exports = defineConfig({
 ### WebKit
 
 To enable WebKit support in Cypress, you need to set the `experimentalWebKitSupport` flag in your Cypress configuration
-file. Note that on macOS, WebKit only works on macOS 13+.
+file. WebKit works on macOS 13 and later, including Apple Silicon macOS 14 and 15. Firefox is not supported on macOS 15
+due to a macOS firewall issue.
 
 ```javascript
 module.exports = defineConfig({

--- a/docs/web-apps/quarterly-browser-updates.md
+++ b/docs/web-apps/quarterly-browser-updates.md
@@ -109,6 +109,10 @@ Google announced that starting with **Chrome 153 in September 2026**, Chrome wil
 
 ### Framework and Integration Updates
 
+#### Cypress on macOS 14 and 15 (Apple Silicon)
+
+[Cypress 15.14.2](/web-apps/automated-testing/cypress/) now runs on **macOS 14 (Sonoma) and macOS 15 (Sequoia)** on Apple Silicon. Supported browsers: Chrome, Microsoft Edge, and WebKit (Experimental). Firefox is not supported on macOS 15 due to a macOS firewall issue. Chrome, Firefox, Microsoft Edge, and WebKit (Experimental) remain available on macOS 11.00, 12, 13, and 14.
+
 #### Playwright 1.58.1 — Now on macOS 14 and 15 (ARM)
 
 [Playwright 1.58.1](/web-apps/automated-testing/playwright/) is now available on Sauce Labs with support for **macOS 14 (Sonoma) and macOS 15 (Sequoia)** running on ARM architecture. This is the first Playwright version on Sauce Labs to run on Apple Silicon. Supported browsers: Chromium, Chrome, Firefox, and WebKit.

--- a/docs/web-apps/quarterly-browser-updates.md
+++ b/docs/web-apps/quarterly-browser-updates.md
@@ -111,7 +111,7 @@ Google announced that starting with **Chrome 153 in September 2026**, Chrome wil
 
 #### Cypress on macOS 14 and 15 (Apple Silicon)
 
-[Cypress 15.14.2](/web-apps/automated-testing/cypress/) now runs on **macOS 14 (Sonoma) and macOS 15 (Sequoia)** on Apple Silicon. Supported browsers: Chrome, Microsoft Edge, and WebKit (Experimental). Firefox is not supported on macOS 15 due to a macOS firewall issue. Chrome, Firefox, Microsoft Edge, and WebKit (Experimental) remain available on macOS 11.00, 12, 13, and 14.
+[Cypress 15.14.2](/web-apps/automated-testing/cypress/) now runs on **macOS 14 (Sonoma) and macOS 15 (Sequoia)** on Apple Silicon. On macOS 14, all four browsers are supported: Chrome, Firefox, Microsoft Edge, and WebKit (Experimental). On macOS 15, Firefox is not supported due to a macOS firewall issue, so the supported browsers are Chrome, Microsoft Edge, and WebKit (Experimental). Chrome, Firefox, Microsoft Edge, and WebKit (Experimental) also remain available on macOS 11.00, 12, and 13.
 
 #### Playwright 1.58.1 — Now on macOS 14 and 15 (ARM)
 


### PR DESCRIPTION
This documents macOS 15 on Apple Silicon for the latest Cypress version (15.14.2), continuing the INT-246 work. It also carries the macOS 14 documentation (see the note on #3557 below).

Changes to docs/web-apps/automated-testing/cypress.md:
- Add macOS 14 and 15 to the supported platforms cell for Cypress 15.14.2.
- Add a footnote that on macOS 15 the supported browsers are Chrome, Microsoft Edge, and WebKit (Experimental); Firefox is not supported on macOS 15 due to a macOS firewall issue. Chrome, Firefox, Microsoft Edge, and WebKit (Experimental) all remain available on macOS 11.00, 12, 13, and 14.
- Add a footnote that macOS 14 and later require a Premium subscription, linking to the Apple Silicon page.

Changes to docs/web-apps/automated-testing/cypress/limitations.md:
- WebKit works on macOS 13 and later, including Apple Silicon macOS 14 and 15.

Changes to docs/web-apps/quarterly-browser-updates.md:
- Add a Cypress on macOS 14 and 15 (Apple Silicon) entry that states, per macOS version, which browsers are supported: macOS 14 supports all four browsers; macOS 15 supports Chrome, Microsoft Edge, and WebKit (Experimental) with no Firefox.

Notes for reviewers:
- No Intel WebKit deprecation. The runner uses a per architecture bundle: the ARM bundle adds macOS 14 and 15 WebKit, while the Intel bundle is unchanged, so cypress-webkit on Intel macOS 13 keeps working exactly as before. (An earlier draft of this description wrongly stated Intel WebKit was deprecated. That is not the case, and the docs do not deprecate it.)
- Supersedes #3557 (macOS 14 Cypress docs): this branch carries that macOS 14 commit plus the macOS 15 changes, so #3557 can be closed as superseded once this merges.
- Rebased onto current main, so it is no longer behind. Only the Cypress 15.14.2 block changes; older Cypress version blocks are unchanged and keep macOS 11.00, 12, and 13.
