### PR TITLE
Add Adam Cronin as an Error Reporting code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 # The folders are ordered as follows:
 
 # Dev/API:
-/docs/dev/api/error-reporting/ @anupam-sl @neerav-mittal @sararasmussen
+/docs/dev/api/error-reporting/ @adamcronin42 @anupam-sl @neerav-mittal @sararasmussen
 /docs/dev/api/rdc/ @saucelabs/rdcdev
 /docs/dev/api/storage/ @saucelabs/rdcdev
 
@@ -22,7 +22,7 @@
 /docs/dev/cli/ @saucelabs/devx
 
 # Backtrace/Error Reporting
-/docs/error-reporting/ @anupam-sl @neerav-mittal @sararasmussen
+/docs/error-reporting/ @adamcronin42 @anupam-sl @neerav-mittal @sararasmussen
 
 # Sauce Orchestrate
 /docs/orchestrate/ @saucelabs/sauce-orchestrate-team


### PR DESCRIPTION
Adds `@adamcronin42` to the CODEOWNERS entries for the Error Reporting documentation, alongside the existing owners.

- `/docs/error-reporting/`
- `/docs/dev/api/error-reporting/`