### PR TITLE
Error Reporting Android: add native crash integration guide

### DIFF
--- a/docs/error-reporting/platform-integrations/android/configuration.md
+++ b/docs/error-reporting/platform-integrations/android/configuration.md
@@ -193,10 +193,9 @@ settings.setRetryOrder(RetryOrder.Queue);
 
 BacktraceDatabase database = new BacktraceDatabase(context, settings);
 BacktraceClient backtraceClient = new BacktraceClient(context, credentials, database);
-
-// Required to capture native crashes
-database.setupNativeIntegration(backtraceClient, credentials);
 ```
+
+Complete the client configuration before starting native crash capture. See [Native Crash Integration](./native-crash-integration.md) for the recommended initialization order and the result-returning API.
 
 ## Sending Reports
 
@@ -543,7 +542,7 @@ You can track those metrics at-a-glance, as well as in detail to find out what k
 
 You can enable error-free metrics as follows:
 :::note Important
-Make sure to enable error-free metrics before you [enable the native integration](#enabling-native-integration).
+Make sure to enable error-free metrics before you [enable native integration](./native-crash-integration.md#configure-and-enable-native-crash-capture).
 :::
 
 ```java
@@ -554,33 +553,31 @@ backtraceClient.metrics.enable(metricsSettings);
 
 ## NDK Applications
 
-:::note
-If your native app is built with NDK 16b, the Breakpad native crash client will be used instead of our recommended Crashpad crash client. To avoid this, use NDK 17c+ to build your native app.
-:::
-:::note
-Breakpad crash reports are submitted on the next app startup, instead of at crash time like Crashpad crash reports.
+:::note Legacy Breakpad builds
+The native backend is selected when the Backtrace SDK artifact is built; the application's NDK version does not switch the backend in a prebuilt artifact. Legacy SDK artifacts built with Breakpad submit native reports on the next application startup and do not support `disableNativeIntegration()`.
 :::
 
 ### Enabling Native Integration
 
-In general, this should be the final step in setting up your Backtrace client to ensure all attributes and file attachment paths are captured properly by the native crash handler.
+In general, this should be the final step in setting up your Backtrace client to ensure all attributes, breadcrumbs, and file attachment paths are captured properly by the native crash handler.
 
-To capture native crashes, set up an offline database as noted in [Offline Database Settings](#offline-database-settings) and use the `enableNativeIntegration` method as follows:
+To capture native crashes, set up an offline database as noted in [Offline Database Settings](#offline-database-settings). For new integrations, use the result-returning API:
+
+```java
+boolean nativeEnabled = backtraceClient.tryEnableNativeIntegration();
+```
+
+Existing integrations can continue to use the supported `void` API when they do not need the registration result:
 
 ```java
 backtraceClient.enableNativeIntegration();
 ```
 
-In addition, you may also need to add the `extractNativeLibs` option to your `AndroidManifest.xml` file:
+Both methods perform the same synchronous native registration. Call one method, not both.
 
-```xml
-<application
-        android:extractNativeLibs="true">
-        ...
-</application>
-```
+The SDK supports monolithic APKs, split APKs, and libraries loaded directly from an installed APK. You do not need to set `android:extractNativeLibs="true"` solely for Backtrace native-library path resolution.
 
-For more information about `extractNativeLibs`, see [Android's developer documentation](https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs).
+For startup behavior, threading requirements, failure handling, lifecycle behavior, compatibility, and diagnostic codes, see [Native Crash Integration](./native-crash-integration.md).
 
 #### Disabling Native Integration
 
@@ -590,15 +587,11 @@ You can also disable the native integration as follows:
 backtraceClient.disableNativeIntegration();
 ```
 
-:::note
-Breakpad does not currently support `disableNativeIntegration`.
-:::
-
 ### Uploading Symbols
 
 For an NDK application, debugging symbols are not available to Backtrace by default. You will need to upload the app symbols for your native code to Backtrace.
 
-You can do this by uploading the native libraries themselves, which are usually found in the APK bundle. For more information on how to upload symbols for an NDK app, see [Upload Symbols to Your Project](/docs/error-reporting/symbols/upload-symbols-to-project.md).
+You can do this by uploading the native libraries themselves, which are usually found in the APK bundle. For more information on how to upload symbols for an NDK app, see [Upload Symbols to Your Project](/error-reporting/symbols/upload-symbols-to-project/).
 
 ### Client-Side Unwinding
 
@@ -610,10 +603,10 @@ This may not provide the same callstack quality as with debugging symbols, but w
 When viewing a crash in the Backtrace console, it may still show warning messages that symbols are missing from certain frames after client-side unwinding is performed. This warning is expected if these symbols are not available on the Backtrace server, and should not impact your ability to read the callstack.
 :::
 
-To enable client side unwinding, you can call the `setupNativeIntegration` method with an additional boolean value.
+To enable client-side unwinding and observe the registration result, call `tryEnableNativeIntegration` with an additional boolean value. The corresponding `enableNativeIntegration` overloads remain supported for existing integrations that do not need the result.
 
 ```java
-database.setupNativeIntegration(backtraceClient, credentials, true);
+boolean nativeEnabled = backtraceClient.tryEnableNativeIntegration(true);
 ```
 
 <!-- prettier-ignore-start -->
@@ -634,7 +627,9 @@ Client-side unwinding is only available for the following platforms:
 You can optionally specify the unwinding mode as follows:
 
 ```java
-database.setupNativeIntegration(backtraceClient, credentials, true, UnwindingMode.REMOTE_DUMPWITHOUTCRASH);
+boolean nativeEnabled = backtraceClient.tryEnableNativeIntegration(
+        true,
+        UnwindingMode.REMOTE_DUMPWITHOUTCRASH);
 ```
 
 The following unwinding modes are available:

--- a/docs/error-reporting/platform-integrations/android/native-crash-integration.md
+++ b/docs/error-reporting/platform-integrations/android/native-crash-integration.md
@@ -1,0 +1,165 @@
+---
+id: native-crash-integration
+title: Native Crash Integration for Android
+sidebar_label: Native Crash Integration
+description: Configure native NDK and JNI crash capture with the Backtrace Android SDK.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+The Backtrace Android SDK can install a native crash handler to capture crashes in NDK and JNI code. Native crash capture is optional and operates independently from managed Java exception reporting and Application Not Responding (ANR) monitoring.
+
+## Requirements
+
+- Android API level 21 or later.
+- A writable `BacktraceDatabase` in an application-private directory.
+- A standard Backtrace JSON submission URL that the SDK can convert to a minidump submission URL.
+
+The database must be supplied when constructing `BacktraceClient`. A client constructed without a database uses a disabled default database and cannot register the native crash handler.
+
+## Configure and Enable Native Crash Capture
+
+Native crash capture requires a writable `BacktraceDatabase` supplied to `BacktraceClient`. Configure initial attributes, attachments, breadcrumbs, metrics, and managed exception handling before enabling the native integration.
+
+<Tabs groupId="languages">
+<TabItem value="java" label="Java">
+
+```java
+Context context = getApplicationContext();
+BacktraceCredentials credentials = new BacktraceCredentials("<submissionUrl>");
+
+BacktraceDatabaseSettings databaseSettings = new BacktraceDatabaseSettings(
+        new File(context.getFilesDir(), "backtrace").getAbsolutePath());
+BacktraceDatabase database = new BacktraceDatabase(context, databaseSettings);
+BacktraceClient backtraceClient = new BacktraceClient(context, credentials, database);
+
+// Configure attributes, attachments, breadcrumbs, and metrics before this call.
+BacktraceExceptionHandler.enable(backtraceClient);
+backtraceClient.enableBreadcrumbs(context);
+
+boolean nativeEnabled = backtraceClient.tryEnableNativeIntegration();
+if (!nativeEnabled) {
+    // Native crash capture is unavailable. Managed reporting remains available.
+}
+```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val context = applicationContext
+val credentials = BacktraceCredentials("<submissionUrl>")
+
+val databaseSettings = BacktraceDatabaseSettings(
+    File(context.filesDir, "backtrace").absolutePath
+)
+val database = BacktraceDatabase(context, databaseSettings)
+val backtraceClient = BacktraceClient(context, credentials, database)
+
+// Configure attributes, attachments, breadcrumbs, and metrics before this call.
+BacktraceExceptionHandler.enable(backtraceClient)
+backtraceClient.enableBreadcrumbs(context)
+
+val nativeEnabled = backtraceClient.tryEnableNativeIntegration()
+if (!nativeEnabled) {
+    // Native crash capture is unavailable. Managed reporting remains available.
+}
+```
+
+</TabItem>
+</Tabs>
+
+For new integrations, `tryEnableNativeIntegration()` is recommended. It synchronously installs the native crash handler and returns whether registration succeeded.
+
+The existing `enableNativeIntegration()` method and its client-side unwinding overloads remain supported for applications that do not need the result. They perform the same synchronous registration and return normally when an optional native setup failure is contained. Call either the result-returning API or the corresponding `void` API, not both.
+
+Client-side unwinding is available through the result-returning overloads:
+
+```java
+boolean nativeEnabled = backtraceClient.tryEnableNativeIntegration(true);
+
+boolean nativeEnabledWithMode = backtraceClient.tryEnableNativeIntegration(
+        true,
+        UnwindingMode.REMOTE_DUMPWITHOUTCRASH);
+```
+
+For unwinding behavior and modes, see [Client-Side Unwinding](./configuration.md#client-side-unwinding).
+
+## Startup and Threading Behavior
+
+Native initialization is synchronous because native crash coverage begins only after the crash handler is installed. Call the enable method from exactly one application-controlled thread, as early as practical after completing the initial configuration.
+
+You can initialize native crash capture on a background thread, but native faults that occur before initialization completes cannot be captured. Do not enable native integration concurrently from multiple threads or race an enable call with `disableNativeIntegration()`.
+
+Native initialization is process-scoped and has a process-global, once-only initialization boundary. Java-side validation and preparation occur before that boundary, but an attempt that reaches the native initializer consumes it. Make at most one initial registration attempt per process, and do not retry a failed setup in a loop. Continue using managed reporting, correct the configuration, and initialize native capture after the next application process start.
+
+## APK and Android App Bundle Support
+
+The SDK supports monolithic APKs and Android App Bundle installations that use split APKs. It resolves `libbacktrace-native.so` in this order:
+
+1. The exact filesystem or APK-backed path selected by Android's native linker.
+1. An existing extracted library in `nativeLibraryDir`.
+1. An ABI split identified from installed application metadata.
+1. The base-APK path shape as a compatibility fallback.
+
+The linker-selected path is authoritative. This supports 32-bit processes on 64-bit devices and native-bridge translation; ABI inference is used only to construct fallback paths. Backtrace does not open or parse the base APK or split APK ZIP central directory while resolving the crash-handler library. Android's linker may still access an installed APK when it loads an unextracted native library. Resolution performs a bounded number of linker, package-metadata, and filesystem checks; its work does not scale with the number of files in the APK.
+
+Libraries loaded directly from an installed APK are supported. You do not need to set `android:extractNativeLibs="true"` solely for Backtrace native-library path resolution.
+
+## Failure and Lifecycle Behavior
+
+- A contained native setup failure returns `false` from `tryEnableNativeIntegration()` and leaves managed exception reporting and ANR monitoring operational.
+- Existing integrations that call `BacktraceDatabase.setupNativeIntegration()` directly continue to receive `false` when registration does not succeed. Prefer the client-level `tryEnableNativeIntegration()` API for new integrations.
+- `dumpWithoutCrash()` safely drops and logs a request when native integration is unavailable or disabled.
+- `disableNativeIntegration()` disables native uploads for the current process. It does not uninstall the process-registered crash handler.
+- After successful registration, a later enable call restarts the Crashpad upload thread.
+
+:::note Legacy Breakpad builds
+The native backend is selected when the Backtrace SDK artifact is built; the application's NDK version does not switch the backend in a prebuilt artifact. Legacy SDK artifacts built with Breakpad submit native reports on the next application startup and do not support `disableNativeIntegration()`.
+:::
+
+## Create Nonfatal Native Reports
+
+After native integration is enabled, use `dumpWithoutCrash()` to create a native report without terminating the application:
+
+```java
+backtraceClient.dumpWithoutCrash("native diagnostic");
+```
+
+Use the boolean overload to identify the main thread as the faulting thread in the generated report:
+
+```java
+backtraceClient.dumpWithoutCrash("native diagnostic", true);
+```
+
+If native integration is unavailable or disabled, these methods log and safely drop the request instead of invoking an uninitialized native backend.
+
+## Compatibility and Limitations
+
+- Android API 21 is the minimum supported API level.
+- `x86_64`, `armeabi-v7a`, and `arm64-v8a` native crash capture are supported.
+- The `x86` native crash backend is not supported.
+- `arm64-v8a` and `x86_64` support flexible 16 KB page-size environments.
+- Managed Java exception reporting and ANR monitoring remain available independently of native ABI support or native crash-handler registration.
+
+## Native Integration Diagnostic Codes
+
+For the optional native setup and Java crash-handler failure paths listed below, the SDK logs a stable stage code and, where applicable, the exception class. These diagnostics omit exception messages and stack traces because they can contain credentials, application data, or filesystem paths. Some unsupported or disabled configurations can return `false` without emitting one of these codes.
+
+| Code                                | Meaning                                                                                         |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `BT_NATIVE_PREPARE_FAILURE`         | Native configuration or environment preparation failed.                                         |
+| `BT_NATIVE_BRIDGE_FAILURE`          | The JNI or native initialization bridge failed.                                                 |
+| `BT_NATIVE_BREADCRUMB_HOOK_FAILURE` | The breadcrumb synchronization hook could not be installed. Native integration remains enabled. |
+| `BT_NATIVE_DISABLE_FAILURE`         | The native disable bridge failed. The Java enabled state is still cleared.                      |
+| `BT_NATIVE_DUMP_UNAVAILABLE`        | A dump was requested while native integration was unavailable.                                  |
+| `BT_HANDLER_ENV_UNAVAILABLE`        | The crash-handler process environment was unavailable.                                          |
+| `BT_HANDLER_PATH_UNAVAILABLE`       | The crash-handler native-library path was unavailable.                                          |
+| `BT_HANDLER_LOAD_FAILURE`           | The crash-handler native library could not be loaded.                                           |
+| `BT_HANDLER_DISPATCH_FAILURE`       | Dispatch to the native crash handler failed.                                                    |
+| `BT_HANDLER_RETURNED_FAILURE`       | The native crash handler returned a failure result.                                             |
+
+## Upload Native Symbols
+
+Native reports contain instruction addresses that require the matching debug symbols for readable call stacks. See [Upload Symbols to Your Project](/error-reporting/symbols/upload-symbols-to-project/) for upload instructions.

--- a/docs/error-reporting/platform-integrations/android/setup.md
+++ b/docs/error-reporting/platform-integrations/android/setup.md
@@ -113,6 +113,14 @@ val backtraceCredentials = BacktraceCredentials("https://submit.backtrace.io/{su
 </TabItem>
 </Tabs>
 
+## Enable Native Crash Integration (Optional)
+
+To capture crashes in NDK or JNI code, construct `BacktraceClient` with a writable `BacktraceDatabase` and complete the initial client configuration. For new integrations, call `tryEnableNativeIntegration()` so the application can observe whether native crash-handler registration succeeded. The existing `enableNativeIntegration()` method remains supported for applications that do not need the result. Call one of these methods, not both.
+
+A contained native setup failure does not disable managed Java exception reporting or ANR monitoring.
+
+Native initialization is synchronous and process-scoped. For complete setup examples, threading requirements, Android App Bundle behavior, supported ABIs, lifecycle behavior, and diagnostic codes, see [Native Crash Integration](./native-crash-integration.md).
+
 ## Verify the Setup
 
 At this point, you've installed and setup the Backtrace client to automatically capture exceptions and crashes in your Android app.

--- a/sidebars.js
+++ b/sidebars.js
@@ -58,6 +58,7 @@ module.exports = {
                                     items: [
                                         'error-reporting/platform-integrations/android/setup',
                                         'error-reporting/platform-integrations/android/configuration',
+                                        'error-reporting/platform-integrations/android/native-crash-integration',
                                         'error-reporting/platform-integrations/android/proguard-deobfuscation',
                                     ],
                                 },
@@ -1229,9 +1230,9 @@ module.exports = {
                         'insights/home',
                         'insights/sauce-home/export-widget-report',
                         'insights/sauce-home/sauce-home-filters',
-                      ],
-                  },
-                  {
+                    ],
+                },
+                {
                     type: 'category',
                     label: 'Job Overview',
                     collapsed: true,

--- a/styles/sauce/SentenceSpacing.yml
+++ b/styles/sauce/SentenceSpacing.yml
@@ -4,5 +4,6 @@ message: "Remove the extra space."
 level: warning
 nonword: true
 tokens:
-  - '[a-z][.?!,][A-Z]'
+  - '[a-z][?!,][A-Z]'
+  - '[a-z]\.[A-Z](?![A-Z0-9_])'
   - '[\w.?!,\(\)\-":] {2,}[\w.?!,\(\)\-":]'


### PR DESCRIPTION
### Description

Add a dedicated Android native crash integration guide and update the existing Android documentation to use it as the canonical reference.

## What changed

- Added a Native Crash Integration for Android page covering:
  - writable `BacktraceDatabase` requirements
  - Java and Kotlin initialization examples
  - the recommended initialization order
  - synchronous startup and threading requirements
  - monolithic APK and Android App Bundle/split APK support
  - native-library path resolution behavior
  - failure containment and managed-reporting fallback
  - disable and re-enable lifecycle behavior;
  - nonfatal native reports with `dumpWithoutCrash()`
  - supported API levels, ABIs, and flexible 16 KB page sizes
  - stable native integration and crash-handler diagnostic codes
  - native symbol upload requirements.

- Documented `tryEnableNativeIntegration()` as the recommended API for new integrations that need to observe the registration result.

- Retained `enableNativeIntegration()` and its unwinding overloads as supported APIs for integrations that do not need the result.

- Clarified that callers should invoke either the result-returning API or the corresponding `void` API, not both.

- Updated Android setup and configuration pages to link to the new guide.

- Replaced lower-level `BacktraceDatabase.setupNativeIntegration()` examples with the client-level API while documenting the existing database API's failure contract for compatibility.

- Removed the recommendation to force `android:extractNativeLibs="true"` solely for Backtrace.

- Clarified that a prebuilt SDK artifact selects its native backend at build time; an application's NDK version does not switch that backend.

- Corrected the Android native-symbol upload link.

- Added the guide to the Android sidebar.

- Corrected existing Sauce Home sidebar indentation.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

ref: BT-7473
