### PR TITLE
INT-246: Document macOS 26 availability for Playwright and TestCafe

### DIFF
--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -1342,7 +1342,7 @@ suite:
 When set to `true`, this option adds capability requirement for ARM architecture on the machine running the test.
 
 :::note
-ARM is available for macOS 14 and macOS 15 with Playwright >=1.58.1. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required in order for tests to execute on macOS 14+ and can be omitted from your configuration.
+ARM is available for macOS 14, macOS 15, and macOS 26 with Playwright >=1.58.1. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required in order for tests to execute on macOS 14+ and can be omitted from your configuration.
 :::
 
 ```yaml

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -1342,7 +1342,7 @@ suite:
 When set to `true`, this option adds capability requirement for ARM architecture on the machine running the test.
 
 :::note
-ARM is available for macOS 14, macOS 15, and macOS 26 with Playwright >=1.58.1. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required in order for tests to execute on macOS 14+ and can be omitted from your configuration.
+ARM is available for macOS 14, macOS 15, and macOS 26 with Playwright >=1.58.1. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required in order for tests to run on macOS 14+ and can be omitted from your configuration.
 :::
 
 ```yaml

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -1740,7 +1740,7 @@ suite:
 When set to `true`, this option adds capability requirement for ARM architecture on the machine running the test.
 
 :::note
-ARM is available for macOS 14, macOS 15, and macOS 26 with TestCafe >=3.7.2. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required in order for tests to execute on macOS 14+ and can be omitted from your configuration.
+ARM is available for macOS 14, macOS 15, and macOS 26 with TestCafe >=3.7.2. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required in order for tests to run on macOS 14+ and can be omitted from your configuration.
 :::
 
 ```yaml

--- a/docs/web-apps/automated-testing/testcafe/yaml.md
+++ b/docs/web-apps/automated-testing/testcafe/yaml.md
@@ -1740,7 +1740,7 @@ suite:
 When set to `true`, this option adds capability requirement for ARM architecture on the machine running the test.
 
 :::note
-ARM is available for macOS 14 and macOS 15 with TestCafe >=3.7.2. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required in order for tests to execute on macOS 14+ and can be omitted from your configuration.
+ARM is available for macOS 14, macOS 15, and macOS 26 with TestCafe >=3.7.2. Note: Firefox is not supported on macOS 15 due to a known macOS firewall issue. As of March 20th, 2026 this parameter is no longer required in order for tests to execute on macOS 14+ and can be omitted from your configuration.
 :::
 
 ```yaml


### PR DESCRIPTION
Documents macOS 26 availability for Playwright and TestCafe.

macOS 26 (ARM) is now live and validated on prod for both frameworks — extends the `armRequired` ARM-availability note to include macOS 26 (Playwright >=1.58.1, TestCafe >=3.7.2, same version floor as macOS 14/15).

The main pages already say "macOS 12+", so no change needed there. The Firefox-not-supported note is kept specific to macOS 15 — Firefox passed on macOS 26 in the prod E2E validation.

Part of INT-246 (macOS 26 enablement).