### PR TITLE
Add ARM emulator test duration guidance, mark ChromiumOS GA

### DIFF
--- a/docs/mobile-apps/android-emulators.md
+++ b/docs/mobile-apps/android-emulators.md
@@ -71,6 +71,10 @@ Live Testing and automated Appium and Espresso testing are available against And
 App and Android test APKs must include the `arm64-v8a` ABI to run on ARM emulators. Rebuild or download a universal APK, or ensure your Gradle splits include `arm64-v8a`.
 :::
 
+:::caution Long-running tests
+We don't recommend tests that run longer than 60 minutes on ARM emulators. The ARM Cloud is maintained on a regular cadence, and a session still running when maintenance begins can be interrupted before your test finishes. For the session length limits that apply to all virtual devices, see [`maxDuration`](/dev/test-configuration-options/#maxduration).
+:::
+
 ### Live Testing
 
 If your account has access to Android ARM, the **Google ARM Emulator** appears in the Mobile Virtual section of **Live > Mobile App** and **Live > Cross Browser**.

--- a/docs/web-apps/chromiumos.md
+++ b/docs/web-apps/chromiumos.md
@@ -17,8 +17,6 @@ keywords:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<p><span className="sauceGreen">Beta</span></p>
-
 Sauce Labs supports automated web testing on ChromiumOS virtual machines. ChromiumOS is the
 open-source platform behind Google's ChromeOS — it shares the same Chromium browser engine,
 rendering pipeline, and web platform APIs. You can validate your web applications against
@@ -64,7 +62,7 @@ supported.
 ### Automated Tests
 
 Set the following capabilities in your test configuration to target a ChromiumOS virtual
-machine on Sauce Labs. It's recommend to use `latest` or `latest-1` for `browserVersion` in order to stay current with each monthly release.
+machine on Sauce Labs. ChromiumOS supports the current and previous Chromium releases, which are kept up to date as part of our regular browser updates. We recommend using `latest` or `latest-1` for `browserVersion` to stay on those versions automatically.
 
 | Capability | Value |
 |---|---|


### PR DESCRIPTION
- android-emulators: note that tests longer than 60 minutes aren't recommended on ARM emulators, since ARM Cloud maintenance can interrupt a session that is still running (VMD-1666)
- chromiumos: remove the Beta badge and state the GA support policy — current and previous Chromium releases, kept up to date as part of our regular browser updates


### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation fix (typos, incorrect content, missing content, etc.)
