### PR TITLE
docs(playwright): document the workers param and config.yml precedence

### DIFF
--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -1229,6 +1229,25 @@ suites:
 
 ---
 
+#### `workers`
+
+<p><small>| OPTIONAL | INTEGER |</small></p>
+
+Sets the maximum number of parallel worker processes Playwright uses to run the tests within a suite. Defaults to `1`.
+
+```yaml
+suites:
+  - name: "saucy test"
+    params:
+      workers: 4
+```
+
+:::note
+Set `workers` here in `params` — not in your `playwright.config.js|ts`. `saucectl` passes this value to Playwright as a command-line flag, which takes precedence over the `workers` field in your Playwright config file, so the config-file value has no effect when running on Sauce Cloud. This setting controls parallelism _within_ a single suite; to run suites in parallel, see [`concurrency`](#concurrency) and [`numShards`](#numshards).
+:::
+
+---
+
 ### `timeout`
 
 <p><small>| OPTIONAL | DURATION |</small></p>

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -1089,6 +1089,10 @@ suites:
       grepInvert: "should exclude"
 ```
 
+:::note
+Any option you set under `params` is passed to `playwright test` as a command-line flag, which takes precedence over the same setting in your `playwright.config.js|ts`. Options not set here are read from your Playwright config as usual. A few settings are always managed by Sauce Labs regardless of your config file: browser selection, `headless`, video capture, the test reporters, and — when a [tunnel](#tunnel) is active — the proxy.
+:::
+
 #### `browserName`
 
 <p><small>| OPTIONAL | STRING |</small></p>

--- a/docs/web-apps/automated-testing/playwright/yaml.md
+++ b/docs/web-apps/automated-testing/playwright/yaml.md
@@ -1237,7 +1237,7 @@ suites:
 
 <p><small>| OPTIONAL | INTEGER |</small></p>
 
-Sets the maximum number of parallel worker processes Playwright uses to run the tests within a suite. Defaults to `1`.
+Sets the maximum number of parallel worker processes Playwright uses to run the tests in a suite. Defaults to `1`.
 
 ```yaml
 suites:
@@ -1247,7 +1247,7 @@ suites:
 ```
 
 :::note
-Set `workers` here in `params` — not in your `playwright.config.js|ts`. `saucectl` passes this value to Playwright as a command-line flag, which takes precedence over the `workers` field in your Playwright config file, so the config-file value has no effect when running on Sauce Cloud. This setting controls parallelism _within_ a single suite; to run suites in parallel, see [`concurrency`](#concurrency) and [`numShards`](#numshards).
+Set `workers` here in `params` — not in your `playwright.config.js|ts`. `saucectl` passes this value to Playwright as a command-line flag, which takes precedence over the `workers` field in your Playwright config file, so the config-file value has no effect when running on Sauce Cloud. This setting controls parallelism in a single suite; to run multiple suites in parallel, see [`concurrency`](#concurrency) and [`numShards`](#numshards).
 :::
 
 ---


### PR DESCRIPTION
## What

Documents how the Playwright `config.yml` `params` relate to `playwright.config`, and adds the missing `workers` parameter to the [Playwright YAML reference](https://docs.saucelabs.com/web-apps/automated-testing/playwright/yaml/).

## Why

`workers` is honored by `saucectl` but is not documented on the Playwright YAML page. This has caused confusion: setting `workers` in `playwright.config.(js|ts)` has no effect when running on Sauce Cloud, because `saucectl` passes the value to Playwright as a command-line flag (which takes precedence over the config file), and it defaults to `1` — so tests run serially within a suite unless `params.workers` is set.

## Changes

- **New `params` note** — explains that any option under `params` is passed to `playwright test` as a CLI flag and takes precedence over `playwright.config`, that options not set there fall through to the Playwright config, and which settings Sauce Labs always manages (browser, `headless`, video, reporters, and the tunnel proxy).
- **New `workers` subsection** — documents the option, its default of `1`, the `config.yml`-vs-`playwright.config` precedence, and cross-links [`concurrency`](https://docs.saucelabs.com/web-apps/automated-testing/playwright/yaml/#concurrency) / [`numShards`](https://docs.saucelabs.com/web-apps/automated-testing/playwright/yaml/#numshards) to distinguish within-suite from across-suite parallelism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
