### PR TITLE
Update Error Reporting code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 # The folders are ordered as follows:
 
 # Dev/API:
-/docs/dev/api/error-reporting/ @rick-bt @sararasmussen
+/docs/dev/api/error-reporting/ @anupam-sl @neerav-mittal @sararasmussen
 /docs/dev/api/rdc/ @saucelabs/rdcdev
 /docs/dev/api/storage/ @saucelabs/rdcdev
 
@@ -22,7 +22,7 @@
 /docs/dev/cli/ @saucelabs/devx
 
 # Backtrace/Error Reporting
-/docs/error-reporting/ @rick-bt @sararasmussen @rahuljain-prog
+/docs/error-reporting/ @anupam-sl @neerav-mittal @sararasmussen
 
 # Sauce Orchestrate
 /docs/orchestrate/ @saucelabs/sauce-orchestrate-team


### PR DESCRIPTION
Updates the CODEOWNERS entries for the Error Reporting documentation to @anupam-sl, @neerav-mittal, and @sararasmussen.

- `/docs/error-reporting/`
- `/docs/dev/api/error-reporting/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)