### PR TITLE
E.R: add Unity's Android native crash integration guide

### DIFF
--- a/docs/error-reporting/platform-integrations/unity/attributes.md
+++ b/docs/error-reporting/platform-integrations/unity/attributes.md
@@ -103,9 +103,11 @@ You can also define custom attributes. For more information, see [Configuration]
 | `battery.level`                     | The current battery level.                                                                                    | User Defined | User Defined |
 | `battery.status`                    | The current status of the device's battery.                                                                   | User Defined | User Defined |
 | `cpu.frequency`                     | The frequency of the device's central processing unit (CPU) in megahertz (MHz).                               | User Defined | User Defined |
+| `device.abi`                        | The ABI of the running Android application process, when available.                                           | User Defined | User Defined |
 | `device.manufacturer`               | The manufacturer of the device running the app.                                                               | User Defined | User Defined |
 | `device.model`                      | The model of the device running the app.                                                                      | User Defined | User Defined |
 | `device.name`                       | The name of the device running the app. Defined by the end user.                                              | User Defined | User Defined |
+| `device.sdk`                        | The Android API level of the device running the app.                                                          | User Defined | User Defined |
 | `device.type`                       | The broad type of device.                                                                                     | User Defined | User Defined |
 | `error.type`                        | A categorization of the error that generated a report.                                                        | User Defined | User Defined |
 | `graphic.driver.version`            | The graphics API type and driver version used by the graphics device.                                         | User Defined | User Defined |
@@ -118,6 +120,8 @@ You can also define custom attributes. For more information, see [Configuration]
 | `graphic.type`                      | The graphics API type used by the graphics device.                                                            | User Defined | User Defined |
 | `graphic.vendor`                    | The vendor of the graphics device.                                                                            | User Defined | User Defined |
 | `graphic.vendor.id`                 | The identifier code for the vendor of the graphics device.                                                    | User Defined | User Defined |
+| `memory.warning`                    | Indicates whether Unity reported a low-memory condition before a native crash.                                | User Defined | User Defined |
+| `memory.warning.date`               | The Unix timestamp when Unity reported the most recent low-memory condition.                                  | User Defined | User Defined |
 | `mono.heap`                         | The amount of memory allocated to the managed heap.                                                           | User Defined | User Defined |
 | `mono.used`                         | The amount of memory used by the managed heap.                                                                | User Defined | User Defined |
 | `scene.active`                      | The name of the active scene.                                                                                 | User Defined | User Defined |

--- a/docs/error-reporting/platform-integrations/unity/configuration.md
+++ b/docs/error-reporting/platform-integrations/unity/configuration.md
@@ -137,46 +137,23 @@ The Backtrace Unity SDK includes support for capturing native crashes, as well a
 
 For more information about other data that is captured, see [Attributes](/error-reporting/platform-integrations/unity/attributes).
 
-| Setting                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                            | Type    | Default |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------- |
-| Capture native crashes                     | Captures and symbolicates stack traces for native crashes. A crash report is generated, stored locally, and uploaded upon next game start. This requires "Enable Database" to also be true.                                                                                                                                                                                                                                                                                             | Boolean | True    |
-| Capture ANR (Application not responding)   | Generates an error report whenever an app hangs for more than 5 seconds. The `error.type` for these reports will be `Hang`.                                                                                                                                                                                                                                                                                                            | Boolean | True    |
-| Send Out of Memory exceptions to Backtrace | Detects low memory conditions. If the app crashes due to a memory condition, a crash report will be submitted to Backtrace with the `memory.warning` and `memory.warning.date` attributes.                                                                                                                                                                                                                                             | Boolean | False   |
-| Enable client-side unwinding               | Enables callstack unwinding. If you're unable to upload all debug symbols for your app, you can use this setting to get debug information. Available only for supported versions of Android (NDK 19; Unity 2019+). <br /><br /> You can also enable this setting via the [`BacktraceConfiguration`](/error-reporting/platform-integrations/unity/configuration/#backtraceclient) object and the `.ClientSideUnwinding = true;` option. | Boolean | False   |
-| Symbols upload token                       | Required to automatically upload debug symbols to Backtrace. <br /> <br /> To generate a symbol upload token, in Backtrace go to Project Settings > Symbols > Access tokens > and select + to generate a new token.                                                                                                                                                                                                                    | String  |
+| Setting                                    | Description                                                                                                                                                                                                      | Type    | Default |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------- |
+| Capture native crashes                     | Captures native crash data. A fatal report is stored locally and uploaded after the next application start. **Enable Database** must also be enabled. Upload matching debug symbols to resolve native addresses. | Boolean | True    |
+| Capture ANR (Application not responding)   | Generates a hang report when the application remains unresponsive beyond the configured watchdog timeout. The default timeout is five seconds, and the report's `error.type` is `Hang`.                          | Boolean | True    |
+| Send Out of Memory exceptions to Backtrace | Adds `memory.warning` and `memory.warning.date` context after Unity reports a low-memory condition. The callback doesn't submit a report immediately; a later native crash can include these attributes.         | Boolean | False   |
+| Enable client-side unwinding               | This setting doesn't change Android native crash-capture behavior.                                                                                                                                               | Boolean | False   |
+| Symbols upload token                       | Enables automatic upload of matching Android IL2CPP symbols. To generate a token, in Backtrace go to **Project Settings > Symbols > Access tokens**, then select **+**.                                          | String  |
+
+For Android native crash startup behavior, APK and Android App Bundle support, supported ABIs, failure containment, and diagnostic codes, see [Android Native Crash Integration for Unity](/error-reporting/platform-integrations/unity/native-crash-integration/).
 
 #### ProGuard Rules
-ProGuard obfuscation prevents the reflection used to invoke Java code from the Unity bridge. The ProGuard symbolication id must be passed to BacktraceClient, and additional ProGuard rules must be added to allow Backtrace to identify Java classes. 
-<br /> 
-Symbolication id is a UUID identifier created by the user. The same identifier value must be sent when uploading the source map and must be accessible in the game's runtime environment.
 
-<br/>
-Please follow [this guide](/error-reporting/platform-integrations/android/proguard-deobfuscation/) to enable ProGuard, and add the following:
-
-- Pass your ProGuard symbolication id to BacktraceClient:
-   ```java
-   var backtraceClient = GameObject.Find("manager name").GetComponent<BacktraceClient>();
-   var symbolicationId = "f6c3e8d4-8626-4051-94ec-53e6daccce25";
-   backtraceClient.UseProguard(symbolicationId);
-   ```
-- Use these rules in proguard_rules.pro:
-    ```
-    -keep class backtraceio.unity.* { *; }
-    -keep class backtraceio.library.**.* { *; }
-    ```
+See [Configure ProGuard](/error-reporting/platform-integrations/unity/native-crash-integration/#configure-proguard) for the required keep rules and symbolication ID configuration.
 
 #### Uploading Debug Symbols
 
-You can configure the Backtrace client to automatically upload debug symbols in IL2CPP builds for Android apps.
-
-To enable automatic upload of debug symbols, in your Unity project's Android settings:
-
-1. In the **Build Settings**, set **Create symbols.zip** to 'Debugging'.
-   <img src={useBaseUrl('img/error-reporting/unity/unity-android-build-settings-debug-symbols.png')} alt="Build setting required to upload debug symbols to Backtrace for Android builds." />
-1. In the **Player Settings**, under **Configuration (Other Settings)**, set **Scripting Backend** to 'IL2CPP'.
-   <img src={useBaseUrl('img/error-reporting/unity/unity-android-player-settings-debug-symbols.png')} alt="Player setting required to upload debug symbols to Backtrace for Android builds." />
-
-For more information about debug symbols, see [Symbolication](/error-reporting/project-setup/symbolication/).
+See [Upload Debug Symbols](/error-reporting/platform-integrations/unity/native-crash-integration/#upload-debug-symbols) for Android IL2CPP build and symbol-upload configuration.
 
 </TabItem>
 <TabItem value="ios" label="iOS">

--- a/docs/error-reporting/platform-integrations/unity/native-crash-integration.md
+++ b/docs/error-reporting/platform-integrations/unity/native-crash-integration.md
@@ -1,0 +1,230 @@
+---
+id: native-crash-integration
+title: Android Native Crash Integration for Unity
+sidebar_label: Android Native Crashes
+description: Configure and troubleshoot Android native crash reporting with the Backtrace Unity SDK.
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+The Backtrace Unity SDK captures native Android crashes, application not responding (ANR) events, and low-memory context in Unity applications.
+Native reports include process and system information that can help diagnose failures outside managed C# code.
+
+:::note Version Availability
+Linker-first native-library resolution, process-aware application binary interface (ABI) selection, contained native setup and dynamic-attribute failures, and the diagnostic codes described on this page require Backtrace Unity SDK 3.16.3 or later. Earlier SDK versions support Android native crash capture but don't provide all of these behaviors.
+:::
+
+## Requirements
+
+Android native crash capture requires:
+
+- Android API level 21 or later.
+- A valid **Server Address** in the Backtrace Configuration.
+- **Enable Database** enabled in the Backtrace Configuration.
+- **Capture native crashes** enabled in the Backtrace Configuration.
+- A writable Backtrace database directory.
+
+Backtrace Unity supports native crash capture for these Android ABIs:
+
+- `arm64-v8a`
+- `armeabi-v7a`
+- `x86_64`
+
+Native crash capture isn't supported for 32-bit `x86`. Managed Unity exception and message reporting remains available on that ABI.
+
+Matching debug symbols aren't required to capture a native report, but they are required to resolve native addresses into readable function names and source context.
+
+## Configure Native Crash Capture
+
+In the Backtrace Configuration asset:
+
+1. Enter a valid **Server Address**.
+1. Enable **Enable Database**.
+1. Configure a writable **Backtrace database path**.
+1. Enable **Capture native crashes**.
+1. Configure attachments, breadcrumbs, ANR capture, and low-memory reporting as needed.
+
+The SDK initializes Android native crash capture automatically and synchronously when the Backtrace client starts. Configure the database, native crash setting, attachment paths, and breadcrumbs before the Backtrace Client component initializes.
+
+Pass initial custom attributes to `BacktraceClient.Initialize(...)`, or add them later with `SetAttribute(...)` or `SetAttributes(...)`.
+
+Native crashes that occur before initialization completes can't be captured.
+Fatal native reports are stored in the Backtrace database and uploaded after the application starts again.
+
+## Android Application Package and App Bundle Support
+
+Backtrace Unity supports:
+
+- Traditional Android application package (APK) installations.
+- Android App Bundle installations.
+- Split-APK installations.
+- Extracted native libraries.
+- Native libraries loaded directly from an installed APK or ABI configuration split.
+
+Applications don't need to calculate or configure the native crash-handler library path.
+You also don't need to force native-library extraction solely for Backtrace Unity.
+
+In version 3.16.3 and later, the SDK resolves the loaded native module and installed package metadata without opening or parsing APK contents.
+
+### Native-Library Path Resolution
+
+The SDK resolves the native crash-handler library in this order:
+
+| Priority | Source                       | Behavior                                                                                                   |
+| -------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 1        | Android linker-selected path | Uses the validated path of the loaded `libbacktrace-native.so` module selected by Android's native linker. |
+| 2        | Extracted native library     | Uses an existing `nativeLibraryDir/libbacktrace-native.so`.                                                |
+| 3        | Installed ABI split          | Selects an installed ABI configuration split from Android application metadata.                            |
+| 4        | Base APK fallback            | Constructs the compatibility path from the base APK when the earlier sources are unavailable.              |
+
+The linker-selected path is authoritative because Android has already selected and loaded that module for the running process. If installed split metadata is ambiguous, the SDK doesn't select a candidate based on array or filesystem order.
+
+### Process ABI Selection
+
+On Android, the `device.abi` report attribute identifies the ABI of the running application process when that information is available.
+The process ABI can differ from the device's preferred ABI. For example, a 32-bit Unity application can run on a 64-bit-capable device.
+
+The SDK uses the process ABI consistently for:
+
+- Native-library fallback resolution.
+- ABI split selection.
+- The `device.abi` report attribute.
+- Native crash-capture support checks.
+
+## Failure Behavior
+
+Android native crash capture is optional. A native initialization failure doesn't stop the Backtrace Unity client from starting.
+
+When native setup can't be completed:
+
+- Native crash capture becomes unavailable.
+- Completed or partial native initialization is rolled back when possible.
+- Managed Unity exception and message reporting continues.
+- The SDK writes a status message or stage-specific diagnostic code to Unity logging or Android Logcat.
+
+Failures during native attribute propagation, ANR processing, native dump operations, rollback, and shutdown are contained so they don't terminate the application. Shutdown stages are attempted independently so one cleanup failure doesn't skip the remaining cleanup.
+
+Native initialization applies to the Android process that initializes the Backtrace client. Restart that process after correcting a configuration or packaging problem before testing native crash capture again.
+
+## Dynamic Attributes and Attachments
+
+`BacktraceClient.SetAttribute(...)` stores the managed attribute before it attempts optional native propagation. Its successful return value means the managed attribute was accepted; it doesn't confirm that native propagation succeeded.
+
+If native propagation fails:
+
+- The managed attribute remains available to managed reports.
+- The failure doesn't escape into the Unity application.
+- Native capture isn't disabled solely because of that attribute failure.
+- Later entries passed to `SetAttributes(...)` continue to be processed.
+
+Android native reports omit attributes whose values are empty strings.
+
+Configure native attachment paths before native initialization.
+Attachments added later with `AddAttachment(...)` apply to managed reports only.
+
+## ANR and Low-Memory Behavior
+
+When **Capture ANR (Application not responding)** is enabled, the SDK monitors the Unity application for hangs.
+ANR reports use `error.type=Hang`. The SDK restores the native classification to `Crash` after the dump attempt, including failure paths. ANR worker failures don't terminate the application.
+
+When **Send Out of Memory exceptions to Backtrace** is enabled and native capture is active, a Unity low-memory callback adds this context to native state:
+
+- `memory.warning=true`
+- `memory.warning.date=<Unix timestamp in seconds>`
+
+The callback doesn't immediately create or submit a report. A later native crash can include these attributes, but their presence doesn't prove that low memory caused the crash.
+
+## Diagnostic Codes
+
+The following codes are log identifiers, not report attributes. They identify the failed stage and, where relevant, include the exception type. 
+These messages don't include submission URLs, application attributes, attachment paths, handler arguments, or resolved native-library paths.
+
+Not every unavailable native setup path emits a code. Expected preflight conditions, such as a disabled database, an unsupported API level, or an unsupported 32-bit `x86` process, can use a `Backtrace native integration status` message instead.
+
+| Code                                                 | Meaning                                                                                    |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `BT_UNITY_ANDROID_NATIVE_PREPARE_FAILURE`            | An unexpected failure occurred while preparing native capture.                             |
+| `BT_UNITY_ANDROID_NATIVE_ROLLBACK_FAILURE`           | Cleanup after incomplete native initialization failed.                                     |
+| `BT_UNITY_ANDROID_NATIVE_ATTRIBUTE_FAILURE`          | An optional Android native attribute update failed. Managed attribute reporting continues. |
+| `BT_UNITY_ANDROID_NATIVE_DUMP_FAILURE`               | A nonfatal native dump request failed.                                                     |
+| `BT_UNITY_ANDROID_ANR_THREAD_FAILURE`                | The native ANR worker failed.                                                              |
+| `BT_UNITY_ANDROID_JNI_DETACH_FAILURE`                | The ANR worker couldn't detach from the Java virtual machine (JVM).                        |
+| `BT_UNITY_ANDROID_ANR_STOP_FAILURE`                  | Stopping the ANR worker during shutdown failed.                                            |
+| `BT_UNITY_ANDROID_NATIVE_DISABLE_FAILURE`            | Disabling native integration during shutdown failed.                                       |
+| `BT_UNITY_ANDROID_ANR_WATCHER_STOP_FAILURE`          | Stopping the Java ANR watcher failed.                                                      |
+| `BT_UNITY_ANDROID_ANR_WATCHER_DISPOSE_FAILURE`       | Disposing the Java ANR watcher failed.                                                     |
+| `BT_UNITY_ANDROID_UNHANDLED_WATCHER_STOP_FAILURE`    | Stopping the Java exception watcher failed.                                                |
+| `BT_UNITY_ANDROID_UNHANDLED_WATCHER_DISPOSE_FAILURE` | Disposing the Java exception watcher failed.                                               |
+| `BT_HANDLER_ENV_UNAVAILABLE`                         | The crash-handler child environment was unavailable.                                       |
+| `BT_HANDLER_PATH_UNAVAILABLE`                        | The native handler path was missing or blank.                                              |
+| `BT_HANDLER_LOAD_FAILURE`                            | The crash-handler child couldn't load the native handler.                                  |
+| `BT_HANDLER_DISPATCH_FAILURE`                        | The crash-handler child couldn't invoke native handling.                                   |
+| `BT_HANDLER_RETURNED_FAILURE`                        | The native crash handler returned a failure result.                                        |
+
+## Configure ProGuard
+
+ProGuard obfuscation can prevent the reflection used to invoke Java code from the Unity bridge. Follow the [Android ProGuard guide](/error-reporting/platform-integrations/android/proguard-deobfuscation/) and complete the following steps.
+
+1. Pass the ProGuard symbolication ID to `BacktraceClient`:
+
+   ```csharp
+   var backtraceClient = GameObject.Find("manager name")
+       .GetComponent<BacktraceClient>();
+   var symbolicationId = "f6c3e8d4-8626-4051-94ec-53e6daccce25";
+   backtraceClient.UseProguard(symbolicationId);
+   ```
+
+1. Add these rules to `proguard_rules.pro`:
+
+   ```text
+   -keep class backtraceio.unity.* { *; }
+   -keep class backtraceio.library.**.* { *; }
+   ```
+
+The symbolication ID must match the identifier used when uploading the ProGuard mapping.
+ProGuard mapping symbolication and native IL2CPP symbols are separate.
+
+## Upload Debug Symbols
+
+You can configure the Backtrace Unity SDK to upload Android IL2CPP debug symbols automatically.
+Use the symbols from the exact application build that generated the reports.
+
+1. Add a **Symbols upload token** to the Backtrace Configuration.
+1. In **Build Settings**, set **Create symbols.zip** to **Debugging**.
+
+   <img src={useBaseUrl('img/error-reporting/unity/unity-android-build-settings-debug-symbols.png')} alt="Build setting required to upload debug symbols to Backtrace for Android builds." />
+
+1. In **Player Settings**, under **Configuration (Other Settings)**, set
+   **Scripting Backend** to **IL2CPP**.
+
+   <img src={useBaseUrl('img/error-reporting/unity/unity-android-player-settings-debug-symbols.png')} alt="Player setting required to upload debug symbols to Backtrace for Android builds." />
+
+To create a symbol upload token in Backtrace, go to **Project Settings**, select **Symbols > Access tokens**, then select **+**.
+
+For more information, see [Symbolication](/error-reporting/project-setup/symbolication/).
+
+## Troubleshoot Native Crash Capture
+
+### Native Reports Aren't Created
+
+1. Confirm that you're using Backtrace Unity SDK 3.16.3 or later for the startup and diagnostic behavior described on this page.
+2. Confirm that the application runs on Android API level 21 or later.
+3. Enable both **Enable Database** and **Capture native crashes**.
+4. Confirm that the server address is valid and the database directory exists or can be created and written.
+5. Confirm that the running process uses `arm64-v8a`, `armeabi-v7a`, or `x86_64`.
+6. Search Unity output or Android Logcat for `Backtrace native integration status`, `BT_UNITY_ANDROID_`, or `BT_HANDLER_` messages.
+7. Restart the application after correcting the configuration or packaging.
+
+Managed Unity exception and message reporting should remain available when optional native setup fails.
+
+### App Bundle or Split-APK Capture Doesn't Start
+
+Don't hard-code a crash-handler path or force native-library extraction solely for Backtrace.
+Confirm that the installed package includes `libbacktrace-native.so` for the ABI of the running process, then inspect logs for a path, load, or dispatch diagnostic code.
+
+### Native Stacks Aren't Symbolicated
+
+Native capture can succeed even when stack frames show unresolved addresses.
+Upload the matching IL2CPP symbols from the exact build and verify that the symbol upload token belongs to the intended Backtrace project.
+
+For more information, see [Symbolication](/error-reporting/project-setup/symbolication/).

--- a/docs/error-reporting/platform-integrations/unity/setup.md
+++ b/docs/error-reporting/platform-integrations/unity/setup.md
@@ -144,6 +144,8 @@ To change Backtrace client and database options, we recommend to change these va
 
 For more information about the available configuration options, see [Configuration](/error-reporting/platform-integrations/unity/configuration).
 
+For Android native crash capture requirements, supported APK and Android App Bundle layouts, supported ABIs, and failure behavior, see [Android Native Crash Integration for Unity](/error-reporting/platform-integrations/unity/native-crash-integration/).
+
 ## Configure the Server Address
 
 The server address is required to submit exceptions from your Unity project to your Backtrace instance.

--- a/docs/error-reporting/platform-integrations/unity/troubleshooting.md
+++ b/docs/error-reporting/platform-integrations/unity/troubleshooting.md
@@ -10,6 +10,10 @@ import TabItem from '@theme/TabItem';
 
 This page outlines known platform-specific limitations of the Backtrace Unity SDK. These constraints are inherent to Unity, IL2CPP, and (for WebGL) the browser sandbox.
 
+## Android
+
+For Android native crash capture requirements, APK and Android App Bundle support, failure behavior, and diagnostic codes, see [Android Native Crash Integration for Unity](/error-reporting/platform-integrations/unity/native-crash-integration/).
+
 ## WebGL
 
 ### Stack Traces

--- a/sidebars.js
+++ b/sidebars.js
@@ -85,6 +85,7 @@ module.exports = {
                                     items: [
                                         'error-reporting/platform-integrations/unity/setup',
                                         'error-reporting/platform-integrations/unity/configuration',
+                                        'error-reporting/platform-integrations/unity/native-crash-integration',
                                         'error-reporting/platform-integrations/unity/attributes',
                                         'error-reporting/platform-integrations/unity/metrics',
                                         'error-reporting/platform-integrations/unity/helpshift',
@@ -1292,7 +1293,7 @@ module.exports = {
                     items: [
                         'insights/failure-analysis',
                         'insights/failure-analysis/filter-failure-analysis',
-                     ],
+                    ],
                 },
                 'insights/debug',
             ],


### PR DESCRIPTION
## Summary

Add comprehensive documentation for Android native crash reporting with the Backtrace Unity SDK.

The new guide documents native crash startup, APK and Android App Bundle support, process ABI selection, failure behaviour, diagnostic codes, ProGuard configuration, symbol uploads, and troubleshooting.

## Changes

### Native Crash Integration Guide

- Document the requirements for Android native crash capture.
- Explain automatic, synchronous initialization during Backtrace client startup.
- Document the supported native ABIs:
  - `arm64-v8a`
  - `armeabi-v7a`
  - `x86_64`
- Clarify that managed Unity reporting remains available on unsupported 32-bit `x86` processes.
- Document support for:
  - traditional APK installations;
  - Android App Bundles;
  - split-APK installations;
  - extracted native libraries;
  - native libraries loaded directly from an installed APK or ABI split.
- Describe the native-library resolution order:
  1. Android linker-selected path
  2. existing extracted native library
  3. installed ABI split metadata
  4. base-APK compatibility fallback.
- Explain process-aware ABI selection and the `device.abi` report attribute.
- Document native initialization rollback and managed-reporting fallback.
- Explain best-effort native propagation of dynamic attributes.
- Document ANR and low-memory behavior.
- Add the complete `BT_UNITY_ANDROID_*` and `BT_HANDLER_*` diagnostic-code reference.
- Centralize ProGuard and Android IL2CPP symbol-upload guidance.
- Add troubleshooting guidance for missing reports, App Bundle installations, and unsymbolicated native stacks.

### Existing Documentation

- Add the new guide to the Unity documentation sidebar.
- Link to it from Unity Setup, Configuration, and Troubleshooting.
- Preserve the existing ProGuard and symbol-upload anchors for compatibility.
- Correct the Android low-memory and client-side-unwinding descriptions.
- Clarify that debug symbols are required for symbolication, not report capture.

### Attributes

Document these Android report attributes:

- `device.abi`
- `device.sdk`
- `memory.warning`
- `memory.warning.date`

## Version Availability

Android native crash capture existed before version 3.17.0.

The following behaviour documented by the new guide requires Backtrace Unity SDK 3.17.0 or later:

- linker-first native-library resolution
- Android App Bundle and split-APK fallback resolution
- process-aware ABI selection
- contained native setup and dynamic-attribute failures
- partial initialization rollback
- stable native diagnostic codes.

Backtrace Unity SDK 3.17.0 is now generally available. This documentation describes the released Android integration.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

ref: BT-7654