### PR TITLE
Update Sauce MCP tool reference and client config endpoints

### DIFF
--- a/docs/sauce-ai/sauce-mcp-getting-started.md
+++ b/docs/sauce-ai/sauce-mcp-getting-started.md
@@ -65,7 +65,7 @@ You can connect Claude Code in either of two ways.
 **Option 1: Add it with the CLI**
 
 ```bash
-claude mcp add --transport http sauce-labs https://<sauce-mcp-endpoint> \
+claude mcp add --transport http sauce-labs https://mcp.saucelabs.com \
   --header "Authorization: Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
 ```
 
@@ -78,7 +78,7 @@ Add the server to a `.mcp.json` file in your project root (or to your user-level
   "mcpServers": {
     "sauce-labs": {
       "type": "http",
-      "url": "https://<sauce-mcp-endpoint>",
+      "url": "https://mcp.saucelabs.com",
       "headers": {
         "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
       }
@@ -103,7 +103,7 @@ Edit `claude_desktop_config.json` (Settings → Developer → Edit Config). Clau
       "args": [
         "-y",
         "mcp-remote",
-        "https://<sauce-mcp-endpoint>",
+        "https://mcp.saucelabs.com",
         "--header",
         "Authorization: Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
       ]
@@ -123,7 +123,7 @@ Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per project):
 {
   "mcpServers": {
     "sauce-labs": {
-      "url": "https://<sauce-mcp-endpoint>",
+      "url": "https://mcp.saucelabs.com",
       "headers": {
         "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
       }
@@ -142,7 +142,7 @@ Edit your Windsurf MCP config (`~/.codeium/windsurf/mcp_config.json`):
 {
   "mcpServers": {
     "sauce-labs": {
-      "serverUrl": "https://<sauce-mcp-endpoint>",
+      "serverUrl": "https://mcp.saucelabs.com",
       "headers": {
         "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
       }
@@ -162,7 +162,7 @@ Create `.vscode/mcp.json` in your workspace:
   "servers": {
     "sauce-labs": {
       "type": "http",
-      "url": "https://<sauce-mcp-endpoint>",
+      "url": "https://mcp.saucelabs.com",
       "headers": {
         "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
       }
@@ -183,7 +183,7 @@ In your JetBrains IDE (IntelliJ IDEA and others), open **Settings | Tools | AI A
 {
   "mcpServers": {
     "sauce-labs": {
-      "url": "https://<sauce-mcp-endpoint>",
+      "url": "https://mcp.saucelabs.com",
       "headers": {
         "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
       }
@@ -201,7 +201,7 @@ In Antigravity, open the MCP settings and add a server, or edit its MCP configur
 {
   "mcpServers": {
     "sauce-labs": {
-      "serverUrl": "https://<sauce-mcp-endpoint>",
+      "serverUrl": "https://mcp.saucelabs.com",
       "headers": {
         "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
       }
@@ -219,7 +219,7 @@ Edit `~/.gemini/settings.json`:
 {
   "mcpServers": {
     "sauce-labs": {
-      "httpUrl": "https://<sauce-mcp-endpoint>",
+      "httpUrl": "https://mcp.saucelabs.com",
       "headers": {
         "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
       }
@@ -235,7 +235,7 @@ Edit `~/.gemini/settings.json`:
 Add an extension in Goose with these settings:
 
 - **Type:** Remote (Streamable HTTP)
-- **Endpoint:** `https://<sauce-mcp-endpoint>`
+- **Endpoint:** `https://mcp.saucelabs.com`
 - **Header:** `Authorization: Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>`
 
 </TabItem>

--- a/docs/sauce-ai/sauce-mcp-tools.md
+++ b/docs/sauce-ai/sauce-mcp-tools.md
@@ -32,6 +32,11 @@ Look up account, user, team, and region information. Useful for confirming which
 | `get_my_active_team` | Show the team your account is currently acting under. | "Which team am I currently using?" | <span className="mcp-tag mcp-tag--muted">Standard</span> |
 | `lookup_teams` | Search the teams in your organization. | "List the teams in my organization." | <span className="mcp-tag mcp-tag--muted">Standard</span> |
 | `get_active_region` | Report which Sauce Labs data center the server is connected to. | "Which Sauce Labs region am I connected to?" | <span className="mcp-tag mcp-tag--muted">Standard</span> |
+| `get_team` | Retrieve the full profile of a team by its ID. | "Show the details for my team." | <span className="mcp-tag mcp-tag--muted">Standard</span> |
+| `list_team_members` | List all members of a team. | "Who's on my team?" | <span className="mcp-tag mcp-tag--muted">Standard</span> |
+| `lookup_users` | Search the organization for users, filtered by name, email, role, status, or team. | "Find users with 'smith' in their name." | <span className="mcp-tag mcp-tag--muted">Standard</span> |
+| `get_service_account` | Get the details of a service account by ID. | "Show the details for that service account." | <span className="mcp-tag mcp-tag--muted">Standard</span> |
+| `lookup_service_accounts` | List the service accounts in your organization. | "List my organization's service accounts." | <span className="mcp-tag mcp-tag--muted">Standard</span> |
 
 
 ## Real Device Access API
@@ -106,6 +111,19 @@ Shape network conditions and capture traffic during a session.
 | `listNetworkProfiles` | List the available network profiles. | "What network profiles are available?" | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
 | `startNetworkCapture` | Begin capturing the device's network traffic. | "Start capturing network traffic." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
 | `stopNetworkCapture` | Stop the active network capture. | "Stop the network capture." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `resetNetworkConditions` | Remove all network throttling and restore normal connectivity. | "Reset the network back to normal." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+
+### Appium and WebDriverAgent
+
+Start and inspect a hosted Appium server or iOS WebDriverAgent for a session, so you can connect your own Appium client for advanced automation.
+
+| Tool | Description | Example prompt | Requirements |
+| --- | --- | --- | --- |
+| `startAppiumServer` | Start a hosted Appium server co-located with the device and return its URL. Optionally pin an Appium version. | "Start an Appium server for this session." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `getAppiumServerStatus` | Report the hosted Appium server's status and endpoint URL for a session. | "Is the Appium server running, and what's its URL?" | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `listAppiumVersions` | List the Appium versions available for real devices. | "What Appium versions can I use?" | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `launchWebDriverAgent` | Launch WebDriverAgent (WDA) on an iOS device for Appium-based automation. iOS only. | "Launch WebDriverAgent on this iPhone." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `getWebDriverAgentStatus` | Report WebDriverAgent's state, and its ports once it is running. iOS only. | "Is WebDriverAgent ready yet?" | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
 
 ## Jobs, builds &amp; assets
 
@@ -123,6 +141,10 @@ Inspect jobs and builds, and retrieve the assets they produce, such as logs, scr
 | `filter_har_data` | Filter a HAR capture down to the entries you care about. | "Show only the failed requests in that HAR." | <span className="mcp-tag">Real Device Cloud</span> <span className="mcp-conn">or</span> <span className="mcp-tag">Virtual Device Cloud</span> |
 | `lookup_builds` | Search your builds. | "List my recent builds." | <span className="mcp-tag">Real Device Cloud</span> <span className="mcp-conn">or</span> <span className="mcp-tag">Virtual Device Cloud</span> |
 | `get_build` | Retrieve the details of a specific build. | "Show the details of my latest build." | <span className="mcp-tag">Real Device Cloud</span> <span className="mcp-conn">or</span> <span className="mcp-tag">Virtual Device Cloud</span> |
+| `get_specific_real_device_job_asset` | Download a specific asset (device logs, Appium logs, video, screenshots, HAR, or crash data) from a real-device job. | "Download the video from that real-device job." | <span className="mcp-tag">Real Device Cloud</span> |
+| `get_log_json_file` | Retrieve the structured JSON command log of a virtual-device test. | "Get the command log for that VDC job." | <span className="mcp-tag">Virtual Device Cloud</span> |
+| `get_build_for_job` | Find the build a specific job belongs to. | "Which build was that job part of?" | <span className="mcp-tag">Real Device Cloud</span> <span className="mcp-conn">or</span> <span className="mcp-tag">Virtual Device Cloud</span> |
+| `lookup_jobs_in_build` | List the jobs in a build, with optional status filters. | "List the failed jobs in that build." | <span className="mcp-tag">Real Device Cloud</span> <span className="mcp-conn">or</span> <span className="mcp-tag">Virtual Device Cloud</span> |
 
 ## Storage
 
@@ -133,6 +155,7 @@ Upload and browse app builds in Sauce Storage.
 | `upload_file_to_storage` | Upload an app build to Sauce Storage. | "Upload this APK to Sauce Storage." | <span className="mcp-tag">Real Device Cloud</span> <span className="mcp-conn">or</span> <span className="mcp-tag">Virtual Device Cloud</span> |
 | `get_storage_files` | List the app builds in Sauce Storage. | "What app builds are in my storage?" | <span className="mcp-tag">Real Device Cloud</span> <span className="mcp-conn">or</span> <span className="mcp-tag">Virtual Device Cloud</span> |
 | `get_storage_groups` | List the storage groups (apps grouped by identifier). | "List my storage groups." | <span className="mcp-tag">Real Device Cloud</span> <span className="mcp-conn">or</span> <span className="mcp-tag">Virtual Device Cloud</span> |
+| `get_storage_groups_settings` | Get the settings for a storage app group. | "Show the settings for that app group." | <span className="mcp-tag">Real Device Cloud</span> <span className="mcp-conn">or</span> <span className="mcp-tag">Virtual Device Cloud</span> |
 
 ## Tunnels
 
@@ -143,10 +166,11 @@ Inspect Sauce Connect tunnels and the jobs running through them.
 | `get_tunnel_information` | Retrieve details for a specific tunnel. | "Show details for tunnel my-tunnel." | <span className="mcp-tag mcp-tag--muted">Standard</span> |
 | `get_tunnels_for_user` | List the tunnels owned by a user. | "Do I have any active tunnels?" | <span className="mcp-tag mcp-tag--muted">Standard</span> |
 | `get_current_jobs_for_tunnel` | List the jobs currently running through a tunnel. | "What jobs are running through my tunnel?" | <span className="mcp-tag mcp-tag--muted">Standard</span> |
+| `get_tunnel_version_downloads` | Get the download URLs for a specific Sauce Connect version. | "Get the download links for Sauce Connect 5.2.3." | <span className="mcp-tag mcp-tag--muted">Standard</span> |
 
 ## Test Authoring
 
-The following tools are powered by [Sauce AI for Test Authoring](/sauce-ai/ai-authoring), a paid add-on for Enterprise accounts. They let your agent generate test cases from natural-language intent, manage and run them, organize them into suites, and schedule recurring runs — all without writing code. All tools in this section require the Test Authoring add-on.
+The following tools are powered by [Sauce AI for Test Authoring](/sauce-ai/ai-authoring), a paid add-on for Enterprise accounts. They let your agent generate test cases from natural-language intent, manage and run them, organize them into suites, and schedule recurring runs, all without writing code. All tools in this section require the Test Authoring add-on.
 
 ### Test cases
 
@@ -190,7 +214,7 @@ Group test cases into suites and run them together for broader regression covera
 | `Create_a_test_suite` | Create a test suite, optionally with a name, tags, and an initial set of test cases. | "Create a 'Checkout regression' suite from these three test cases." | <span className="mcp-tag">Test Authoring</span> |
 | `List_test_suites` | List your test suites. | "What test suites do I have?" | <span className="mcp-tag">Test Authoring</span> |
 | `Get_a_test_suite` | Retrieve the details of a single test suite, including its test cases. | "What's in the checkout regression suite?" | <span className="mcp-tag">Test Authoring</span> |
-| `Update_a_test_suite` | Update a suite — rename it, change tags, or add and remove test cases. | "Add the guest-checkout test to the regression suite." | <span className="mcp-tag">Test Authoring</span> |
+| `Update_a_test_suite` | Update a suite: rename it, change tags, or add and remove test cases. | "Add the guest-checkout test to the regression suite." | <span className="mcp-tag">Test Authoring</span> |
 | `Delete_a_test_suite` | Delete a test suite. | "Delete the old regression suite." | <span className="mcp-tag">Test Authoring</span> |
 | `Run_all_test_cases_in_a_suite` | Queue runs for every test case in a suite, optionally under a shared build name. | "Run all tests in the checkout regression suite." | <span className="mcp-tag">Test Authoring</span> |
 
@@ -203,5 +227,5 @@ Schedule test suites to run automatically on a recurring cadence.
 | `Create_a_test_schedule` | Create a schedule that runs one or more suites on a cron cadence in a given timezone, with optional start/end dates and a max run count. | "Schedule the regression suite to run every weekday at 6am Eastern." | <span className="mcp-tag">Test Authoring</span> |
 | `List_test_schedules` | List your test schedules. | "What schedules do I have set up?" | <span className="mcp-tag">Test Authoring</span> |
 | `Get_a_test_schedule` | Retrieve the details of a single schedule. | "Show the settings for my nightly schedule." | <span className="mcp-tag">Test Authoring</span> |
-| `Update_a_test_schedule` | Update a schedule — change its cadence, suites, run owner, or enable/pause it. | "Pause the nightly schedule." | <span className="mcp-tag">Test Authoring</span> |
+| `Update_a_test_schedule` | Update a schedule: change its cadence, suites, run owner, or enable or pause it. | "Pause the nightly schedule." | <span className="mcp-tag">Test Authoring</span> |
 | `Delete_a_test_schedule` | Delete a schedule. | "Delete the nightly schedule." | <span className="mcp-tag">Test Authoring</span> |

--- a/docs/sauce-ai/sauce-mcp-tools.md
+++ b/docs/sauce-ai/sauce-mcp-tools.md
@@ -55,11 +55,23 @@ Start, inspect, and end real-device sessions, and interact with the device direc
 | `listSessions` | List your active real-device sessions. | "What sessions do I have open?" | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
 | `deleteSession` | End an active session and release the device. | "Close my current session." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
 | `take_screenshot` | Capture a PNG screenshot of the current device screen. | "Take a screenshot of the current screen." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
-| `tap_element` | Tap an element or screen coordinates on the device. | "Tap the Login button." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
-| `dump_ui` | Return the device's current UI hierarchy for inspection. | "What elements are on the screen right now?" | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
 | `openUrl` | Open a URL on the device. | "Open example.com on the device." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
 | `applyDeviceSettings` | Change device settings such as orientation, locale, or animations. | "Switch the device to dark mode." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
 | `executeShellCommand` | Run an ADB shell command on an Android device. | "Run `pm list packages` on the device." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+
+### UI interaction
+
+Read the on-screen UI and drive the device by tapping, swiping, and typing. These tools are platform-specific.
+
+| Tool | Description | Example prompt | Requirements |
+| --- | --- | --- | --- |
+| `get_source_android` | Read the Android UI source (text, resource-id, bounds) to find elements. Android only. | "What elements are on the screen right now?" | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `get_source_ios` | Read the iOS UI element tree (labels, types, and coordinates). iOS only. | "What's on the screen so I can tap something?" | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `tap_android` | Tap an Android element by selector (text, content-desc, or resource-id). Android only. | "Tap the element with text 'Sign in'." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `tap_ios` | Tap an iOS element by its accessibility label. iOS only. | "Tap the Login button." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `tap_at_ios` | Tap an iOS screen coordinate when no unique label is available. iOS only. | "Tap the menu icon in the top-left corner." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `type_text_ios` | Type text into the focused iOS field. iOS only. | "Type my email address into the field." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
+| `swipe_ios` | Swipe or scroll between two screen coordinates. iOS only. | "Scroll down to the bottom of the page." | <span className="mcp-tag">Private Device</span> <span className="mcp-conn">and</span> <span className="mcp-tag">Real Device Access API</span> |
 
 ### App management
 


### PR DESCRIPTION
## Summary

Post-launch follow-up to the Sauce MCP docs (#3541). Syncs the tool reference with the current hosted server and replaces the endpoint placeholders in the client config snippets with the real endpoint.

## Changes

### MCP Tools reference (`sauce-mcp-tools.md`)

- **Removed** `dump_ui` and `tap_element` — the server no longer exposes these generic tools (they now error); they were split into platform-specific tools.
- **Added a "UI interaction" subsection** with the tools that replaced them: `get_source_android`, `get_source_ios`, `tap_android`, `tap_ios`, `tap_at_ios`, `type_text_ios`, `swipe_ios`.
- **Documented the remaining live tools** that were previously missing:
  - Account & team: `get_team`, `list_team_members`, `lookup_users`, `get_service_account`, `lookup_service_accounts`
  - Appium & WebDriverAgent (new subsection): `startAppiumServer`, `getAppiumServerStatus`, `listAppiumVersions`, `launchWebDriverAgent`, `getWebDriverAgentStatus`
  - Network: `resetNetworkConditions`
  - Jobs, builds & assets: `get_specific_real_device_job_asset`, `get_log_json_file`, `get_build_for_job`, `lookup_jobs_in_build`
  - Storage: `get_storage_groups_settings`
  - Tunnels: `get_tunnel_version_downloads`

  The reference now matches the live server, except the variable/secret tools, which are intentionally left out until that feature is ready.

### Connect Your AI Client (`sauce-mcp-getting-started.md`)

- Replaced the `https://<sauce-mcp-endpoint>` placeholder with the documented `https://mcp.saucelabs.com` endpoint across all client configuration snippets.
