### PR TITLE
Add Community Frameworks docs (Maestro, Vibium)

### DIFF
--- a/docs/basics/community-frameworks.md
+++ b/docs/basics/community-frameworks.md
@@ -1,0 +1,74 @@
+---
+id: community-frameworks
+title: Community Frameworks on Sauce Labs
+sidebar_label: Overview
+description: Open-source test frameworks and tools built outside Sauce Labs that run on the Sauce Labs cloud through our standard Appium and WebDriver BiDi endpoints.
+keywords:
+- community
+- frameworks
+- maestro
+- vibium
+---
+
+Community frameworks are open-source test frameworks and tools built and maintained outside Sauce Labs. They run on
+the Sauce Labs cloud through our standard Appium and WebDriver BiDi endpoints, and Sauce Labs has validated each guide
+in this section end to end, so you get the same video, logs, and test results as with any other framework.
+
+## How Community Frameworks Differ from Sauce Labs Frameworks
+
+Sauce Labs frameworks are the ones we run for you or support directly: Selenium and Appium, whose servers run in
+the Sauce Labs cloud, and Cypress, Playwright, TestCafe, Espresso, and XCUITest, which the `saucectl` CLI runs on
+Sauce Labs infrastructure. Community frameworks reach the same cloud, but the framework itself belongs to its
+open-source project.
+
+|                                                        | Sauce Labs frameworks                                               | Community frameworks                                                                                     |
+| ------------------------------------------------------ | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Examples                                               | Selenium, Appium, Cypress, Playwright, TestCafe, Espresso, XCUITest | Maestro (via maestro-runner), Vibium                                                                     |
+| Who builds and maintains the Sauce Labs integration    | Sauce Labs, or Sauce Labs together with the framework project       | The framework's open-source project                                                                      |
+| Where to report a problem in the framework             | Sauce Labs Support triages it                                       | The project's issue tracker; Sauce Labs Support can confirm whether the Sauce Labs side behaved correctly |
+| Where to report a device, browser, session, or artifact problem | Sauce Labs Support                                         | Sauce Labs Support                                                                                       |
+| What Sauce Labs validates                              | Every supported version, on an ongoing basis                        | The framework version named on each guide, at the date shown                                             |
+| Roadmap                                                | Tracked on the Sauce Labs roadmap                                   | Not on the Sauce Labs roadmap; guides are updated as the project evolves                                 |
+
+## Supported Targets
+
+Verified by Sauce Labs in September 2026 with the framework versions shown.
+
+| Framework                                                             | Desktop browsers                                                   | Android emulators              | iOS simulators | Android real devices | iOS real devices | How it reaches Sauce Labs                                              |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------ | -------------- | -------------------- | ---------------- | ---------------------------------------------------------------------- |
+| [Maestro via maestro-runner](/basics/community-frameworks/maestro) 1.1.25 | ❌                                                                 | ✔️ including ARM emulators     | ✔️             | ✔️                   | ✔️               | Appium endpoint (`ondemand.<dc>.saucelabs.com/wd/hub`)                 |
+| [Vibium](/basics/community-frameworks/vibium) 26.8.21                 | ✔️ Chrome, Edge, Firefox on Windows, macOS, and Linux (not Safari) | ❌                             | ❌             | ❌                   | ❌               | WebDriver BiDi URL returned by a Sauce Labs session (`webSocketUrl`)   |
+
+## Guides
+
+<div className="box-wrapper" markdown="1">
+  <div className="box box1 card">
+    <div className="container">
+    <a href="/basics/community-frameworks/maestro"><h3>Maestro with maestro-runner</h3></a>
+    <p>Run unmodified Maestro YAML flows on Sauce Labs Android emulators, iOS simulators, and Android and iOS real devices through the Sauce Labs Appium endpoint.</p>
+    </div>
+  </div>
+  <div className="box box2 card">
+    <div className="container">
+    <a href="/basics/community-frameworks/vibium"><h3>Vibium</h3></a>
+    <p>Attach Vibium's CLI, MCP server, or JavaScript and Python clients to a Sauce Labs desktop browser session over WebDriver BiDi.</p>
+    </div>
+  </div>
+</div>
+
+## Before You Start
+
+- Every guide assumes you have a Sauce Labs account and have set your `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` as
+  [environment variables](/basics/environment-variables).
+- Set [`name`](/dev/test-configuration-options/#name) and [`build`](/dev/test-configuration-options/#build) in
+  `sauce:options` so jobs started by a community framework are easy to find in
+  [Test Results](/test-results/viewing-test-results/). Most community tools do not print the Sauce Labs job link.
+- Your Sauce Labs concurrency limits and session timeouts apply exactly as they do for any Appium or WebDriver session.
+- Read the Security Considerations section of each guide. Some tools write credentials or session URLs to logs that you
+  must mask in CI.
+
+## Suggest a Framework
+
+Know a community framework or tool that should run on Sauce Labs? Email the Sauce Labs product team at
+[product@saucelabs.com](mailto:product@saucelabs.com) with a link to the project and a short description of how you
+would use it with Sauce Labs.

--- a/docs/basics/community-frameworks/_partials/_community-support.md
+++ b/docs/basics/community-frameworks/_partials/_community-support.md
@@ -1,0 +1,5 @@
+:::caution Community Supported
+This framework is built and maintained by its open-source project, not by Sauce Labs. Sauce Labs supports the cloud
+side: devices, browsers, endpoints, and test artifacts. Report framework issues to the project's issue tracker.
+Validated with the version noted below; later versions may differ.
+:::

--- a/docs/basics/community-frameworks/maestro.md
+++ b/docs/basics/community-frameworks/maestro.md
@@ -1,0 +1,408 @@
+---
+id: maestro
+title: Maestro on Sauce Labs with maestro-runner
+sidebar_label: Maestro (maestro-runner)
+description: Run Maestro YAML flows on Sauce Labs Android emulators, iOS simulators, and Android and iOS real devices with the open-source maestro-runner CLI.
+keywords:
+- maestro
+- maestro-runner
+- appium
+- community
+- mobile
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CommunitySupport from './\_partials/\_community-support.md';
+
+<p><span className="sauceGreen">Community Supported</span> <span className="sauceGreen">Virtual and Real Devices</span></p>
+
+Maestro is a YAML-based mobile UI testing framework. maestro-runner is an open-source command-line tool, maintained by
+DeviceLab, that runs unmodified Maestro flows by translating each flow step into Appium commands. Point it at the
+Sauce Labs Appium endpoint and your existing Maestro flows run on Sauce Labs Android emulators, iOS simulators, and
+Android and iOS real devices, with the video, device log, Appium log, and screenshots you get from any Appium job.
+
+<CommunitySupport />
+
+Sauce Labs validated this guide with maestro-runner 1.1.25 in September 2026. Use 1.1.25 or later; earlier versions
+could lose pre-created sessions to the Sauce Labs idle timeout during parallel runs.
+
+## How It Works with Sauce Labs
+
+```text
++--------------------------+            +-----------------------------+            +----------------------------+
+|  Your machine or CI      |            |  Sauce Labs                 |            |  Sauce Labs device         |
+|                          |   Appium   |  ondemand.<dc>.saucelabs    |   Appium   |  emulator, simulator, or   |
+|  Maestro YAML flows      |  (HTTPS)   |  .com/wd/hub                |            |  real device               |
+|  maestro-runner          | ---------> |  Appium server              | ---------> |  your app from App Storage |
+|  --driver appium         |            |                             |            |                            |
++--------------------------+            +-----------------------------+            +----------------------------+
+            |                                          |
+            | HTML, JUnit, Allure reports              | video, logs, screenshots, pass/fail
+            v                                          v
+   local report directory                     Sauce Labs Test Results
+```
+
+1. You upload your app build to Sauce Labs App Storage.
+2. You write one Appium capabilities file per Sauce Labs target type: Android emulator, iOS simulator, Android real
+   device, or iOS real device.
+3. maestro-runner opens an Appium session on Sauce Labs with those capabilities and translates each Maestro step
+   (`tapOn`, `inputText`, `assertVisible`, and so on) into Appium commands.
+4. Sauce Labs records the job like any Appium test: video, device log, Appium log, and a screenshot per command.
+5. When the flow finishes, maestro-runner names the Sauce Labs job after the flow file, sets its pass or fail status
+   through the Sauce Labs REST API, and writes HTML, JUnit, and Allure reports locally.
+
+Nothing runs on the Sauce Labs side except the Appium session. maestro-runner needs no Sauce Labs specific
+configuration beyond the endpoint URL and capabilities.
+
+## What You'll Need
+
+- A Sauce Labs account ([Log in](https://accounts.saucelabs.com/am/XUI/#login/) or sign up for a
+  [free trial license](https://saucelabs.com/sign-up)).
+- Your Sauce Labs [Username and Access Key](https://app.saucelabs.com/user-settings).
+- [Node.js](https://nodejs.org/en/) to install maestro-runner from npm.
+- Your app builds: an `.apk` for Android, an `.ipa` for iOS real devices, and a zipped `.app` simulator build for iOS
+  simulators. To try the steps without your own app, use the Sauce Labs My Demo App builds in the
+  [Sauce Labs maestro-runner demo repository](https://github.com/saucelabs-training/demo-maestro-runner).
+- Maestro flows. The demo repository includes flows for the My Demo App on both platforms.
+
+## Step 1: Install maestro-runner
+
+Install maestro-runner as a development dependency of your test project. It is a single binary with no Java
+requirement.
+
+```bash
+npm install --save-dev maestro-runner
+npx maestro-runner --version
+```
+
+You can also download a release binary from the
+[maestro-runner GitHub releases](https://github.com/devicelab-dev/maestro-runner/releases).
+
+## Step 2: Link Your Sauce Labs Account
+
+Set your `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` as environment variables so you never write them into flows,
+capabilities files, or CI configuration.
+
+```bash title="Check Environment Variables"
+echo $SAUCE_USERNAME
+echo $SAUCE_ACCESS_KEY
+```
+
+If nothing is returned, set them:
+
+```bash
+export SAUCE_USERNAME="your Sauce username"
+export SAUCE_ACCESS_KEY="your Sauce access key"
+```
+
+## Step 3: Upload Your App to Sauce Labs
+
+maestro-runner installs your app from [Sauce Labs App Storage](/mobile-apps/app-storage). Upload each build to the
+data center you will run in, and keep the file name that your capabilities file references.
+
+```bash title="Upload to App Storage (US West)"
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" --location \
+  --request POST 'https://api.us-west-1.saucelabs.com/v1/storage/upload' \
+  --form 'payload=@"SauceLabs-Demo-App.apk"' \
+  --form 'name="SauceLabs-Demo-App.apk"'
+```
+
+Repeat for the `.ipa` and the simulator `.zip`. You can also upload through
+[Sauce Labs > App Management](https://app.saucelabs.com/app-management) or the
+[Upload File to App Storage](/dev/api/storage/#upload-file-to-app-storage) API.
+
+:::note
+App Storage is per data center. If you switch between `us-west-1`, `eu-central-1`, and `us-east-4`, upload the
+build again in the new data center.
+:::
+
+## Step 4: Create a Capabilities File for Each Target
+
+maestro-runner reads standard Appium capabilities from a JSON file passed with `--caps`. Create one file per Sauce
+Labs target type. The examples below are the files Sauce Labs validated with the My Demo App; replace the `appium:app`
+file name, and for Android the package and activity, with your own.
+
+<Tabs
+groupId="sauce-target"
+defaultValue="android-emulator"
+values={[
+{label: 'Android Emulator', value: 'android-emulator'},
+{label: 'Android ARM Emulator', value: 'android-arm-emulator'},
+{label: 'iOS Simulator', value: 'ios-simulator'},
+{label: 'Android Real Device', value: 'android-real-device'},
+{label: 'iOS Real Device', value: 'ios-real-device'},
+]}>
+
+<TabItem value="android-emulator">
+
+```json title="provider-caps/android-emulator.json"
+{
+  "platformName": "Android",
+  "appium:automationName": "UiAutomator2",
+  "appium:deviceName": "Google Pixel 9 Emulator",
+  "appium:platformVersion": "16.0",
+  "appium:app": "storage:filename=SauceLabs-Demo-App.apk",
+  "appium:appPackage": "com.saucelabs.mydemoapp.android",
+  "appium:appActivity": ".view.activities.SplashActivity",
+  "appium:appWaitActivity": "*",
+  "sauce:options": {
+    "build": "maestro-android-emulator",
+    "appiumVersion": "2.11.0"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="android-arm-emulator">
+
+```json title="provider-caps/android-arm-emulator.json"
+{
+  "platformName": "Android",
+  "appium:automationName": "UiAutomator2",
+  "appium:deviceName": "Google ARM Medium Phone Emulator",
+  "appium:platformVersion": "16.0",
+  "appium:app": "storage:filename=SauceLabs-Demo-App.apk",
+  "appium:appPackage": "com.saucelabs.mydemoapp.android",
+  "appium:appActivity": ".view.activities.SplashActivity",
+  "appium:appWaitActivity": "*",
+  "sauce:options": {
+    "build": "maestro-android-arm-emulator",
+    "appiumVersion": "2.11.0"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="ios-simulator">
+
+```json title="provider-caps/ios-simulator.json"
+{
+  "platformName": "iOS",
+  "appium:automationName": "XCUITest",
+  "appium:deviceName": "iPhone Simulator",
+  "appium:platformVersion": "18.0",
+  "appium:app": "storage:filename=SauceLabs-Demo-App.Simulator.zip",
+  "appium:iosInstallPause": 5000,
+  "appium:appLaunchStateTimeoutSec": 120,
+  "appium:settings": {
+    "waitForIdleTimeout": 3000,
+    "animationCoolOffTimeout": 2
+  },
+  "sauce:options": {
+    "build": "maestro-ios-simulator",
+    "appiumVersion": "2.11.3"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="android-real-device">
+
+```json title="provider-caps/android-real-device.json"
+{
+  "platformName": "Android",
+  "appium:automationName": "UiAutomator2",
+  "appium:deviceName": "Samsung.*",
+  "appium:platformVersion": "^1[6-7].*",
+  "appium:app": "storage:filename=SauceLabs-Demo-App.apk",
+  "sauce:options": {
+    "build": "maestro-android-real-device",
+    "appiumVersion": "latest"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="ios-real-device">
+
+```json title="provider-caps/ios-real-device.json"
+{
+  "platformName": "iOS",
+  "appium:automationName": "XCUITest",
+  "appium:deviceName": "iPhone.*",
+  "appium:platformVersion": "^(18|26).*",
+  "appium:app": "storage:filename=SauceLabs-Demo-App.ipa",
+  "sauce:options": {
+    "build": "maestro-ios-real-device",
+    "appiumVersion": "latest",
+    "resigningEnabled": true
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Points to note:
+
+- `appium:app` uses the `storage:filename=` form, so the file name must match the upload in Step 3 exactly.
+- Emulator and simulator names and OS versions come from the [Platform Configurator](/basics/platform-configurator).
+  ARM emulators are described on the [Android Emulators](/mobile-apps/android-emulators) page.
+- Real device capabilities use regular expressions for `appium:deviceName` and `appium:platformVersion` so Sauce Labs
+  can allocate any matching device. See [Appium on Real Devices](/mobile-apps/automated-testing/appium/real-devices).
+- iOS real devices need [`resigningEnabled: true`](/dev/test-configuration-options/#resigningenabled) so Sauce Labs can
+  install your `.ipa`. iOS simulators need the simulator build, not the `.ipa`.
+- Pin [`appiumVersion`](/dev/test-configuration-options/#appiumversion) to a version listed on the
+  [Appium Versions](/mobile-apps/automated-testing/appium/appium-versions) page.
+- Leave your username and access key out of the file. maestro-runner takes them from the endpoint URL in Step 5.
+- Set [`build`](/dev/test-configuration-options/#build) so you can find all the jobs from one run in Test Results.
+  Add [`name`](/dev/test-configuration-options/#name) only if you want a fixed job name instead of the flow name.
+
+## Step 5: Run a Flow
+
+Pass the Sauce Labs Appium endpoint, with your credentials, as `--appium-url`, and the capabilities file for the
+target you want. The last argument is a flow file or a directory of flows.
+
+```bash title="Run one flow on an Android emulator (US West)"
+export SAUCE_HUB="https://$SAUCE_USERNAME:$SAUCE_ACCESS_KEY@ondemand.us-west-1.saucelabs.com/wd/hub"
+
+npx maestro-runner --driver appium --appium-url "$SAUCE_HUB" \
+  --caps provider-caps/android-emulator.json \
+  test --output results/android-emulator flows/android/login_standard_user.yaml
+```
+
+For the EU Central or US East data centers, replace `us-west-1` with `eu-central-1` or `us-east-4`. See
+[Data Center Endpoints](/basics/data-center-endpoints).
+
+The flow itself is ordinary Maestro YAML. Nothing in it refers to Sauce Labs:
+
+```yaml title="flows/android/login_standard_user.yaml"
+appId: com.saucelabs.mydemoapp.android
+name: Login - standard user
+tags:
+  - smoke
+  - login
+---
+- assertVisible:
+    id: "productRV"
+- tapOn:
+    id: "menuIV"
+- tapOn: "Log In"
+- tapOn:
+    id: "nameET"
+- inputText: "bod@example.com"
+- tapOn:
+    id: "passwordET"
+- inputText: "10203040"
+- hideKeyboard
+- tapOn:
+    id: "loginBtn"
+- assertVisible:
+    id: "menuIV"
+```
+
+## Step 6: View Your Results
+
+maestro-runner prints each step as it runs and writes HTML, JUnit, and Allure reports to the `--output` directory.
+The Sauce Labs job is available as soon as the session ends under
+[Automated > Test Results](https://app.saucelabs.com/dashboard/tests/vdc) for emulators and simulators, or
+[Real Devices](https://app.saucelabs.com/dashboard/tests/rdc) for real devices. Filter by the `build` value you set in
+Step 4.
+
+## Running Suites in Parallel
+
+maestro-runner can run a directory of flows across several Sauce Labs sessions at once, or run them all in one
+session.
+
+```bash title="Four concurrent emulator sessions"
+npx maestro-runner --driver appium --appium-url "$SAUCE_HUB" \
+  --caps provider-caps/android-emulator.json \
+  test --parallel 4 --output results/android-parallel flows/android/
+```
+
+```bash title="Whole iOS suite in one reused real device session"
+npx maestro-runner --driver appium --appium-url "$SAUCE_HUB" \
+  --caps provider-caps/ios-real-device.json \
+  test --parallel 1 --output results/ios-suite flows/ios/
+```
+
+- `--parallel N` starts up to N Sauce Labs sessions and feeds flows to them from a queue. Each session is one Sauce Labs
+  job. The runner never starts more sessions than you have flows, and your Sauce Labs concurrency limit still applies.
+- `--parallel 1` over a directory runs every flow in a single session, which appears as a single job. Start each flow
+  with `launchApp` so Maestro restarts the app between flows.
+- `--include-tags` and `--exclude-tags` select flows by the `tags` in their YAML header.
+- Flow discovery is one level deep: `test flows/android/` runs only the `.yaml` files directly inside that directory.
+  Keep one directory per platform and run each with its own `--caps` file.
+- `--appium-session-file sessions.json` writes the Appium session IDs of the running sessions. On emulators and
+  simulators the Appium session ID is also the Sauce Labs job ID. On real devices the job ID differs, so use the
+  `build` name to find jobs.
+- `--flatten` writes reports directly into `--output` instead of a timestamped subdirectory, which is easier to
+  archive from CI.
+
+## How Jobs Appear in Sauce Labs
+
+- **Name:** the flow file's base name, for example `login_standard_user`. When one session runs several flows, the job
+  takes the first flow's name. Set `name` in `sauce:options` for a fixed name.
+- **Status:** maestro-runner marks the job passed or failed when the run finishes. It picks the REST API endpoint from
+  the data center in your `--appium-url` (`us-west-1`, `eu-central-1`, or `us-east-4`).
+- **Framework:** Sauce Labs shows the job as an Appium test. Maestro steps appear as the Appium commands they were
+  translated into, not as named Maestro steps, and there are no per-flow annotations in the job.
+- **Artifacts:** video, device log, Appium log, and a screenshot per command, exactly as for any Appium job.
+- **Reports:** the Maestro-style HTML, JUnit, and Allure reports exist only in your local `--output` directory. They
+  do not include the Sauce Labs job link, so use `--appium-session-file` or the `build` name to cross-reference.
+
+## Supported Targets
+
+Verified by Sauce Labs in September 2026 with maestro-runner 1.1.25 and the My Demo App flows.
+
+| Sauce Labs target                | Validated on                                   | Result                   |
+| -------------------------------- | ---------------------------------------------- | ------------------------ |
+| Android emulator                 | Google Pixel 9 Emulator, Android 16            | ✔️ flows pass            |
+| Android ARM emulator             | Google ARM Medium Phone Emulator, Android 16   | ✔️ flows pass            |
+| iOS simulator                    | iPhone Simulator, iOS 18.0                     | ✔️ flows pass            |
+| Android real device              | Samsung Galaxy S26 Ultra, Android 16           | ✔️ flows pass            |
+| iOS real device                  | iPhone 16 Pro, iOS 18.7.1                      | ✔️ flows pass            |
+| Parallel suite (`--parallel 4`)  | Four Android emulator sessions                 | ✔️ four concurrent jobs  |
+| Session reuse (`--parallel 1`)   | One iOS real device session                    | ✔️ one job, all flows    |
+| Mobile web (`browserName` set)   | Chrome on Android emulator                     | ❌ not supported          |
+| Desktop web (`--platform web`)   | Sauce Labs desktop browsers                    | ❌ not supported          |
+
+## Limitations
+
+- **Mobile web is not supported.** maestro-runner's Appium driver parses the native UI hierarchy only. A Sauce Labs
+  browser session returns HTML page source, so the first `assertVisible` fails with
+  `invalid page source: no hierarchy element found`.
+- **Desktop web is not supported on Sauce Labs.** The runner's `--platform web` mode launches a local Chrome and has no
+  option to attach to a remote browser.
+- **No Maestro step names in the Sauce Labs job.** Steps appear as Appium commands.
+- **Data center detection is by URL.** The pass or fail update goes to `eu-central-1` or `us-east-4` when the endpoint
+  URL contains that name, otherwise to `us-west-1`.
+- **Parallel emulator reports show one device.** All concurrent emulator sessions report the same device ID, so the
+  local report's per-device summary collapses to a single entry. The Sauce Labs jobs are unaffected.
+
+## Security Considerations
+
+:::warning Your access key appears in maestro-runner logs
+maestro-runner prints the full `--appium-url`, including your access key, in its `Connecting to Appium server` log
+line. It writes the same line into `maestro-runner.log` inside every report directory, and it writes the URL into the
+`--appium-session-file`. Before you adopt it in CI:
+
+- Mask `SAUCE_ACCESS_KEY` in your CI system so it is redacted from console output.
+- Do not publish report directories or session files as build artifacts without removing the key.
+- Do not commit report or session files to source control.
+:::
+
+Check the maestro-runner release notes for a fix to the credential echo before relying on unmasked logs.
+
+## Troubleshooting
+
+| Symptom                                                              | Cause and fix                                                                                                                                    |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `invalid page source: no hierarchy element found` on the first step   | The capabilities start a browser session. Mobile web is not supported; test the native app instead.                                             |
+| `Invalid version format used` when the session starts                | `appiumVersion: "latest"` was used with a browser session. Pin a version from the Appium Versions page.                                          |
+| iOS real device install or launch fails                              | Add `resigningEnabled: true` to `sauce:options`, and use the `.ipa`, not the simulator build.                                                    |
+| iOS simulator install fails                                          | Use the zipped `.app` simulator build in `appium:app`, not the `.ipa`.                                                                           |
+| Parallel sessions end before their flows start                       | Upgrade to maestro-runner 1.1.25 or later, which keeps pre-created sessions active.                                                              |
+| Flows in subdirectories are skipped                                  | Discovery is one level deep. Point `test` at the directory that contains the flow files.                                                         |
+| The runner reports `Update available`                                | The npm package can lag GitHub releases by a few days. Either channel works with Sauce Labs.                                                     |
+
+## More Information
+
+- [maestro-runner on GitHub](https://github.com/devicelab-dev/maestro-runner) and the
+  [maestro-runner CLI reference](https://devicelab.dev/open-source/maestro-runner/docs/cli-reference) from DeviceLab
+- [Maestro documentation](https://docs.maestro.dev/) for flow syntax and commands
+- [Sauce Labs maestro-runner demo repository](https://github.com/saucelabs-training/demo-maestro-runner) with flows,
+  capabilities files, and demo app builds for every target in this guide
+- [Appium on Sauce Labs](/mobile-apps/automated-testing/appium) for capabilities, device selection, and Appium versions
+- [Community Frameworks](/basics/community-frameworks) for the support model that applies to this guide

--- a/docs/basics/community-frameworks/vibium.md
+++ b/docs/basics/community-frameworks/vibium.md
@@ -1,0 +1,405 @@
+---
+id: vibium
+title: Vibium on Sauce Labs
+sidebar_label: Vibium
+description: Attach Vibium's CLI, MCP server, or JavaScript and Python clients to a Sauce Labs desktop browser session over WebDriver BiDi.
+keywords:
+- vibium
+- bidi
+- webdriver-bidi
+- mcp
+- community
+- web-testing
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CommunitySupport from './\_partials/\_community-support.md';
+
+<p><span className="sauceGreen">Community Supported</span> <span className="sauceGreen">Desktop Browsers Only</span></p>
+
+Vibium is an open-source browser automation tool built for coding agents. A single binary speaks WebDriver BiDi to the
+browser and exposes that control as a command-line interface, a Model Context Protocol (MCP) server, and JavaScript
+and Python client libraries. Vibium can attach to a browser session that already exists, and every Sauce Labs desktop
+browser session can hand out a WebDriver BiDi URL, so you can drive Chrome, Edge, and Firefox on Sauce Labs Windows,
+macOS, and Linux virtual machines from Vibium with no Sauce Labs specific code.
+
+<CommunitySupport />
+
+Sauce Labs validated this guide with Vibium 26.8.21 in September 2026.
+
+:::note
+Vibium depends on Sauce Labs [CDP / BiDi support](/web-apps/automated-testing/cdp-bidi), which is in Beta. The
+limitations of that feature apply to Vibium as well.
+:::
+
+## How It Works with Sauce Labs
+
+Sauce Labs does not host Vibium. You create an ordinary W3C WebDriver session on Sauce Labs with the `webSocketUrl`
+capability set to `true`, Sauce Labs returns a WebDriver BiDi WebSocket URL for that session, and Vibium connects to
+that URL.
+
+```text
++-----------------------------+      1. POST /session  (webSocketUrl: true)       +-----------------------------+
+|  Your machine, CI job,      | ------------------------------------------------> |  Sauce Labs                 |
+|  or coding agent            | <------------------------------------------------ |  ondemand.<dc>.saucelabs    |
+|                             |      2. webSocketUrl: wss://.../se/bidi           |  .com/wd/hub                |
+|  vibium start <url>         |                                                   |                             |
+|  browser.start(url)         |      3. WebDriver BiDi over the returned URL      |  Chrome, Edge, or Firefox   |
+|  VIBIUM_CONNECT_URL=<url>   | <===============================================> |  on a Windows, macOS, or    |
+|                             |                                                   |  Linux virtual machine      |
+|                             |      4. PUT /jobs/<id>  {"passed": true}          |                             |
+|                             |      5. DELETE /session/<id>                      |                             |
++-----------------------------+ ------------------------------------------------> +-----------------------------+
+```
+
+1. Create a Sauce Labs session with any W3C WebDriver client or a plain HTTP request. Set `webSocketUrl: true` next to
+   your usual browser, platform, and `sauce:options` capabilities.
+2. Read `webSocketUrl` from the response. It has the form
+   `wss://<host>.saucelabs.com/selenium/session/<sessionId>/se/bidi`.
+3. Hand that URL to Vibium: `vibium start <url>` for the CLI, `browser.start(url)` in the JavaScript or Python client,
+   or the `VIBIUM_CONNECT_URL` environment variable for the MCP server. Vibium detects the existing session and attaches
+   to it instead of launching a browser.
+4. Drive the browser with Vibium. Navigation, element lookups, screenshots, and JavaScript evaluation all run against
+   the Sauce Labs browser.
+5. When you are done, set the job's pass or fail status through the Sauce Labs REST API and end the session with a
+   WebDriver `DELETE`. Vibium detaches from a session it did not create, but it never ends one.
+
+## What You'll Need
+
+- A Sauce Labs account ([Log in](https://accounts.saucelabs.com/am/XUI/#login/) or sign up for a
+  [free trial license](https://saucelabs.com/sign-up)).
+- Your Sauce Labs [Username and Access Key](https://app.saucelabs.com/user-settings).
+- [Node.js](https://nodejs.org/en/) for the CLI, the MCP server, and the JavaScript client, or Python 3 for the Python
+  client.
+- A way to create the Sauce Labs session: `curl`, Node.js `fetch`, Python `requests`, or any Selenium or WebDriver
+  client you already use.
+
+## Step 1: Install Vibium
+
+<Tabs
+groupId="vibium-lang"
+defaultValue="node"
+values={[
+{label: 'Node.js', value: 'node'},
+{label: 'Python', value: 'python'},
+]}>
+
+<TabItem value="node">
+
+```bash
+npm install vibium
+npx vibium --version
+```
+
+The npm package provides the `vibium` CLI, the MCP server, and the JavaScript client.
+
+</TabItem>
+<TabItem value="python">
+
+```bash
+pip install vibium requests
+```
+
+`requests` is used below to create the Sauce Labs session; any HTTP client works.
+
+</TabItem>
+</Tabs>
+
+Installing Vibium downloads the Vibium binary. Vibium downloads a local browser only the first time you launch one
+locally, so a CI job that only attaches to Sauce Labs never needs a browser download.
+
+## Step 2: Link Your Sauce Labs Account
+
+Set your `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` as environment variables.
+
+```bash title="Check Environment Variables"
+echo $SAUCE_USERNAME
+echo $SAUCE_ACCESS_KEY
+```
+
+If nothing is returned, set them:
+
+```bash
+export SAUCE_USERNAME="your Sauce username"
+export SAUCE_ACCESS_KEY="your Sauce access key"
+```
+
+## Step 3: Create a Sauce Labs Session with a BiDi URL
+
+Create a normal desktop browser session and add [`webSocketUrl: true`](/dev/test-configuration-options/#websocketurl).
+Every other `sauce:options` value you already use, such as [`build`](/dev/test-configuration-options/#build),
+[`tags`](/dev/test-configuration-options/#tags), [`tunnelName`](/dev/test-configuration-options/#tunnelname),
+[`screenResolution`](/dev/test-configuration-options/#screenresolution), and
+[`maxDuration`](/dev/test-configuration-options/#maxduration), applies unchanged. Do not set
+[`extendedDebugging`](/dev/test-configuration-options/#extendeddebugging); it cannot be combined with `webSocketUrl`.
+
+<Tabs
+groupId="vibium-lang"
+defaultValue="node"
+values={[
+{label: 'Node.js', value: 'node'},
+{label: 'Python', value: 'python'},
+{label: 'curl', value: 'curl'},
+]}>
+
+<TabItem value="node">
+
+```javascript title="Create the session"
+const region = process.env.SAUCE_REGION ?? 'us-west-1';
+const hub = `https://ondemand.${region}.saucelabs.com/wd/hub`;
+const auth = 'Basic ' + Buffer.from(
+  `${process.env.SAUCE_USERNAME}:${process.env.SAUCE_ACCESS_KEY}`).toString('base64');
+
+const res = await fetch(`${hub}/session`, {
+  method: 'POST',
+  headers: { Authorization: auth, 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    capabilities: {
+      alwaysMatch: {
+        browserName: 'chrome',
+        browserVersion: 'latest',
+        platformName: 'Windows 11',
+        webSocketUrl: true,
+        'sauce:options': { name: 'Vibium on Sauce Labs', build: 'vibium-quickstart' },
+      },
+    },
+  }),
+});
+const { value } = await res.json();
+const sessionId = value.sessionId;
+const bidiUrl = value.capabilities.webSocketUrl;
+console.log(`Sauce Labs job: https://app.saucelabs.com/tests/${sessionId}`);
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python title="Create the session"
+import os, requests
+
+region = os.environ.get("SAUCE_REGION", "us-west-1")
+hub = f"https://ondemand.{region}.saucelabs.com/wd/hub"
+auth = (os.environ["SAUCE_USERNAME"], os.environ["SAUCE_ACCESS_KEY"])
+
+caps = {"capabilities": {"alwaysMatch": {
+    "browserName": "chrome",
+    "browserVersion": "latest",
+    "platformName": "Windows 11",
+    "webSocketUrl": True,
+    "sauce:options": {"name": "Vibium on Sauce Labs", "build": "vibium-quickstart"},
+}}}
+value = requests.post(f"{hub}/session", auth=auth, json=caps, timeout=300).json()["value"]
+session_id = value["sessionId"]
+bidi_url = value["capabilities"]["webSocketUrl"]
+print(f"Sauce Labs job: https://app.saucelabs.com/tests/{session_id}")
+```
+
+</TabItem>
+<TabItem value="curl">
+
+```bash title="Create the session"
+curl -s -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"capabilities":{"alwaysMatch":{
+        "browserName":"chrome","browserVersion":"latest","platformName":"Windows 11",
+        "webSocketUrl":true,
+        "sauce:options":{"name":"Vibium on Sauce Labs","build":"vibium-quickstart"}}}}' \
+  https://ondemand.us-west-1.saucelabs.com/wd/hub/session
+```
+
+The response contains `value.sessionId` and `value.capabilities.webSocketUrl`. Keep both; you need the session ID in
+Step 5.
+
+</TabItem>
+</Tabs>
+
+For the EU Central or US East data centers, replace `us-west-1` with `eu-central-1` or `us-east-4` in both the
+`ondemand` and `api` host names. See [Data Center Endpoints](/basics/data-center-endpoints).
+
+## Step 4: Attach Vibium and Drive the Browser
+
+Copy the `webSocketUrl` from the response exactly as returned. No additional authentication header is needed.
+
+<Tabs
+groupId="vibium-lang"
+defaultValue="cli"
+values={[
+{label: 'CLI', value: 'cli'},
+{label: 'Node.js', value: 'node'},
+{label: 'Python', value: 'python'},
+{label: 'MCP server', value: 'mcp'},
+]}>
+
+<TabItem value="cli">
+
+```bash
+export BIDI_URL="wss://<host>.saucelabs.com/selenium/session/<sessionId>/se/bidi"
+
+npx vibium start "$BIDI_URL"
+npx vibium go https://www.saucedemo.com
+npx vibium title
+npx vibium screenshot -o saucedemo.png
+npx vibium stop
+```
+
+`vibium stop` disconnects Vibium. The Sauce Labs session keeps running until you end it in Step 5. If you drive more
+than one Sauce Labs browser from the same machine, add `--session <name>` to every command to keep the daemons apart.
+
+</TabItem>
+<TabItem value="node">
+
+```javascript title="Drive the Sauce Labs browser"
+import { browser } from 'vibium';
+
+let passed = false;
+try {
+  const bro = await browser.start(bidiUrl);   // attaches to the Sauce Labs session
+  const page = await bro.page();
+  await page.go('https://www.saucedemo.com');
+  await (await page.find('#user-name')).type('standard_user');
+  await (await page.find('#password')).type('secret_sauce');
+  await (await page.find('#login-button')).click();
+  const heading = await (await page.find('.title')).text();
+  passed = heading === 'Products';
+  await bro.stop();                            // detaches; does not end the Sauce Labs session
+} finally {
+  // Step 5: report the result and end the session (see below)
+}
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python title="Drive the Sauce Labs browser"
+from vibium import browser
+
+passed = False
+try:
+    bro = browser.start(bidi_url)          # attaches to the Sauce Labs session
+    page = bro.page()
+    page.go("https://www.saucedemo.com")
+    page.find("#user-name").type("standard_user")
+    page.find("#password").type("secret_sauce")
+    page.find("#login-button").click()
+    passed = page.find(".title").text() == "Products"
+    bro.stop()                             # detaches; does not end the Sauce Labs session
+finally:
+    pass  # Step 5: report the result and end the session (see below)
+```
+
+</TabItem>
+<TabItem value="mcp">
+
+Set `VIBIUM_CONNECT_URL` in the MCP server's environment and Vibium's browser tools operate on the Sauce Labs
+browser instead of launching a local one.
+
+```json title="MCP server configuration (Claude Code, Cursor, or any MCP client)"
+{
+  "mcpServers": {
+    "vibium-sauce": {
+      "command": "npx",
+      "args": ["vibium", "mcp"],
+      "env": {
+        "VIBIUM_CONNECT_URL": "wss://<host>.saucelabs.com/selenium/session/<sessionId>/se/bidi"
+      }
+    }
+  }
+}
+```
+
+Or start it from a shell:
+
+```bash
+VIBIUM_CONNECT_URL="$BIDI_URL" npx vibium mcp
+```
+
+Tools such as `browser_navigate`, `browser_get_title`, `browser_find`, and `browser_screenshot` then run on the Sauce
+Labs browser. The session URL is only valid for the life of that Sauce Labs session, so treat the configuration as
+temporary.
+
+</TabItem>
+</Tabs>
+
+## Step 5: Report the Result and End the Session
+
+Vibium never ends a session it did not create, so you must do both of the following yourself, ideally in a `finally`
+block so they run even when the test fails.
+
+```bash title="Set pass/fail and end the session"
+curl -s -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X PUT -H 'Content-Type: application/json' \
+  -d '{"passed": true}' \
+  "https://api.us-west-1.saucelabs.com/rest/v1/$SAUCE_USERNAME/jobs/<sessionId>"
+
+curl -s -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X DELETE \
+  "https://ondemand.us-west-1.saucelabs.com/wd/hub/session/<sessionId>"
+```
+
+The first call is the [Update a Job](/dev/api/jobs/#update-a-job) API. Without it the job shows as complete with no
+pass or fail status. Without the second call the session runs until it hits the Sauce Labs idle or maximum duration
+timeout and continues to consume concurrency.
+
+## Step 6: View Your Results
+
+Open the job under [Automated > Test Results](https://app.saucelabs.com/dashboard/tests/vdc). You get the full video
+of the browser, the `name` and `build` you set, and the pass or fail status you reported. The Commands tab lists the
+WebDriver HTTP calls you made (typically the session creation and deletion); WebDriver BiDi traffic from Vibium is not
+itemised there.
+
+## Supported Browsers and Platforms
+
+Verified by Sauce Labs in September 2026 with Vibium 26.8.21.
+
+| Sauce Labs target                                   | Result                                                                                       |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Chrome on Windows 11                                | ✔️ CLI, JavaScript client, Python client, and MCP server all validated end to end             |
+| Firefox on Windows 11                               | ✔️ JavaScript client validated end to end                                                     |
+| Microsoft Edge on Windows; Chrome on macOS and Linux | ✔️ Sauce Labs returns a BiDi URL; same attach mechanism                                       |
+| Safari on macOS                                     | ❌ Session creation fails when `webSocketUrl` is set; Safari cannot be used with Vibium       |
+| Chrome and Safari on Android emulators and iOS simulators | ❌ `webSocketUrl` returns `true` instead of a URL; nothing to attach to                  |
+| Browsers on Android and iOS real devices            | ❌ The returned URL is internal to the Sauce Labs network and not reachable                    |
+| Java client                                         | Not validated by Sauce Labs                                                                   |
+
+## Limitations
+
+- **Desktop browsers only.** Safari and all mobile targets are not available, as shown above.
+- **Extended debugging is not available** in the same session as `webSocketUrl`.
+- **You own the session lifecycle.** Vibium detaches but never deletes the Sauce Labs session; always send the
+  `DELETE` in Step 5.
+- **No automatic pass or fail.** Set it with the Jobs API as shown in Step 5.
+- **BiDi commands are not listed in the job.** The video shows everything Vibium did; the command list shows only
+  WebDriver HTTP calls.
+- **Sauce Labs session limits apply.** The [`idleTimeout`](/dev/test-configuration-options/#idletimeout) and
+  [`maxDuration`](/dev/test-configuration-options/#maxduration) values of the session govern how long Vibium can stay
+  attached.
+
+## Security Considerations
+
+:::warning The BiDi URL is a credential
+Sauce Labs does not require an additional authentication header on the BiDi WebSocket. Anyone who has the
+`webSocketUrl` can drive that browser until the session ends. Do not print it in CI logs, do not commit it to source
+control, and remove it from MCP configuration files when the session is over.
+:::
+
+Keep `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` in environment variables or your CI secret store; they are only needed to
+create and end the session.
+
+## Troubleshooting
+
+| Symptom                                                        | Cause and fix                                                                                                          |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| HTTP 500 when creating a Safari session                        | Safari does not accept `webSocketUrl`. Use Chrome, Edge, or Firefox.                                                   |
+| `webSocketUrl` in the response is `true`, not a URL             | The session is on a mobile emulator or simulator. Use a desktop browser.                                               |
+| The URL starts with `ws://172.` and Vibium cannot connect      | The session is on a real device. Use a desktop browser.                                                                |
+| The Sauce Labs job keeps running after `vibium stop`           | Expected. End the session with the WebDriver `DELETE` in Step 5.                                                       |
+| The job shows Complete with no pass or fail                    | Send the `PUT` in Step 5 with `{"passed": true}` or `{"passed": false}`.                                               |
+| The session ends during a long pause                           | The session hit `idleTimeout`. Keep commands flowing or raise the timeout when you create the session.                 |
+
+## More Information
+
+- [Vibium on GitHub](https://github.com/VibiumDev/vibium), the [Vibium CLI reference](https://vibium.com/docs/commands/),
+  and the [Vibium client libraries](https://vibium.com/docs/client-libraries/) documentation
+- [CDP / BiDi on Sauce Labs](/web-apps/automated-testing/cdp-bidi) for how Sauce Labs exposes WebDriver BiDi
+- [Test Configuration Options](/dev/test-configuration-options/) for every capability you can set on the session
+- [Jobs API](/dev/api/jobs/) for setting job status and reading job details
+- [Community Frameworks](/basics/community-frameworks) for the support model that applies to this guide

--- a/docs/basics/integrations-overview.md
+++ b/docs/basics/integrations-overview.md
@@ -11,6 +11,8 @@ Sauce Labs integrates with the most important tools for your SDLC. Whether you n
 
 We partner with the top companies in the industry to bring you a complete solution for your testing needs. We also integrate seamlessly with the best open source tools in the ecosystem.
 
+Looking for community-built test frameworks such as Maestro or Vibium? See [Community Frameworks](/basics/community-frameworks).
+
 ## CI/CD Tools
 
 Your CI/CD process needs automated testing in order to be successful. Sauce Labs integrates with every tool in the ecosystem.

--- a/docs/basics/quickstarts.md
+++ b/docs/basics/quickstarts.md
@@ -28,6 +28,17 @@ Below you will find links to our quickstart guides and demo repos, listed by fra
 | WebdriverIO                  |                                     <img src={useBaseUrl('/img/desktop-icon.png')} alt="Desktop" width="20"/>                                      | JavaScript               | [GitHub](https://github.com/saucelabs-training/demo-js/tree/main/webdriverio/mobile-app)                                                   |
 | XCUITest                     |                                     <img src={useBaseUrl('/img/desktop-icon.png')} alt="Desktop" width="20"/>                                      | Swift                    | [GitHub](https://github.com/saucelabs-training/demo-xcuitest)                                                                                |
 
+## Community Frameworks
+
+These frameworks and tools are built and supported by their open-source maintainers, not by Sauce Labs. They reach
+the Sauce Labs cloud through our standard Appium and WebDriver BiDi endpoints, and Sauce Labs has validated the
+guides below. See [Community Frameworks](/basics/community-frameworks) for what that means for support.
+
+| Framework                    |                               Platform                                | Language                            | Links                                                                                                                       |
+| ---------------------------- | :-------------------------------------------------------------------: | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Maestro (via maestro-runner) | <img src={useBaseUrl('/img/mobile-icon.png')} alt="Mobile" width="15"/> | YAML                                | [Guide](/basics/community-frameworks/maestro)<br/>[GitHub](https://github.com/devicelab-dev/maestro-runner)                 |
+| Vibium                       | <img src={useBaseUrl('/img/desktop-icon.png')} alt="Desktop" width="20"/> | JavaScript<br/>Python<br/>CLI / MCP | [Guide](/basics/community-frameworks/vibium)<br/>[GitHub](https://github.com/VibiumDev/vibium)                              |
+
 ## Sample Code by Language
 
 | Language   | Frameworks                                                       | Description                                                                                                                     | Links                                                       |

--- a/docs/mobile-apps.md
+++ b/docs/mobile-apps.md
@@ -40,7 +40,7 @@ Debug faster, facilitate collaboration, increase mobile device coverage, and com
 
 ## Automated Testing
 
-Accelerate and scale your testing and broaden coverage by running automated tests on Sauce Labs mobile devices (real and virtual) through your preferred test UI framework (Appium, Espresso, or XCUITest).
+Accelerate and scale your testing and broaden coverage by running automated tests on Sauce Labs mobile devices (real and virtual) through your preferred test UI framework (Appium, Espresso, or XCUITest), or through a [community framework](/basics/community-frameworks) such as [Maestro](/basics/community-frameworks/maestro).
 
 <div>
   <div className="box boxwidetop card">

--- a/docs/web-apps.md
+++ b/docs/web-apps.md
@@ -25,6 +25,7 @@ Achieving digital confidence for your website app involves knowing that every us
       <li><a href="/web-apps/automated-testing/cucumberjs-playwright/quickstart">Cucumber.js with Playwright</a></li>
       <li><a href="/web-apps/automated-testing/testcafe">TestCafe</a></li>
       <li><a href="/web-apps/automated-testing/replay">Replay</a></li>
+      <li><a href="/basics/community-frameworks/vibium">Vibium</a> (community framework)</li>
   </ul>
   </div>
   </div>

--- a/sidebars.js
+++ b/sidebars.js
@@ -568,6 +568,16 @@ module.exports = {
                     items: [
                         'sauce-basics',
                         'basics/quickstarts',
+                        {
+                            type: 'category',
+                            label: 'Community Frameworks',
+                            collapsed: true,
+                            items: [
+                                'basics/community-frameworks',
+                                'basics/community-frameworks/maestro',
+                                'basics/community-frameworks/vibium',
+                            ],
+                        },
                         'basics/platform-configurator',
                         'basics/data-center-endpoints',
                         'basics/environment-variables',
@@ -1055,6 +1065,11 @@ module.exports = {
                                 'mobile-apps/automated-testing/alttester/unreal',
                             ],
                         },
+                        {
+                            type: 'link',
+                            label: 'Maestro (Community)',
+                            href: '/basics/community-frameworks/maestro',
+                        },
                         'mobile-apps/automated-testing/ipa-files',
                         'mobile-apps/automated-testing/app-files',
                     ],
@@ -1187,6 +1202,11 @@ module.exports = {
                                 'web-apps/automated-testing/cdp-bidi',
                                 'web-apps/automated-testing/cdp-bidi/examples',
                             ],
+                        },
+                        {
+                            type: 'link',
+                            label: 'Vibium (Community)',
+                            href: '/basics/community-frameworks/vibium',
                         },
                     ],
                 },


### PR DESCRIPTION
### Description

Adds a **Community Frameworks** section to Sauce Labs Basics with three pages:

- `basics/community-frameworks` — Overview: what a community framework is, how it differs from Sauce Labs frameworks
  (Selenium/Appium, saucectl-run frameworks), the support boundary, a verified support matrix, and how to suggest one
  (product@saucelabs.com).
- `basics/community-frameworks/maestro` — Maestro YAML flows on Sauce Labs emulators, simulators, and real devices via
  the open-source `maestro-runner` CLI (Appium endpoint). Validated on all five target types with 1.1.25.
- `basics/community-frameworks/vibium` — Vibium (CLI, MCP server, JS/Python clients) attached to Sauce Labs desktop
  browser sessions over WebDriver BiDi (`webSocketUrl: true`). Validated on Chrome/Firefox/Edge; Safari and mobile are
  documented as not supported.

Shared `_partials/_community-support.md` admonition on every page. Sidebar: new category under *Sauce Labs Basics*
(after *Sample Frameworks and Quickstarts*) plus `type: 'link'` cross-lists "Maestro (Community)" under
*Mobile Apps → Automated Testing* and "Vibium (Community)" under *Web Apps → Automated Testing*. Cross-links added to
`basics/quickstarts`, `web-apps`, `mobile-apps`, and `basics/integrations-overview`.

### Motivation and Context

Customers ask for Maestro (Productboard: Walmart, JPMC, Brightwell, Best Western, EON Digital) and for agent-first
BiDi tooling. Both already work against our standard endpoints with no platform change. This documents them as
**community supported** — built and maintained by their projects, validated by Sauce Labs — explicitly *not* as
first-class Sauce features (framing agreed with Ömer, Aug 14).

### Types of Changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation fix (typos, incorrect content, missing content, etc.)

### Reviewer notes

1. **Placement.** Nested under Sauce Labs Basics for now. Happy to promote *Community Frameworks* to a top-level
   sidebar category (after *Web Apps*) if the team prefers; the pages and links are placement-independent.
2. **Badge.** Introduces the green badge text "Community Supported" (style guide allows new green badges). Also uses a
   new "Desktop Browsers Only" scope badge on the Vibium page.
3. **CDP/BiDi page not touched.** That page states "CDP / BiDi Sessions are currently limited to 10mins". In the
   Vibium validation a BiDi-attached session stayed usable for 13 minutes. I have deliberately not contradicted it in
   the new pages; I'll correct the CDP/BiDi page in a follow-up once the VDC team confirms the real limit. The Vibium
   page links to it and inherits its Beta status.
4. **Legal/Security.** The April maestro-runner review's open questions (recommending third-party OSS in official
   docs; `curl | bash` install guidance) are still open. The pages recommend npm / GitHub releases and do not mention
   `curl | bash`. Merge should wait for that sign-off.
5. **Credential echo in maestro-runner.** The runner prints the access key (userinfo in `--appium-url`) to stdout,
   `maestro-runner.log`, and the session file. The page carries a warning; upstream issue to be filed.
6. **Mobilewright** is intentionally omitted until a Sauce Labs driver is published upstream.
7. **Code hosting.** Maestro caps/flows mirror `saucelabs-training/demo-maestro-runner` (no `docs-x.y` tag yet).
   Vibium samples are inline for v1; a `demo-vibium` training repo is a follow-up.
8. **CODEOWNERS.** No owner matches `docs/basics/`; suggest adding `/docs/basics/community-frameworks/ @nsaunders-sl`
   if you want PM review on future edits.
9. **Build.** `npm run build` passes locally with `onBrokenLinks`/`onBrokenAnchors` set to throw (see PR checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
