### PR TITLE
docs(cypress): document macOS 26 on Apple Silicon

### DIFF
--- a/docs/web-apps/automated-testing/cypress.md
+++ b/docs/web-apps/automated-testing/cypress.md
@@ -40,7 +40,7 @@ Sauce Labs supports the following test configurations for Cypress:
       <td rowspan='2'>15.14.2</td>
       <td rowspan='2'>22</td>
       <td rowspan='2'>✅</td>
-      <td><b>macOS:</b> 11.00, 12, 13, 14*, 15*†</td>
+      <td><b>macOS:</b> 11.00, 12, 13, 14*, 15*†, 26*†</td>
       <td rowspan='2'>Chrome, Firefox, Microsoft Edge, Webkit (Experimental)</td>
       <td rowspan='2'>June 15th, 2027</td>
     </tr>
@@ -182,7 +182,7 @@ Sauce Labs supports the following test configurations for Cypress:
 
 *macOS 14+ requires a Premium subscription. For additional details see [macOS Browser Tests on Apple Silicon](/web-apps/macos-apple-silicon).
 
-† On macOS 15, Cypress supports Chrome, Microsoft Edge, and Webkit (Experimental). Firefox is not supported on macOS 15 due to a macOS firewall issue. Chrome, Firefox, Microsoft Edge, and Webkit (Experimental) all remain available on macOS 11.00, 12, 13, and 14.
+† On macOS 15 and macOS 26, Cypress supports Chrome, Microsoft Edge, and Webkit (Experimental); Firefox is not available (on macOS 15 this is due to a macOS firewall issue). Chrome, Firefox, Microsoft Edge, and Webkit (Experimental) all remain available on macOS 11.00, 12, 13, and 14.
 
 ## How to Get Started
 

--- a/docs/web-apps/automated-testing/cypress/yaml/v1.md
+++ b/docs/web-apps/automated-testing/cypress/yaml/v1.md
@@ -1027,6 +1027,10 @@ suites:
     platformName: "Windows 10"
 ```
 
+:::note
+macOS 14, macOS 15, and macOS 26 run on Apple Silicon (ARM). On these platforms Cypress supports Chrome, Microsoft Edge, and WebKit (experimental); Firefox is not available. Cypress does not use the `armRequired` option—selecting one of these `platformName` values routes the test to Apple Silicon automatically. macOS 14 and above require a Premium subscription; see [macOS Browser Tests on Apple Silicon](/web-apps/macos-apple-silicon).
+:::
+
 ---
 
 ### `screenResolution`


### PR DESCRIPTION
## What
Document Cypress support for **macOS 26 Tahoe** on Apple Silicon (INT-612, part of INT-246).

- `cypress.md`: add the `*macOS 14+ requires a Premium subscription` footnote under the Supported Testing Platforms table (mirrors the Playwright/TestCafe pages).
- `cypress/yaml/v1.md`: add a note to `platformName` explaining that macOS 14/15/26 run on Apple Silicon, which browsers are available (Chrome, Edge, WebKit-experimental; no Firefox), and that Cypress routes via `platformName` (no `armRequired`, which Cypress does not support).

## Why draft
Holding until Cypress macOS 26 is GA (frameworks.yml + IMS shipped; end-to-end validation in progress). Ready to merge once GA is confirmed.
