### PR TITLE
Bump Sauce Connect version references to 5.5.2

### DIFF
--- a/docs/basics/integrations/gitlab.md
+++ b/docs/basics/integrations/gitlab.md
@@ -119,7 +119,7 @@ for your account.
 
 ```yaml title="gitlab-sc.yml"
 script:
-  - curl -L -o sauce-connect.tar.gz https://saucelabs.com/downloads/sauce-connect/5.2.2/sauce-connect-5.2.2_linux.x86_64.tar.gz
+  - curl -L -o sauce-connect.tar.gz https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.x86_64.tar.gz
   - mkdir -p ./sauce-connect && tar -xzf sauce-connect.tar.gz -C ./sauce-connect
   - export PATH="./sauce-connect:$PATH"
   # The --api-address flag starts a local API server to enable readiness checks
@@ -149,7 +149,7 @@ build_test_windows:
   before_script:
     # Getting Sauce Connect ready
     - echo "Sauce Connect on Windows"
-    - Invoke-WebRequest -Uri "https://saucelabs.com/downloads/sauce-connect/5.5.0/sauce-connect-5.5.0_windows.x86_64.zip" -OutFile "sauce-connect.zip"
+    - Invoke-WebRequest -Uri "https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_windows.x86_64.zip" -OutFile "sauce-connect.zip"
     - Expand-Archive -Path "sauce-connect.zip" -DestinationPath ".\sauce-connect"
     - $env:PATH = ".\sauce-connect;$env:PATH"
     # The --api-address flag starts a local API server to enable readiness checks

--- a/docs/secure-connections/sauce-connect-4.md
+++ b/docs/secure-connections/sauce-connect-4.md
@@ -4,8 +4,11 @@ title: Sauce Connect Proxy 4
 sidebar_label: Overview
 ---
 
-:::caution Important Notice: Sauce Connect 4 is reaching End of Support
-Sauce Connect 4 will reach **End of Support** on **January 31, 2026**. Sauce Labs will continue to accept traffic from Sauce Connect v4, but customers must upgrade to [Sauce Connect 5](/secure-connections/sauce-connect-5/migrating) to stay supported and receive fixes and improvements. We strongly recommend upgrading as soon as possible.
+:::caution Important Notice: Sauce Connect 4 End of Support and End of Life
+- **End of Support:** January 31, 2026
+- **End of Life:** July 31, 2026
+
+After July 31, 2026, Sauce Labs will no longer accept traffic from Sauce Connect 4. Customers must upgrade to [Sauce Connect 5](/secure-connections/sauce-connect-5/migrating) to continue using Sauce Connect Proxy. Migrate to Sauce Connect 5 now.
 :::
 
 If your company has firewall rules that limit your ability to run tests on Sauce Labs, you can use our Sauce Connect Proxy feature to connect to Sauce Labs in the cloud without exposing your company's IT infrastructure to security risks.

--- a/docs/secure-connections/sauce-connect-4/lifecycle.md
+++ b/docs/secure-connections/sauce-connect-4/lifecycle.md
@@ -6,8 +6,11 @@ sidebar_label: Lifecycle
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-:::caution Important Notice: Sauce Connect 4 is reaching End of Support
-Sauce Connect 4 will reach **End of Support** on **January 31, 2026**. Sauce Labs will continue to accept traffic from Sauce Connect v4, but customers must upgrade to [Sauce Connect 5](/secure-connections/sauce-connect-5/migrating) to stay supported and receive fixes and improvements. We strongly recommend upgrading as soon as possible.
+:::caution Important Notice: Sauce Connect 4 End of Support and End of Life
+- **End of Support:** January 31, 2026
+- **End of Life:** July 31, 2026
+
+After July 31, 2026, Sauce Labs will no longer accept traffic from Sauce Connect 4. Customers must upgrade to [Sauce Connect 5](/secure-connections/sauce-connect-5/migrating) to continue using Sauce Connect Proxy. Migrate to Sauce Connect 5 now.
 :::
 
 <table>

--- a/docs/secure-connections/sauce-connect-5/installation.md
+++ b/docs/secure-connections/sauce-connect-5/installation.md
@@ -17,7 +17,7 @@ Visit the following pages for installation instructions for your platform:
 
 If you prefer to perform a custom installation, you can download the Sauce Connect binaries from the following links.
 
-SHA256 checksums are available [on this page](https://saucelabs.com/downloads/sauce-connect/5.5.1/checksums).
+SHA256 checksums are available [on this page](https://saucelabs.com/downloads/sauce-connect/5.5.2/checksums).
 
 <table>
   <tr>
@@ -27,51 +27,51 @@ SHA256 checksums are available [on this page](https://saucelabs.com/downloads/sa
   <tr>
     <td rowspan="3">Linux x86_64</td>
     <td>
-      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_linux.x86_64.tar.gz">https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_linux.x86_64.tar.gz</a>
+      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.x86_64.tar.gz">https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.x86_64.tar.gz</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect_5.5.1.linux_amd64.deb">https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect_5.5.1.linux_amd64.deb</a>
+      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect_5.5.2.linux_amd64.deb">https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect_5.5.2.linux_amd64.deb</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_linux.x86_64.rpm">https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_linux.x86_64.rpm</a>
+      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.x86_64.rpm">https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.x86_64.rpm</a>
     </td>
   </tr>
   <tr>
     <td rowspan="3">Linux arm64</td>
     <td>
-      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_linux.aarch64.tar.gz">https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_linux.aarch64.tar.gz</a>
+      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.aarch64.tar.gz">https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.aarch64.tar.gz</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect_5.5.1.linux_arm64.deb">https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect_5.5.1.linux_arm64.deb</a>
+      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect_5.5.2.linux_arm64.deb">https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect_5.5.2.linux_arm64.deb</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_linux.aarch64.rpm">https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_linux.aarch64.rpm</a>
+      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.aarch64.rpm">https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.aarch64.rpm</a>
     </td>
   </tr>
   <tr>
     <td>macOS</td>
     <td>
-      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_darwin.all.zip">https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_darwin.all.zip</a>
+      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_darwin.all.zip">https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_darwin.all.zip</a>
     </td>
   </tr>
   <tr>
     <td>Windows x86_64</td>
     <td>
-      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_windows.x86_64.zip">https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_windows.x86_64.zip</a>
+      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_windows.x86_64.zip">https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_windows.x86_64.zip</a>
     </td>
   </tr>
   <tr>
     <td>Windows arm64</td>
     <td>
-      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_windows.aarch64.zip">https://saucelabs.com/downloads/sauce-connect/5.5.1/sauce-connect-5.5.1_windows.aarch64.zip</a>
+      <a href="https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_windows.aarch64.zip">https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_windows.aarch64.zip</a>
     </td>
   </tr>
 </table>

--- a/docs/secure-connections/sauce-connect-5/installation/linux.md
+++ b/docs/secure-connections/sauce-connect-5/installation/linux.md
@@ -24,7 +24,7 @@ defaultValue="ARM64"
   <TabItem value="ARM64">
 
 ```bash
-curl -L -o sauce-connect.deb https://saucelabs.com/downloads/sauce-connect/5.5.0/sauce-connect_5.5.0.linux_arm64.deb
+curl -L -o sauce-connect.deb https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect_5.5.2.linux_arm64.deb
 sudo dpkg -i sauce-connect.deb
 ```
   </TabItem>
@@ -32,7 +32,7 @@ sudo dpkg -i sauce-connect.deb
   <TabItem value="x86-64">
 
 ```bash
-curl -L -o sauce-connect.deb https://saucelabs.com/downloads/sauce-connect/5.5.0/sauce-connect_5.5.0.linux_amd64.deb
+curl -L -o sauce-connect.deb https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect_5.5.2.linux_amd64.deb
 sudo dpkg -i sauce-connect.deb
 ```
 
@@ -83,14 +83,14 @@ defaultValue="ARM64"
   <TabItem value="ARM64">
 
 ```bash
-sudo rpm -i https://saucelabs.com/downloads/sauce-connect/5.5.0/sauce-connect-5.5.0_linux.aarch64.rpm
+sudo rpm -i https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.aarch64.rpm
 ```
   </TabItem>
 
   <TabItem value="x86-64">
 
 ```bash
-sudo rpm -i https://saucelabs.com/downloads/sauce-connect/5.5.0/sauce-connect-5.5.0_linux.x86_64.rpm
+sudo rpm -i https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.x86_64.rpm
 ```
 
   </TabItem>
@@ -136,7 +136,7 @@ defaultValue="ARM64"
   <TabItem value="ARM64">
 
 ```bash
-curl -L -o sauce-connect.tar.gz https://saucelabs.com/downloads/sauce-connect/5.5.0/sauce-connect-5.5.0_linux.aarch64.tar.gz
+curl -L -o sauce-connect.tar.gz https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.aarch64.tar.gz
 sudo mkdir -p /opt/sauce-connect
 sudo tar -C /opt/sauce-connect -xzf sauce-connect.tar.gz
 ```
@@ -145,7 +145,7 @@ sudo tar -C /opt/sauce-connect -xzf sauce-connect.tar.gz
   <TabItem value="x86-64">
 
 ```bash
-curl -L -o sauce-connect.tar.gz https://saucelabs.com/downloads/sauce-connect/5.5.0/sauce-connect-5.5.0_linux.x86_64.tar.gz
+curl -L -o sauce-connect.tar.gz https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_linux.x86_64.tar.gz
 sudo mkdir -p /opt/sauce-connect
 sudo tar -C /opt/sauce-connect -xzf sauce-connect.tar.gz
 ```

--- a/docs/secure-connections/sauce-connect-5/installation/macos.md
+++ b/docs/secure-connections/sauce-connect-5/installation/macos.md
@@ -49,7 +49,7 @@ Sauce Connect provides `.zip` package with a signed binary that can be used on a
 ### Unpack the zip file
 
 ```bash
-curl -L -o sauce-connect.zip https://saucelabs.com/downloads/sauce-connect/5.5.0/sauce-connect-5.5.0_darwin.all.zip
+curl -L -o sauce-connect.zip https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_darwin.all.zip
 sudo mkdir -p /opt/sauce-connect
 sudo unzip -d /opt/sauce-connect sauce-connect.zip
 ```

--- a/docs/secure-connections/sauce-connect-5/installation/windows.md
+++ b/docs/secure-connections/sauce-connect-5/installation/windows.md
@@ -82,7 +82,7 @@ Sauce Connect provides `.zip` package that can be used on older Windows versions
 
 ```powershell
 mkdir C:\sauce-connect
-Invoke-WebRequest -Uri https://saucelabs.com/downloads/sauce-connect/5.5.0/sauce-connect-5.5.0_windows.x86_64.zip -OutFile sauce-connect.zip
+Invoke-WebRequest -Uri https://saucelabs.com/downloads/sauce-connect/5.5.2/sauce-connect-5.5.2_windows.x86_64.zip -OutFile sauce-connect.zip
 Expand-Archive -Path sauce-connect.zip -DestinationPath C:\sauce-connect
 Rename-Item -Path C:\sauce-connect\sauce-connect.exe -NewName C:\sauce-connect\sauce-connect.exe
 ```


### PR DESCRIPTION
Updates installation and integration docs to reference sc/v5.5.2. Includes a follow-up bump of the stale 5.2.2 example in the GitLab integration guide.

<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `sauce-docs` project!**
**A well described pull request helps maintainers quickly review and merge your change**

Before submitting your PR, please check our [contributing](https://github.com/saucelabs/sauce-docs/blob/main/docs/contributing.md)
guidelines, applied for this repository. Avoid large PRs, help reviewers by making them as simple
and short as possible. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
