### PR TITLE
Update - now service accounts can start and manage SC tunnels

### DIFF
--- a/docs/basics/acct-team-mgmt/managing-service-accounts.md
+++ b/docs/basics/acct-team-mgmt/managing-service-accounts.md
@@ -33,7 +33,6 @@ Key characteristics:
 - **Team Assignment:** Once created, a service account is tied to a specific team and cannot be reassigned.
 - **Limited Permissions:** Service accounts have limited permissions compared to user accounts, amongst others they **cannot**:
   - manage teams and accounts ([Accounts API](/dev/api/accounts/))
-  - manage tunnels with Sauce Trusted Connection ([Sauce Connect API](/dev/api/connect/), [SC CLI 4](/dev/cli/sauce-connect-proxy), [SC CLI 5](/dev/cli/sauce-connect-5))
   - manage private real devices ([Private Real Device API](/dev/api/rdc/#private-real-device-management))
   - submit a crash in the [Crash/Error Reporting](/dev/api/error-reporting/)
   - use the [Virtual USB CLI](/dev/cli/virtual-usb/)
@@ -140,4 +139,4 @@ Jobs run by service accounts are displayed on the [Automated Test Results page](
 
 ### Using Sauce Connect Proxy with a Service Account
 
-If you plan to run tests through a [Sauce Connect Proxy tunnel](/secure-connections/), be mindful of tunnel sharing options. Service accounts cannot create or manage tunnels, so you must use a tunnel that has been shared with the service account’s assigned team. For detailed configuration instructions, refer to the [sharing tunnel guide](/secure-connections/sauce-connect-5/guides/sharing-tunnel/).
+If you plan to run tests through a [Sauce Connect Proxy tunnel](/secure-connections/), be mindful of tunnel sharing options. For detailed configuration instructions, refer to the [sharing tunnel guide](/secure-connections/sauce-connect-5/guides/sharing-tunnel/).

--- a/docs/secure-connections/sauce-connect-5/faq.md
+++ b/docs/secure-connections/sauce-connect-5/faq.md
@@ -18,7 +18,7 @@ For more information, see [Data Center Endpoints](/basics/data-center-endpoints)
 
 ## Can Sauce Connect be managed by a service account?
 
-No, [service accounts](/basics/acct-team-mgmt/managing-service-accounts) cannot start or manage Sauce Connect instances. Only user accounts have the permissions required to create and manage tunnels.
+Yes, [service accounts](/basics/acct-team-mgmt/managing-service-accounts) can start or manage Sauce Connect instances.
 
 ## Can I access apps on localhost?
 

--- a/docs/secure-connections/sauce-connect-5/guides/sharing-tunnel.md
+++ b/docs/secure-connections/sauce-connect-5/guides/sharing-tunnel.md
@@ -21,7 +21,7 @@ The ability to use a Sauce Connect Proxy tunnel depends on the role of the user 
 | Organization Admin | Any user                         | Any user                                      | Any user                          |
 | Team Admin         | All members of their team        | Organization admins, team members, themselves | Themselves and other team members |
 | Team Member        | All members of their team        | Organization admins, team members, themselves | Only themselves                   |
-| Service Account    | ❌ Cannot create or share tunnels | Organization admins, team members             | ❌ Cannot stop any tunnels         |
+| Service Account    | All members of their team        | Organization admins, team members, themselves | Only themselves                   |
 
 For details about user roles and permissions, see [User Roles](/basics/acct-team-mgmt/managing-user-info/#user-roles).
 


### PR DESCRIPTION
Just removed info about not supporting service accounts by Sauce Connect