### PR TITLE
docs: add Sharing Your Accessibility Session section to iOS and Android live accessibility pages

### DIFF
--- a/docs/mobile-apps/features/accessibility-testing/android-talkback.md
+++ b/docs/mobile-apps/features/accessibility-testing/android-talkback.md
@@ -44,6 +44,25 @@ Text-to-speech audio of the focused element is streamed to your browser as you i
 Text-to-speech audio is not available for download once the session is over.
 :::
 
+## Sharing Your Accessibility Session
+
+You can share a live accessibility session so someone else can follow your test in real time. This is useful for collaborative accessibility reviews. An accessibility specialist can drive the session while developers or stakeholders watch along, seeing the focus rectangle move between elements and hearing the same audio feedback as it is announced.
+
+To share your session:
+
+1. Start a Live Testing session on an Android real device and enable TalkBack.
+2. In the live testing toolbar, click the <img src={useBaseUrl('img/live-testing/share-session-icon.png')} alt="Share Session icon" width="25"/> **Share Session** icon to open the **Share Device** window.
+3. Click **Get Link** to generate a shareable link.
+4. Send the link to the person you want to share the session with.
+
+The viewer follows your session live, including the focus rectangle and the streamed TalkBack audio feedback, as you navigate element by element.
+
+:::note
+Viewers must be logged in to a Sauce Labs account to view the shared session.
+:::
+
+For more details on sharing sessions, see [Live Mobile App Testing](/mobile-apps/live-testing/live-mobile-app-testing).
+
 ## Limitations
 
 - TalkBack is only supported on **private devices**. Contact our Support Team to get this configured.

--- a/docs/mobile-apps/features/accessibility-testing/ios-live-accessibility-testing.md
+++ b/docs/mobile-apps/features/accessibility-testing/ios-live-accessibility-testing.md
@@ -125,6 +125,25 @@ When the screen changes (e.g., after tapping into a new page), the inspector:
 2. Repositions the cursor to the first element on the new screen.
 3. Announces the spoken description of the first element.
 
+## Sharing Your Accessibility Session
+
+You can share a live accessibility session so someone else can follow your test in real time. This is useful for collaborative accessibility reviews. An accessibility specialist can drive the session while developers or stakeholders watch along, seeing the focus rectangle move between elements and hearing the same audio feedback as it is announced.
+
+To share your session:
+
+1. Start a Live Testing session on an iOS real device and enable the Accessibility Inspector.
+2. In the live testing toolbar, click the <img src={useBaseUrl('img/live-testing/share-session-icon.png')} alt="Share Session icon" width="25"/> **Share Session** icon to open the **Share Device** window.
+3. Click **Get Link** to generate a shareable link.
+4. Send the link to the person you want to share the session with.
+
+The viewer follows your session live, including the focus rectangle and the streamed audio feedback, as you navigate element by element.
+
+:::note
+Viewers must be logged in to a Sauce Labs account to view the shared session.
+:::
+
+For more details on sharing sessions, see [Live Mobile App Testing](/mobile-apps/live-testing/live-mobile-app-testing).
+
 ## Limitations and Known Issues
 
 ### Screen Change and Focus Sync


### PR DESCRIPTION
### Description
Adds a new \`Sharing Your Accessibility Session\` section to both mobile live accessibility testing pages:
- \`docs/mobile-apps/features/accessibility-testing/ios-live-accessibility-testing.md\`
- \`docs/mobile-apps/features/accessibility-testing/android-talkback.md\`

The section explains how to share a live accessibility session using **Share Session** > **Get Link**, and clarifies that the viewer follows the session live, including the focus rectangle and the streamed audio feedback (TalkBack audio on Android). It includes step-by-step instructions, the Share Session toolbar icon, a note that viewers must be logged in, and a link to the Live Mobile App Testing page. The section is placed directly above Limitations on both pages.

### Motivation and Context
Users testing accessibility on real devices were not aware that these sessions can be shared for real-time collaboration. This lets an accessibility specialist drive a session while developers or stakeholders watch the accessibility navigation and hear the screen-reader audio live, supporting collaborative accessibility reviews.

### Types of Changes
- [x] Documentation fix (typos, incorrect content, missing content, etc.)