### PR TITLE
docs: Sauce MCP region header + mark Cursor/Antigravity IDE plugins as coming soon

### DIFF
--- a/docs/ide-plugins.md
+++ b/docs/ide-plugins.md
@@ -2,7 +2,7 @@
 id: ide-plugins
 title: Sauce Labs IDE Plugins
 sidebar_label: Overview
-description: Test on Sauce Labs real devices and author tests with AI without leaving your IDE. Available for VS Code, Cursor, and Antigravity, with IntelliJ IDEA and Android Studio coming soon.
+description: Test on Sauce Labs real devices and author tests with AI without leaving your IDE. Available for VS Code, with Cursor, Antigravity, IntelliJ IDEA, and Android Studio coming soon.
 keywords:
   - ide plugin
   - vs code extension
@@ -32,17 +32,17 @@ The Sauce Labs IDE plugin brings Real Device Cloud and AI Test Authoring directl
 
 ## Supported IDEs
 
-The plugin is available today for **VS Code** and VS Code-based editors, including **Cursor** and **Antigravity**:
+The plugin is available today for **VS Code**:
 
 <div className="client-grid">
   <div className="client-tile"><img src={useBaseUrl('img/ide-plugins/vscode.png')} alt="Visual Studio Code logo" /><span>VS Code</span></div>
-  <div className="client-tile"><img src={useBaseUrl('img/ide-plugins/cursor.svg')} alt="Cursor logo" /><span>Cursor</span></div>
-  <div className="client-tile"><img src={useBaseUrl('img/ide-plugins/antigravity.png')} alt="Antigravity logo" /><span>Antigravity</span></div>
 </div>
 
-Support for **IntelliJ IDEA** and **Android Studio** (and other JetBrains-based IDEs) is coming soon:
+Support for **Cursor**, **Antigravity**, **IntelliJ IDEA**, and **Android Studio** (and other VS Code- and JetBrains-based IDEs) is coming soon:
 
 <div className="client-grid">
+  <div className="client-tile"><img src={useBaseUrl('img/ide-plugins/cursor.svg')} alt="Cursor logo" /><span>Cursor (coming soon)</span></div>
+  <div className="client-tile"><img src={useBaseUrl('img/ide-plugins/antigravity.png')} alt="Antigravity logo" /><span>Antigravity (coming soon)</span></div>
   <div className="client-tile"><img src={useBaseUrl('img/ide-plugins/intellij.svg')} alt="IntelliJ IDEA logo" /><span>IntelliJ IDEA (coming soon)</span></div>
   <div className="client-tile"><img src={useBaseUrl('img/ide-plugins/android-studio.svg')} alt="Android Studio logo" /><span>Android Studio (coming soon)</span></div>
 </div>

--- a/docs/ide-plugins/installation.md
+++ b/docs/ide-plugins/installation.md
@@ -2,7 +2,7 @@
 id: installation
 title: Install the Sauce Labs IDE Plugin
 sidebar_label: Installation and Sign In
-description: Install the Sauce Labs plugin in VS Code, Cursor, or Antigravity, sign in with your Sauce Labs credentials, and start your first real device session.
+description: Install the Sauce Labs plugin in VS Code, sign in with your Sauce Labs credentials, and start your first real device session.
 keywords:
   - install
   - vs code extension
@@ -12,15 +12,13 @@ keywords:
   - sauce labs plugin
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 This page walks you through installing the Sauce Labs plugin in your IDE, signing in, and starting your first live device session.
 
 ## Prerequisites
 
-- **A supported IDE**: VS Code 1.85 or newer, or a VS Code-based editor such as Cursor or Antigravity. IntelliJ IDEA and Android Studio support is coming soon.
+- **A supported IDE**: VS Code 1.85 or newer. Support for Cursor, Antigravity, IntelliJ IDEA, and Android Studio is coming soon.
 - **A Sauce Labs account** in one of the supported data centers (US West, US East, or EU Central).
 - **Your Sauce Labs username and access key.** Both are available from [Sauce Labs user settings](https://app.saucelabs.com/user-settings). See [Managing User Information](/basics/acct-team-mgmt/managing-user-info).
 - **FFmpeg on your `PATH`** (optional). Only required for MP4 session recording. Screenshots, log streaming, and everything else work without it.
@@ -32,44 +30,12 @@ To start live device sessions you also need **private (dedicated) devices** and 
 
 ## Install the plugin
 
-<Tabs
-  defaultValue="vscode"
-  values={[
-    {label: 'VS Code', value: 'vscode'},
-    {label: 'Cursor', value: 'cursor'},
-    {label: 'Antigravity', value: 'antigravity'},
-  ]}>
-
-<TabItem value="vscode">
-
 1. Open VS Code and go to the **Extensions** view (`Cmd/Ctrl + Shift + X`).
 2. Search for **Sauce Labs** and open the listing from the verified publisher **Sauce Labs**.
 3. Click **Install**.
 4. After installation, the **Sauce Labs** icon appears in the Activity Bar. Reload VS Code if prompted.
 
 <a href={useBaseUrl('img/ide-plugins/install-marketplace.png')} target="_blank" rel="noopener noreferrer"><img src={useBaseUrl('img/ide-plugins/install-marketplace.png')} alt="The Sauce Labs extension listing in the VS Code Extensions view, showing the Real Device Cloud and AI Test Authoring feature descriptions" /></a>
-
-</TabItem>
-
-<TabItem value="cursor">
-
-1. Open Cursor and go to the **Extensions** view (`Cmd/Ctrl + Shift + X`).
-2. Search for **Sauce Labs** and open the listing from the publisher **Sauce Labs**.
-3. Click **Install**.
-4. After installation, the **Sauce Labs** icon appears in the Activity Bar. Reload Cursor if prompted.
-
-</TabItem>
-
-<TabItem value="antigravity">
-
-1. Open Antigravity and go to the **Extensions** view (`Cmd/Ctrl + Shift + X`).
-2. Search for **Sauce Labs** and open the listing from the publisher **Sauce Labs**.
-3. Click **Install**.
-4. After installation, the **Sauce Labs** icon appears in the Activity Bar. Reload Antigravity if prompted.
-
-</TabItem>
-
-</Tabs>
 
 ## Sign in
 

--- a/docs/sauce-ai/sauce-mcp-getting-started.md
+++ b/docs/sauce-ai/sauce-mcp-getting-started.md
@@ -37,6 +37,15 @@ Authentication uses HTTP Basic Auth. The credential is your `username:access_key
 
 `export SAUCE_AUTH_TOKEN=$(echo -n "your_username:your_access_key" | base64)`
 
+## Select your data center
+
+Sauce MCP uses a single endpoint (`https://mcp.saucelabs.com`) for all data centers. The data center your requests are routed to is selected per connection through the optional `X-Sauce-Region` request header.
+
+Accepted values are the canonical region keys `US_WEST`, `US_EAST`, and `EU_CENTRAL` (case-insensitive). If the header is missing or unrecognized, the server falls back to its default region (`US_WEST`) and logs a warning.
+
+To switch regions, update the `X-Sauce-Region` header in your client config and reconnect. Switching mid-session is not supported. If a listing tool returns empty results unexpectedly, ask the agent to call `get_active_region` to confirm which data center it is connected to.
+
+The configuration examples below include the `X-Sauce-Region` header. Replace `<REGION>` with `US_WEST`, `US_EAST`, or `EU_CENTRAL`. You can omit the header entirely to use the default (`US_WEST`).
 
 ## Configure your client
 
@@ -62,7 +71,8 @@ You can connect Claude Code in either of two ways.
 
 ```bash
 claude mcp add --transport http sauce-labs https://mcp.saucelabs.com \
-  --header "Authorization: Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
+  --header "Authorization: Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>" \
+  --header "X-Sauce-Region: <REGION>"
 ```
 
 **Option 2: Add it with a config file**
@@ -76,7 +86,8 @@ Add the server to a `.mcp.json` file in your project root (or to your user-level
       "type": "http",
       "url": "https://mcp.saucelabs.com",
       "headers": {
-        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
+        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>",
+        "X-Sauce-Region": "<REGION>"
       }
     }
   }
@@ -101,7 +112,9 @@ Edit `claude_desktop_config.json` (Settings → Developer → Edit Config). Clau
         "mcp-remote",
         "https://mcp.saucelabs.com",
         "--header",
-        "Authorization: Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
+        "Authorization: Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>",
+        "--header",
+        "X-Sauce-Region: <REGION>"
       ]
     }
   }
@@ -121,7 +134,8 @@ Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per project):
     "sauce-labs": {
       "url": "https://mcp.saucelabs.com",
       "headers": {
-        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
+        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>",
+        "X-Sauce-Region": "<REGION>"
       }
     }
   }
@@ -140,7 +154,8 @@ Edit your Windsurf MCP config (`~/.codeium/windsurf/mcp_config.json`):
     "sauce-labs": {
       "serverUrl": "https://mcp.saucelabs.com",
       "headers": {
-        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
+        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>",
+        "X-Sauce-Region": "<REGION>"
       }
     }
   }
@@ -160,7 +175,8 @@ Create `.vscode/mcp.json` in your workspace:
       "type": "http",
       "url": "https://mcp.saucelabs.com",
       "headers": {
-        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
+        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>",
+        "X-Sauce-Region": "<REGION>"
       }
     }
   }
@@ -181,7 +197,8 @@ In your JetBrains IDE (IntelliJ IDEA and others), open **Settings | Tools | AI A
     "sauce-labs": {
       "url": "https://mcp.saucelabs.com",
       "headers": {
-        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
+        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>",
+        "X-Sauce-Region": "<REGION>"
       }
     }
   }
@@ -199,7 +216,8 @@ In Antigravity, open the MCP settings and add a server, or edit its MCP configur
     "sauce-labs": {
       "serverUrl": "https://mcp.saucelabs.com",
       "headers": {
-        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
+        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>",
+        "X-Sauce-Region": "<REGION>"
       }
     }
   }
@@ -217,7 +235,8 @@ Edit `~/.gemini/settings.json`:
     "sauce-labs": {
       "httpUrl": "https://mcp.saucelabs.com",
       "headers": {
-        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>"
+        "Authorization": "Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>",
+        "X-Sauce-Region": "<REGION>"
       }
     }
   }
@@ -233,6 +252,7 @@ Add an extension in Goose with these settings:
 - **Type:** Remote (Streamable HTTP)
 - **Endpoint:** `https://mcp.saucelabs.com`
 - **Header:** `Authorization: Basic <BASE64_OF_USERNAME_COLON_ACCESSKEY>`
+- **Header:** `X-Sauce-Region: <REGION>`
 
 </TabItem>
 
@@ -249,5 +269,5 @@ If the connection works, the agent calls Sauce MCP and returns your account deta
 ## Troubleshooting
 
 - **Authentication failed / 401:** Recheck your username and access key and confirm the `Authorization` header is correctly Base64-encoded.
-- **Empty or unexpected results:** Confirm you are connecting to the endpoint for the data center where your account and devices live.
+- **Empty or unexpected results:** Confirm your `X-Sauce-Region` header points to the data center where your account and devices live. Ask the agent to call `get_active_region` to check which data center it is connected to. Remember that region changes require reconnecting; mid-session switching is not supported.
 - **Client can't reach the server:** Confirm the endpoint URL is correct and that your client supports remote Streamable HTTP servers (Claude Desktop uses the `mcp-remote` bridge above).


### PR DESCRIPTION
## Sauce MCP: document the X-Sauce-Region header

The Sauce MCP getting started guide never documented the `X-Sauce-Region` header, which is how the hosted MCP server routes requests to a data center. The docs implied a per-data-center endpoint model, which is incorrect: there is a single endpoint (`https://mcp.saucelabs.com`) and region is selected per connection via the `X-Sauce-Region` request header. This brings the docs in line with the latest MCP repo README.

- Add a **Select your data center** section covering:
  - Single endpoint with header-based region routing
  - Accepted values (`US_WEST`, `US_EAST`, `EU_CENTRAL`, case-insensitive)
  - Default region (`US_WEST`) and fallback-with-warning behavior
  - No mid-session switching (update header and reconnect)
  - Tip to call `get_active_region` when results look wrong
- Add `X-Sauce-Region: <REGION>` to every client config example: Claude Code (CLI + JSON), Claude Desktop, Cursor, Windsurf, VS Code, IntelliJ, Antigravity, Gemini CLI, and Goose
- Fix the troubleshooting note that incorrectly pointed users to a per-data-center endpoint; it now references the `X-Sauce-Region` header and `get_active_region`

## IDE Plugins: mark Cursor and Antigravity as coming soon

Only VS Code is available today.

- **Overview** (`docs/ide-plugins.md`): move Cursor and Antigravity from the available list into the coming soon list, with `(coming soon)` labels on their logos
- **Installation** (`docs/ide-plugins/installation.md`): remove the Cursor and Antigravity install tabs (VS Code only now), update prerequisites and description, and drop the unused Tabs imports

## Notes

- MCP source of truth: latest MCP repo README
- Files changed: `docs/sauce-ai/sauce-mcp-getting-started.md`, `docs/ide-plugins.md`, `docs/ide-plugins/installation.md`