### PR TITLE
RDC: document the allowCacheFallback capability for cached real device sessions

### DIFF
--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -1430,7 +1430,7 @@ capabilities.setCapability("sauce:options", sauceOptions);
 
 Controls what happens when a test that asks for a cached device cannot reuse it. Default value is `false`. Only has an effect when paired with [`cacheId`](#cacheid).
 
-By default, if an error occurs while starting the Appium session on the cached device, the session fails immediately with an error describing the issue and the device is deallocated. Sauce Labs does not retry, because a retry resets the device and would silently break the app state that `cacheId` and [`noReset`](#appiumnoreset) preserve.
+A session start that fails on a cached device because of a transient server-side error is always retried on the same device, so the cached session survives. By default, if it still cannot be started, the session fails with an error describing the issue and the device is deallocated. Sauce Labs does not fall back to a different device, because that resets it and would silently break the app state that `cacheId` and [`noReset`](#appiumnoreset) preserve.
 
 Set `allowCacheFallback` to `true` if you use `cacheId` only to save device cleaning time and do not depend on your app's state being preserved. Sauce Labs then releases the cached device and retries on another available device matching your device query — which may be the same device after cleaning. The session can still start, but on a freshly cleaned device: your app is reinstalled, its data is gone, and the cached session ends.
 

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -1432,7 +1432,7 @@ Controls what happens when a test that asks for a cached device cannot reuse it.
 
 A session start that fails on a cached device because of a transient server-side error is retried on the same device, so the cached session survives. By default, if it still cannot be started, the session fails with an error describing the issue and the device is deallocated. Sauce Labs does not fall back to a different device, because that resets it and would silently break the app state that `cacheId` and [`noReset`](#appiumnoreset) preserve.
 
-Set `allowCacheFallback` to `true` if you use `cacheId` only to save device cleaning time and do not depend on your app's state being preserved. Sauce Labs then releases the cached device and retries on another available device matching your device query — which may be the same device after cleaning. The session can still start, but on a freshly cleaned device: your app is reinstalled, its data is gone, and the cached session ends.
+Set `allowCacheFallback` to `true` if losing the app's state does not break your tests. Sauce Labs then releases the cached device and retries on another available device matching your device query — which may be the same device after cleaning. The session can still start, but on a freshly cleaned device: your app is reinstalled, its data is gone, and the cached session ends.
 
 ```java
 MutableCapabilities capabilities = new MutableCapabilities();

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -1410,6 +1410,8 @@ and specific `sauce:options` like:
 
 Suitable for test setups that require the app's state to be reset between tests. Can be used for both [**static allocation and dynamic allocation**](/mobile-apps/supported-devices/#static-and-dynamic-device-allocation).
 
+If the cached device cannot be reused, the session fails instead of falling back to another device. See [`allowCacheFallback`](#allowcachefallback) to change that behavior.
+
 We recommend reviewing [Device Management for Real Devices](/mobile-apps/supported-devices) to learn more about how Sauce Labs manages device allocation, device caching, and device cleanup.
 
 ```java
@@ -1417,6 +1419,27 @@ MutableCapabilities capabilities = new MutableCapabilities();
 //...
 MutableCapabilities sauceOptions = new MutableCapabilities();
 sauceOptions.setCapability("cacheId", "Wou0L9usPI9v");
+capabilities.setCapability("sauce:options", sauceOptions);
+```
+
+---
+
+### `allowCacheFallback`
+
+<p><small>| OPTIONAL | BOOLEAN | <span className="sauceGreen">Real Devices Only</span> |</small></p>
+
+Controls what happens when a test that asks for a cached device cannot reuse it. Default value is `false`. Only has an effect when paired with [`cacheId`](#cacheid).
+
+By default, if an error occurs while starting the Appium session on the cached device, the session fails immediately with an error describing the issue and the device is deallocated. Sauce Labs does not retry, because a retry resets the device and would silently break the app state that `cacheId` and [`noReset`](#appiumnoreset) preserve.
+
+Set `allowCacheFallback` to `true` if you use `cacheId` only to save device cleaning time and do not depend on your app's state being preserved. Sauce Labs then releases the cached device and retries on another available device matching your device query — which may be the same device after cleaning. The session can still start, but on a freshly cleaned device: your app is reinstalled, its data is gone, and the cached session ends.
+
+```java
+MutableCapabilities capabilities = new MutableCapabilities();
+//...
+MutableCapabilities sauceOptions = new MutableCapabilities();
+sauceOptions.setCapability("cacheId", "Wou0L9usPI9v");
+sauceOptions.setCapability("allowCacheFallback", true);
 capabilities.setCapability("sauce:options", sauceOptions);
 ```
 

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -1430,7 +1430,7 @@ capabilities.setCapability("sauce:options", sauceOptions);
 
 Controls what happens when a test that asks for a cached device cannot reuse it. Default value is `false`. Only has an effect when paired with [`cacheId`](#cacheid).
 
-A session start that fails on a cached device because of a transient server-side error is always retried on the same device, so the cached session survives. By default, if it still cannot be started, the session fails with an error describing the issue and the device is deallocated. Sauce Labs does not fall back to a different device, because that resets it and would silently break the app state that `cacheId` and [`noReset`](#appiumnoreset) preserve.
+A session start that fails on a cached device because of a transient server-side error is retried on the same device, so the cached session survives. By default, if it still cannot be started, the session fails with an error describing the issue and the device is deallocated. Sauce Labs does not fall back to a different device, because that resets it and would silently break the app state that `cacheId` and [`noReset`](#appiumnoreset) preserve.
 
 Set `allowCacheFallback` to `true` if you use `cacheId` only to save device cleaning time and do not depend on your app's state being preserved. Sauce Labs then releases the cached device and retries on another available device matching your device query — which may be the same device after cleaning. The session can still start, but on a freshly cleaned device: your app is reinstalled, its data is gone, and the cached session ends.
 

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -1430,7 +1430,7 @@ capabilities.setCapability("sauce:options", sauceOptions);
 
 Controls the behaviour of a test in a cached device session in case of an unrecoverable error. Default value is `false`. Only has an effect when paired with [`cacheId`](#cacheid).
 
-When a test that is part of a cached device session fails to start due of a transient server-side error it is retried on the same device, so the cached session survives. By default, if the retry mechanism can not recover the error, the test fails with an message describing the issue and the device is deallocated. Sauce Labs does not fall back to a different device, in order to avoid silently breaking the app state that `cacheId` and [`noReset`](#appiumnoreset) preserve.
+When a test that is part of a cached device session fails to start due of a transient server-side error it is retried on the same device, so the cached session survives. By default, if the retry mechanism can not recover the error, the test fails with an message describing the issue and the device is deallocated. Sauce Labs does not fall back to a different device, to avoid silently breaking the app state that `cacheId` and [`noReset`](#appiumnoreset) preserve.
 
 Set `allowCacheFallback` to `true` if you would rather try a new device allocation instead of failing the test in this situation. Sauce Labs then releases the cached device and retries on another available device matching your device query — which may be the same device after cleaning. The session can still start, but on a freshly cleaned device: your app is reinstalled, its data is gone, and the cached session ends.
 

--- a/docs/dev/test-configuration-options.md
+++ b/docs/dev/test-configuration-options.md
@@ -1410,7 +1410,7 @@ and specific `sauce:options` like:
 
 Suitable for test setups that require the app's state to be reset between tests. Can be used for both [**static allocation and dynamic allocation**](/mobile-apps/supported-devices/#static-and-dynamic-device-allocation).
 
-If the cached device cannot be reused, the session fails instead of falling back to another device. See [`allowCacheFallback`](#allowcachefallback) to change that behavior.
+If the cached device cannot be reused because of an unrecoverable error, the session fails immediatly. If needed, this behaviour can be changed. See [`allowCacheFallback`](#allowcachefallback) for details.
 
 We recommend reviewing [Device Management for Real Devices](/mobile-apps/supported-devices) to learn more about how Sauce Labs manages device allocation, device caching, and device cleanup.
 
@@ -1428,11 +1428,11 @@ capabilities.setCapability("sauce:options", sauceOptions);
 
 <p><small>| OPTIONAL | BOOLEAN | <span className="sauceGreen">Real Devices Only</span> |</small></p>
 
-Controls what happens when a test that asks for a cached device cannot reuse it. Default value is `false`. Only has an effect when paired with [`cacheId`](#cacheid).
+Controls the behaviour of a test in a cached device session in case of an unrecoverable error. Default value is `false`. Only has an effect when paired with [`cacheId`](#cacheid).
 
-A session start that fails on a cached device because of a transient server-side error is retried on the same device, so the cached session survives. By default, if it still cannot be started, the session fails with an error describing the issue and the device is deallocated. Sauce Labs does not fall back to a different device, because that resets it and would silently break the app state that `cacheId` and [`noReset`](#appiumnoreset) preserve.
+When a test that is part of a cached device session fails to start due of a transient server-side error it is retried on the same device, so the cached session survives. By default, if the retry mechanism can not recover the error, the test fails with an message describing the issue and the device is deallocated. Sauce Labs does not fall back to a different device, in order to avoid silently breaking the app state that `cacheId` and [`noReset`](#appiumnoreset) preserve.
 
-Set `allowCacheFallback` to `true` if losing the app's state does not break your tests. Sauce Labs then releases the cached device and retries on another available device matching your device query — which may be the same device after cleaning. The session can still start, but on a freshly cleaned device: your app is reinstalled, its data is gone, and the cached session ends.
+Set `allowCacheFallback` to `true` if you would rather try a new device allocation instead of failing the test in this situation. Sauce Labs then releases the cached device and retries on another available device matching your device query — which may be the same device after cleaning. The session can still start, but on a freshly cleaned device: your app is reinstalled, its data is gone, and the cached session ends.
 
 ```java
 MutableCapabilities capabilities = new MutableCapabilities();

--- a/docs/mobile-apps/automated-testing/appium/real-devices.md
+++ b/docs/mobile-apps/automated-testing/appium/real-devices.md
@@ -297,6 +297,15 @@ To skip the uninstallation and reinstallation of your app from the device, you c
 }
 ```
 
+If you use `cacheId` purely to avoid the cleaning wait and don't need the app's state kept, set `allowCacheFallback` to `true`. A cached device that can't be reused then falls back to another available device instead of failing the session, at the cost of running on a freshly cleaned device.
+
+```js
+"sauce:options" : {
+  "cacheId" : "jnc0x1256",
+  "allowCacheFallback" : true,
+}
+```
+
 When using `cacheId` the value must match for all tests slated to run on the cached device. In addition, the app must be the same for all tests, as must the values for the following capabilities:
 
 - `deviceName`
@@ -310,7 +319,7 @@ When using `cacheId` the value must match for all tests slated to run on the cac
 - `autoGrantPermissions`
 - `appiumVersion`
 
-If an error occurs while starting an Appium session on a cached device, the session fails with an error message describing the issue, and the device is deallocated. The error details are also available in the test report of the failed session, ending the cached session.
+If an error occurs while starting an Appium session on a cached device, the session fails with an error message describing the issue, and the device is deallocated. The error details are also available in the test report of the failed session, ending the cached session. This is the default; set [`allowCacheFallback`](/dev/test-configuration-options/#allowcachefallback) to `true` to fall back to another device instead of failing.
 
 ### WebDriverAgent for iOS Real Devices
 

--- a/docs/mobile-apps/automated-testing/appium/real-devices.md
+++ b/docs/mobile-apps/automated-testing/appium/real-devices.md
@@ -297,7 +297,7 @@ To skip the uninstallation and reinstallation of your app from the device, you c
 }
 ```
 
-If you use `cacheId` purely to avoid the cleaning wait and don't need the app's state kept, set `allowCacheFallback` to `true`. A cached device that can't be reused then falls back to another available device instead of failing the session, at the cost of running on a freshly cleaned device.
+If losing the app's state does not break your tests, set `allowCacheFallback` to `true`. A cached device that can't be reused then falls back to another available device instead of failing the session, at the cost of running on a freshly cleaned device.
 
 ```js
 "sauce:options" : {

--- a/docs/mobile-apps/automated-testing/appium/real-devices.md
+++ b/docs/mobile-apps/automated-testing/appium/real-devices.md
@@ -319,7 +319,7 @@ When using `cacheId` the value must match for all tests slated to run on the cac
 - `autoGrantPermissions`
 - `appiumVersion`
 
-If an error occurs while starting an Appium session on a cached device, the session fails with an error message describing the issue, and the device is deallocated. The error details are also available in the test report of the failed session, ending the cached session. This is the default; set [`allowCacheFallback`](/dev/test-configuration-options/#allowcachefallback) to `true` to fall back to another device instead of failing.
+If an error occurs while starting an Appium session on a cached device, the session fails with an error message describing the issue, and the device is deallocated. The error details are also available in the test report of the failed session, ending the cached session. The default behavior is to fail the session and end the cached session; set [`allowCacheFallback`](/dev/test-configuration-options/#allowcachefallback) to `true` to fall back to another device instead of failing.
 
 ### WebDriverAgent for iOS Real Devices
 


### PR DESCRIPTION
### Description
Documents `allowCacheFallback`, a new `sauce:options` capability for Appium tests on real devices.

- `test-configuration-options.md`: new reference entry after `cacheId`, plus a link to it from `cacheId`.
- `real-devices.md`: added the opt-in and a snippet to *Using `cacheId` and `noReset`*, and scoped the existing sentence about errors on cached devices as the default behaviour.


### Motivation and Context
By default, a session that fails to start on a cached device fails outright, because retrying would reset the device and break the state `cacheId` and `noReset` preserve. Customers who use `cacheId` only to skip device cleaning can now set `allowCacheFallback: true` to fall back to another device instead.

This also corrects the fail-fast sentence added in #3593, which is now only the default.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)
