### PR TITLE
Document Android TalkBack is available on public devices

### DIFF
--- a/docs/mobile-apps/features/accessibility-testing/android-talkback.md
+++ b/docs/mobile-apps/features/accessibility-testing/android-talkback.md
@@ -11,12 +11,13 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 TalkBack is Android's built-in screen reader. Sauce Labs allows you to enable TalkBack on real devices with a single click during live testing sessions, without going to the OS settings. You can navigate through elements using the keyboard and hear audio feedback for each focused element.
 
+TalkBack is supported on all public and private Android real devices running Android 12 or above.
+
 ## What You'll Need
 
 - A Sauce Labs account ([Log in](https://accounts.saucelabs.com/am/XUI/#login/) or sign up for a [free trial license](https://saucelabs.com/sign-up)).
 - An Android real device session (Live Testing).
 - Android 12 or above.
-- **Private devices only.** Reach out to our Support Team or your Sauce Labs representative to get this configured.
 
 ## Enabling TalkBack
 
@@ -65,7 +66,6 @@ For more details on sharing sessions, see [Live Mobile App Testing](/mobile-apps
 
 ## Limitations
 
-- TalkBack is only supported on **private devices**. Contact our Support Team to get this configured.
 - Android 12 or above is required.
 - Website testing is not yet available on Android.
 

--- a/docs/mobile-apps/features/accessibility-testing/index.md
+++ b/docs/mobile-apps/features/accessibility-testing/index.md
@@ -34,6 +34,6 @@ Key highlights:
 - Arrow keys to navigate, Enter to activate
 - Audio feedback streamed to your browser
 - Requires Android 12 or above
-- Private devices only
+- Works on all public and private Android real devices
 
 [Learn more about Android Live Accessibility Testing](/mobile-apps/features/accessibility-testing/android-talkback)

--- a/docs/mobile-apps/features/audio-capture.md
+++ b/docs/mobile-apps/features/audio-capture.md
@@ -57,14 +57,13 @@ We are using Twilio's webrtc service in order to stream audio from a Real Device
 
 :::note Limitations
 
-- Android TalkBack is ONLY supported on Private devices, reach out to our Support Team or your Sauce Labs representative to get this configured.
 - Website testing is not yet available on Android.
 
 :::
 
 ## Using Audio Capture and Streaming on your Android Device
 
-You will have the capability to capture audio on Android 10 and later versions. On private devices, you can test TalkBack on Android 12 and later versions.
+You will have the capability to capture audio on Android 10 and later versions. You can test TalkBack on Android 12 and later versions.
 
 :::note
 Once `audioCapture` is enabled, the status bar will display the recording icon.


### PR DESCRIPTION
Android TalkBack in Live Testing is no longer limited to private devices and needs no provisioning, so remove the private-devices-only restrictions and the associated Support contact instructions.